### PR TITLE
Fix for error of creating special indexes for fields with empty values

### DIFF
--- a/djangae/indexing.py
+++ b/djangae/indexing.py
@@ -220,7 +220,7 @@ class ContainsIndexer(Indexer):
             if len(result) > 500:
                 raise ValueError("Can't index for contains query, this value has too many permuatations")
 
-        return result
+        return result or None
 
     def prep_value_for_query(self, value):
         value = self.unescape(value)
@@ -234,7 +234,8 @@ class ContainsIndexer(Indexer):
 
 class IContainsIndexer(ContainsIndexer):
     def prep_value_for_database(self, value):
-        return [x.lower() for x in super(IContainsIndexer, self).prep_value_for_database(value)]
+        result = super(IContainsIndexer, self).prep_value_for_database(value)
+        return result if result else None
 
     def indexed_column_name(self, field_column):
         return "_idx_icontains_{0}".format(field_column)
@@ -257,7 +258,7 @@ class EndsWithIndexer(Indexer):
         results = []
         for i in xrange(len(value)):
             results.append(value[i:])
-        return results
+        return results or None
 
     def prep_value_for_query(self, value):
         value = self.unescape(value)
@@ -274,7 +275,8 @@ class IEndsWithIndexer(EndsWithIndexer):
         Same as above, just all lower cased
     """
     def prep_value_for_database(self, value):
-        return super(IEndsWithIndexer, self).prep_value_for_database(value.lower())
+        result = super(IEndsWithIndexer, self).prep_value_for_database(value.lower())
+        return result or None
 
     def prep_value_for_query(self, value):
         return super(IEndsWithIndexer, self).prep_value_for_query(value.lower())

--- a/djangae/indexing.py
+++ b/djangae/indexing.py
@@ -234,7 +234,7 @@ class ContainsIndexer(Indexer):
 
 class IContainsIndexer(ContainsIndexer):
     def prep_value_for_database(self, value):
-        result = super(IContainsIndexer, self).prep_value_for_database(value)
+        result = super(IContainsIndexer, self).prep_value_for_database(value.lower())
         return result if result else None
 
     def indexed_column_name(self, field_column):

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -1041,6 +1041,13 @@ class EdgeCaseTests(TestCase):
         obj2 = SelfRelatedModel.objects.create(related=obj)
         self.assertEqual(list(obj.selfrelatedmodel_set.all()), [obj2])
 
+    def test_special_indexes_for_empty_fields(self):
+        obj = TestFruit.objects.create(name='pear')
+        indexes = ['icontains', 'contains', 'iexact', 'iendswith', 'endswith', 'istartswith', 'startswith']
+        for index in indexes:
+            add_special_index(TestFruit, 'color', index)
+        obj.save()
+
 
 class BlobstoreFileUploadHandlerTest(TestCase):
     boundary = "===============7417945581544019063=="


### PR DESCRIPTION
I created a special index (icontains) for model field which had objects with empty values. This caused this bug:

```
BadValueError: May not use the empty list as a property value; property _idx_icontains_location is [].
```

This patch is making sure we always return None instead of empty list for all special indexes. 