### PR TITLE
import fix to make sure mapreduce is not a dep

### DIFF
--- a/djangae/contrib/mappers/urls.py
+++ b/djangae/contrib/mappers/urls.py
@@ -1,6 +1,12 @@
 from django.conf.urls import patterns
-from mapreduce.main import create_handlers_map
 from djangae.utils import djangae_webapp
 
-wrapped_urls = ((url_re.replace('.*/', '^', 1), djangae_webapp(func)) for url_re, func in create_handlers_map())
+
+try:
+    from mapreduce.main import create_handlers_map
+    wrapped_urls = ((url_re.replace('.*/', '^', 1), djangae_webapp(func)) for url_re, func in create_handlers_map())
+except ImportError as e:
+    wrapped_urls = []
+
+
 urlpatterns = patterns('', *wrapped_urls)


### PR DESCRIPTION
mapreduce is an external library because the one bundled in the sdk is advised against, this just wraps a try around the import