### PR TITLE
Add unique constraint support for ListField and SetField

### DIFF
--- a/djangae/db/unique_utils.py
+++ b/djangae/db/unique_utils.py
@@ -45,7 +45,9 @@ def unique_identifiers_from_entity(model, entity, ignore_pk=False, ignore_null_v
             else:
                 value = entity.get(field.column)  # Get the value from the entity
 
-            if value is None and ignore_null_values:
+            # If ignore_null_values is True, then we don't include combinations where the value is None
+            # or if the field is a multivalue field where None means no value (you can't store None in a list)
+            if value is None and (ignore_null_values or isinstance(value, (list, set))):
                 include_combination = False
 
             if isinstance(value, (list, set)):

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -721,6 +721,9 @@ class ConstraintTests(TestCase):
 
         instance2.save()
 
+        instance2.unique_set_field = set()
+        instance2.save() # You can have two fields with empty sets
+
 class EdgeCaseTests(TestCase):
     def setUp(self):
         add_special_index(TestUser, "username", "iexact")


### PR DESCRIPTION
This adds support for using unique markers with ListField and SetField (e.g. a value can appear in the field for only one instance)