### PR TITLE
Make sure we always pass down the right column for the field when orderi...

### DIFF
--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -26,6 +26,7 @@ from google.appengine.ext import deferred
 from google.appengine.api import taskqueue
 from django.test.utils import override_settings
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import FieldError
 
 # DJANGAE
 from djangae.contrib import sleuth
@@ -1040,6 +1041,9 @@ class EdgeCaseTests(TestCase):
         users = TestUser.objects.all().order_by("-username")
 
         self.assertEqual(["A", "B", "C", "D", "E"][::-1], [x.username for x in users])
+
+        with self.assertRaises(FieldError):
+            users = list(TestUser.objects.order_by("bananas"))
 
     def test_dates_query(self):
         z_user = TestUser.objects.create(username="Z", email="z@example.com")


### PR DESCRIPTION
...ng, raise a FieldError if the field name is unrecognized

The way we passed down ordering wasn't very safe, a typo, or using X_id would silently return nothing from the queryset. This behaves as a Django connector should and raises a FieldError if you attempt to order by something that isn't a field.

We now have 5 failures rather than 4 failures in the testapp, but the same is true in master .. I don't know what changed but this code should be fine.