### PR TITLE
Add an inconsistent_db context manager for testing

### DIFF
--- a/djangae/test.py
+++ b/djangae/test.py
@@ -1,0 +1,23 @@
+import contextlib
+
+@contextlib.contextmanager
+def inconsistent_db(probability=0, connection='default'):
+    from django.db import connections
+
+    conn = connections[connection]
+
+    if not hasattr(conn.creation, "testbed") or "datastore_v3" not in conn.creation.testbed._enabled_stubs:
+        raise RuntimeError("Tried to use the inconsistent_db stub when not testing")
+
+    from google.appengine.api import apiproxy_stub_map
+    from google.appengine.datastore import datastore_stub_util
+
+    stub = apiproxy_stub_map.apiproxy.GetStub('datastore_v3')
+
+    # Set the probability of the datastore stub
+    stub.SetConsistencyPolicy(datastore_stub_util.PseudoRandomHRConsistencyPolicy(probability=probability))
+
+    yield
+
+    # Restore to consistent mode
+    stub.SetConsistencyPolicy(datastore_stub_util.PseudoRandomHRConsistencyPolicy(probability=1))

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -25,6 +25,8 @@ from django.contrib.contenttypes.models import ContentType
 
 # DJANGAE
 from djangae.contrib import sleuth
+from djangae.test import inconsistent_db
+
 from django.db import IntegrityError as DjangoIntegrityError
 from djangae.db.backends.appengine.dbapi import CouldBeSupportedError, NotSupportedError, IntegrityError
 from djangae.db.constraints import UniqueMarker
@@ -1500,3 +1502,12 @@ class TestSpecialIndexers(TestCase):
 
             qry = self.qry.filter(name__istartswith=name)
             self.assertEqual(len(qry), len([x for x in self.names if x.lower().startswith(name.lower())]))
+
+
+class TestHelperTests(TestCase):
+    def test_inconsistent_db(self):
+
+        with inconsistent_db():
+            fruit = TestFruit.objects.create(name="banana")
+            self.assertEqual(0, TestFruit.objects.count()) # Inconsistent query
+            self.assertEqual(1, TestFruit.objects.filter(pk=fruit.pk).count()) #Consistent query


### PR DESCRIPTION
This PR adds a context manager for testing code against an inconsistent database.