### PR TITLE
148 non unicode strings

### DIFF
--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -262,6 +262,9 @@ class DatabaseOperations(BaseDatabaseOperations):
                     # construction, not on execution.
                     raise DatabaseError("Bytestring is not encoded in utf-8")
 
+            # The SDK raises BadValueError for unicode sub-classes like SafeText.
+            value = unicode(value)
+
             if db_type == 'text':
                 value = Text(value)
         elif db_type == 'bytes':

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -276,6 +276,20 @@ class BackendTests(TestCase):
         self.assertIsNone(null_date.time)
         self.assertIsNone(null_date.datetime)
 
+    def test_convert_unicode_subclasses_to_unicode(self):
+        # The App Engine SDK raises BadValueError if you try saving a SafeText
+        # string to a CharField. Djangae explicitly converts it to unicode.
+        from django.template.defaultfilters import slugify
+
+        grue = slugify(u'grue')
+
+        self.assertIsInstance(grue, unicode)
+        self.assertNotEqual(type(grue), unicode)
+
+        obj = TestFruit.objects.create(name=u'foo', color=grue)
+
+        self.assertEqual(type(obj.color), unicode)
+
 
 class ModelFormsetTest(TestCase):
     def test_reproduce_index_error(self):


### PR DESCRIPTION
Think this is enough to force values to unicode when persisting. I ran into this bug when assigning the result of django.template.defaultfilters.slugify(..) to the field.

In theory the test should be OK. Not sure how one is supposed to run djangae's tests.