### PR TITLE
Sort the result programmatically when 'First ordering property must be the same as inequality filter property' exception occurs.

### DIFF
--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -147,6 +147,14 @@ class Cursor(object):
             result.append(entity)
             i += 1
 
+        if hasattr(self.last_select_command, 'sort_ordering'):
+            for order, direction in reversed(self.last_select_command.sort_ordering):
+                if direction == 2:
+                    reverse = True
+                else:
+                    reverse = False
+                result.sort(key=lambda x: x[self.last_select_command.queried_fields.index(order)], reverse=reverse)
+            
         return result
 
     @property

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -668,7 +668,11 @@ class SelectCommand(object):
                     query = datastore.MultiQuery(new_queries, ordering)
                 else:
                     query = queries[0]
-                    query.Order(*ordering)
+                    try:
+                        query.Order(*ordering)
+                    except Exception, exception:
+                        if str(exception).find('First ordering property must be the same as inequality filter property') >= 0:
+                            self.sort_ordering = ordering
         else:
             query.Order(*ordering)
 

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -670,9 +670,11 @@ class SelectCommand(object):
                     query = queries[0]
                     try:
                         query.Order(*ordering)
-                    except Exception, exception:
-                        if str(exception).find('First ordering property must be the same as inequality filter property') >= 0:
+                    except datastore_errors.BadArgumentError as e:
+                        if str(e).find('First ordering property must be the same as inequality filter property') >= 0:
                             self.sort_ordering = ordering
+                        else:
+                            raise
         else:
             query.Order(*ordering)
 

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -1587,3 +1587,55 @@ class TestHelperTests(TestCase):
         self.process_task_queues()
 
         self.assertNumTasksEquals(0) #No tasks
+
+
+class Article(models.Model):
+    headline = models.CharField(max_length=100)
+    pub_date = models.DateTimeField()
+
+    def __str__(self):
+        return self.headline
+
+
+class ProgrammaticallySortTest(TestCase):
+
+    def setUp(self):
+        self.a1 = Article(headline='Article 1', pub_date=datetime.datetime(2005, 7, 26))
+        self.a1.save()
+        self.a2 = Article(headline='Article 2', pub_date=datetime.datetime(2005, 7, 27))
+        self.a2.save()
+        self.a3 = Article(headline='Article 3', pub_date=datetime.datetime(2005, 7, 27))
+        self.a3.save()
+        self.a4 = Article(headline='Article 4', pub_date=datetime.datetime(2005, 7, 28))
+        self.a4.save()
+        self.a5 = Article(headline='Article 5', pub_date=datetime.datetime(2005, 8, 1, 9, 0))
+        self.a5.save()
+        self.a6 = Article(headline='Article 6', pub_date=datetime.datetime(2005, 8, 1, 8, 0))
+        self.a6.save()
+        self.a7 = Article(headline='Article 7', pub_date=datetime.datetime(2005, 7, 27))
+        self.a7.save()
+
+    def test_programmatically_sort(self):
+        self.assertQuerysetEqual(Article.objects.filter(id__gte=1).order_by('-pub_date'),
+            [repr(r) for r in Article.objects.all().order_by('-pub_date')])
+
+        self.assertQuerysetEqual(Article.objects.filter(id__gte=1).order_by('pub_date'),
+            [repr(r) for r in Article.objects.all().order_by('pub_date')])
+        
+        self.assertQuerysetEqual(Article.objects.filter(id__gte=1).order_by('-pub_date', 'id'),
+            [repr(r) for r in Article.objects.all().order_by('-pub_date', 'id')])
+
+        self.assertQuerysetEqual(Article.objects.filter(id__gte=1).order_by('pub_date', '-id'),
+            [repr(r) for r in Article.objects.all().order_by('pub_date', '-id')])
+
+        self.assertQuerysetEqual(Article.objects.filter(id__gte=1).order_by('-pub_date', '-id'),
+            [repr(r) for r in Article.objects.all().order_by('-pub_date', '-id')])
+
+        self.assertQuerysetEqual(Article.objects.filter(id__gte=1).order_by('pub_date', 'id'),
+            [repr(r) for r in Article.objects.all().order_by('pub_date', 'id')])
+      
+        self.assertQuerysetEqual(Article.objects.filter(id__gte=1).order_by('-headline'),
+            [repr(r) for r in Article.objects.all().order_by('-headline')])
+
+        self.assertQuerysetEqual(Article.objects.filter(id__gte=1).order_by('headline'),
+            [repr(r) for r in Article.objects.all().order_by('headline')])


### PR DESCRIPTION
Hi.

<pre>
======================================================================
ERROR: test_object_creation (basic.tests.ModelTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File &quot;django_tests/basic/tests.py&quot;, line 459, in test_object_creation
    Article.objects.filter(id__lte=a4.id).delete()
  File &quot;djangae-testapp/lib/django/db/models/query.py&quot;, line 468, in delete
    collector.delete()
  File &quot;djangae-testapp/lib/django/db/models/deletion.py&quot;, line 260, in delete
    qs._raw_delete(using=self.using)
  File &quot;djangae-testapp/lib/django/db/models/query.py&quot;, line 479, in _raw_delete
    sql.DeleteQuery(self.model).delete_qs(self, using)
  File &quot;djangae-testapp/lib/django/db/models/sql/subqueries.py&quot;, line 85, in delete_qs
    self.get_compiler(using).execute_sql(None)
  File &quot;djangae-testapp/lib/django/db/models/sql/compiler.py&quot;, line 786, in execute_sql
    cursor.execute(sql, params)
  File &quot;djangae-testapp/lib/django/db/backends/util.py&quot;, line 53, in execute
    return self.cursor.execute(sql, params)
  File &quot;djangae-testapp/lib/djangae/db/backends/appengine/base.py&quot;, line 91, in execute
    self.rowcount = sql.execute()
  File &quot;djangae-testapp/lib/djangae/db/backends/appengine/commands.py&quot;, line 918, in execute
    self.select.execute()
  File &quot;djangae-testapp/lib/djangae/db/backends/appengine/commands.py&quot;, line 505, in execute
    self.gae_query = self._build_gae_query()
  File &quot;djangae-testapp/lib/djangae/db/backends/appengine/commands.py&quot;, line 671, in _build_gae_query
    query.Order(*ordering)
  File &quot;djangae-testapp/lib/google_appengine/google/appengine/api/datastore.py&quot;, line 1452, in Order
    (orderings[0][0], self.__inequality_prop))
BadArgumentError: First ordering property must be the same as inequality filter property, if specified for this query; received pub_date, expected __key__
</pre>

App Engine Datastore raises this exception when the first ordering property is not same as the inequality filter property. This limitation brokes the django test case and also causes failures when using those kinds of querysets. 

This patch makes those querysets work by sorting the result programmatically, but it may cause some cpu overheads. So I'm not sure this is the best solution. If you have a better idea, please comment. Then I'll change my codes.

Thanks.