### PR TITLE
Fix exclude() bug when used with __in on an empty list

### DIFF
--- a/djangae/db/backends/appengine/dnf.py
+++ b/djangae/db/backends/appengine/dnf.py
@@ -18,6 +18,9 @@ def process_literal(node, filtered_columns=[], negated=False):
         if not isinstance(value, (list, tuple, set)):
             raise ValueError("IN queries must be supplied a list of values")
         if negated:
+            if len(value) == 0:
+                return None, set()
+                
             lits = []
             for x in value:
                 lits.append(('LIT', (column, '>', x)))

--- a/djangae/db/backends/appengine/dnf.py
+++ b/djangae/db/backends/appengine/dnf.py
@@ -19,8 +19,8 @@ def process_literal(node, filtered_columns=[], negated=False):
             raise ValueError("IN queries must be supplied a list of values")
         if negated:
             if len(value) == 0:
-                return None, set()
-                
+                return None, filtered_columns
+
             lits = []
             for x in value:
                 lits.append(('LIT', (column, '>', x)))

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -872,6 +872,14 @@ class EdgeCaseTests(TestCase):
         results = list(TestFruit.objects.filter(name='apple', color__in=[]))
         self.assertItemsEqual([], results)
 
+        results = list(TestUser.objects.all().exclude(username__in=[]))
+        self.assertEqual(5, len(results))
+        self.assertItemsEqual(["A", "B", "C", "D", "E"], [x.username for x in results ])
+
+        results = list(TestUser.objects.all().exclude(username__in=[]).filter(username__in=["A", "B"]))
+        self.assertEqual(2, len(results))
+        self.assertItemsEqual(["A", "B"], [x.username for x in results])
+
     def test_or_queryset(self):
         """
             This constructs an OR query, this is currently broken in the parse_where_and_check_projection

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -879,6 +879,10 @@ class EdgeCaseTests(TestCase):
         results = list(TestUser.objects.all().exclude(username__in=[]).filter(username__in=["A", "B"]))
         self.assertEqual(2, len(results))
         self.assertItemsEqual(["A", "B"], [x.username for x in results])
+        
+        results = list(TestUser.objects.all().filter(username__in=["A", "B"]).exclude(username__in=[]))
+        self.assertEqual(2, len(results))
+        self.assertItemsEqual(["A", "B"], [x.username for x in results])
 
     def test_or_queryset(self):
         """


### PR DESCRIPTION
Hi.

I fixed exclude() bug when used with __in on an empty list.
This patch fixes a failed test in "test_in (lookup.tests.LookupTests)".

<pre>
======================================================================
FAIL: test_in (lookup.tests.LookupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File &quot;django_tests/lookup/tests.py&quot;, line 463, in test_in
    '&lt;Article: Article 1&gt;',
  File &quot;djangae-testapp/lib/django/test/testcases.py&quot;, line 829, in assertQuerysetEqual
    return self.assertEqual(list(items), values)
AssertionError: Lists differ: [] != [u'&lt;Article: Article 5&gt;', u'&lt;A...

Second list contains 7 additional elements.
First extra element 0:
&lt;Article: Article 5&gt;

- []
+ [u'&lt;Article: Article 5&gt;',
+  u'&lt;Article: Article 6&gt;',
+  u'&lt;Article: Article 4&gt;',
+  u'&lt;Article: Article 2&gt;',
+  u'&lt;Article: Article 3&gt;',
+  u'&lt;Article: Article 7&gt;',
+  u'&lt;Article: Article 1&gt;']
</pre>

Thanks.