### PR TITLE
Fix 'id_iexact=' query

### DIFF
--- a/djangae/indexing.py
+++ b/djangae/indexing.py
@@ -113,6 +113,8 @@ class IExactIndexer(Indexer):
         return len(value) < 500
 
     def prep_value_for_database(self, value):
+        if isinstance(value, (int, long)):
+            value = str(value)
         return value.lower()
 
     def prep_value_for_query(self, value):

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -81,6 +81,10 @@ class UniqueModel(models.Model):
         ]
 
 
+class IntegerModel(models.Model):
+    integer_field = models.IntegerField()
+
+
 class TestFruit(models.Model):
     name = models.CharField(primary_key=True, max_length=32)
     color = models.CharField(max_length=32)
@@ -993,6 +997,11 @@ class EdgeCaseTests(TestCase):
     def test_iexact(self):
         user = TestUser.objects.get(username__iexact="a")
         self.assertEqual("A", user.username)
+
+        add_special_index(IntegerModel, "integer_field", "iexact")
+        IntegerModel.objects.create(integer_field=1000)
+        integer_model = IntegerModel.objects.get(integer_field__iexact=str(1000))
+        self.assertEqual(integer_model.integer_field, 1000)        
 
     def test_ordering(self):
         users = TestUser.objects.all().order_by("username")

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -1003,6 +1003,9 @@ class EdgeCaseTests(TestCase):
         integer_model = IntegerModel.objects.get(integer_field__iexact=str(1000))
         self.assertEqual(integer_model.integer_field, 1000)        
 
+        user = TestUser.objects.get(id__iexact=str(self.u1.id))
+        self.assertEqual("A", user.username)           
+
     def test_ordering(self):
         users = TestUser.objects.all().order_by("username")
 


### PR DESCRIPTION
Hi.

I added some code to deal with 'id_iexact' query.
This patch fixes a failed test in "test_lookup_int_as_str (lookup.tests.LookupTests)".

<pre>
======================================================================
FAIL: test_lookup_int_as_str (lookup.tests.LookupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File &quot;django_tests/lookup/tests.py&quot;, line 57, in test_lookup_int_as_str
    ['&lt;Article: Article 1&gt;'])
  File &quot;djangae-testapp/lib/django/test/testcases.py&quot;, line 829, in assertQuerysetEqual
    return self.assertEqual(list(items), values)
AssertionError: Lists differ: [] != [u'&lt;Article: Article 1&gt;']

Second list contains 1 additional elements.
First extra element 0:
&lt;Article: Article 1&gt;

- []
+ [u'&lt;Article: Article 1&gt;']
</pre>


And I also improved IExactIndexer to handle integer values.

Thanks.