### PR TITLE
Fix KeyError: '__key__' in django_ordering_comparison

### DIFF
--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -258,7 +258,13 @@ class QueryByKeys(object):
 
         # If there was nothing in the cache, or we had more than one key, then use Get()
         if results is None:
-            results = sorted((x for x in datastore.Get(self.queries_by_key.keys()) if x is not None), cmp=partial(utils.django_ordering_comparison, self.ordering))
+            id_list = [i.id() for i in self.queries_by_key.keys()]
+            results = datastore.Get(self.queries_by_key.keys())
+            for idx, result in enumerate(results):
+                if isinstance(result, dict):
+                    result['__key__'] = id_list[idx]
+           
+            results = sorted((x for x in results if x is not None), cmp=partial(utils.django_ordering_comparison, self.ordering))
 
         results = [
             _convert_entity_based_on_query_options(x, opts)

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -1175,7 +1175,7 @@ class EdgeCaseTests(TestCase):
         self.assertItemsEqual(results, [self.u1, self.u2])
         # Check that using more than 30 items in an __in query not on the pk causes death
         query = TestUser.objects.filter(username__in=list([x for x in letters[:31]]))
-        # This currently rasies an error from App Engine, should we raise our own?
+        # This currently raises an error from App Engine, should we raise our own?
         self.assertRaises(Exception, list, query)
         # Check that it's ok with PKs though
         query = TestUser.objects.filter(pk__in=list(xrange(1, 32)))

--- a/djangae/tests.py
+++ b/djangae/tests.py
@@ -841,9 +841,9 @@ class EdgeCaseTests(TestCase):
 
         self.u1 = TestUser.objects.create(username="A", email="test@example.com", last_login=datetime.datetime.now().date())
         self.u2 = TestUser.objects.create(username="B", email="test@example.com", last_login=datetime.datetime.now().date())
-        TestUser.objects.create(username="C", email="test2@example.com", last_login=datetime.datetime.now().date())
-        TestUser.objects.create(username="D", email="test3@example.com", last_login=datetime.datetime.now().date())
-        TestUser.objects.create(username="E", email="test3@example.com", last_login=datetime.datetime.now().date())
+        self.u3 = TestUser.objects.create(username="C", email="test2@example.com", last_login=datetime.datetime.now().date())
+        self.u4 = TestUser.objects.create(username="D", email="test3@example.com", last_login=datetime.datetime.now().date())
+        self.u5 = TestUser.objects.create(username="E", email="test3@example.com", last_login=datetime.datetime.now().date())
 
         self.apple = TestFruit.objects.create(name="apple", color="red")
         self.banana = TestFruit.objects.create(name="banana", color="yellow")
@@ -1118,6 +1118,18 @@ class EdgeCaseTests(TestCase):
 
         with self.assertRaises(FieldError):
             users = list(TestUser.objects.order_by("bananas"))
+
+        users = TestUser.objects.filter(id__in=[self.u2.id, self.u3.id, self.u4.id]).order_by('id')
+        self.assertEqual(["B", "C", "D"], [x.username for x in users])
+
+        users = TestUser.objects.filter(id__in=[self.u2.id, self.u3.id, self.u4.id]).order_by('-id')
+        self.assertEqual(["D", "C", "B"], [x.username for x in users])
+
+        users = TestUser.objects.filter(id__in=[self.u1.id, self.u5.id, self.u3.id]).order_by('id')
+        self.assertEqual(["A", "C", "E"], [x.username for x in users])
+
+        users = TestUser.objects.filter(id__in=[self.u4.id, self.u5.id, self.u3.id, self.u1.id]).order_by('-id')
+        self.assertEqual(["E", "D", "C", "A"], [x.username for x in users])
 
     def test_dates_query(self):
         z_user = TestUser.objects.create(username="Z", email="z@example.com")


### PR DESCRIPTION
Without this patch, djangae could not execute the query "TestUser.objects.filter(id__in=[self.u2.id, self.u3.id, self.u4.id]).order_by('id')".

<pre>
Traceback (most recent call last):
  File &quot;djangae-testapp/lib/djangae/tests.py&quot;, line 1123, in test_ordering
    self.assertEqual([&quot;B&quot;, &quot;C&quot;, &quot;D&quot;], [x.username for x in users])
  File &quot;djangae-testapp/lib/django/db/models/query.py&quot;, line 96, in __iter__
    self._fetch_all()
  File &quot;djangae-testapp/lib/django/db/models/query.py&quot;, line 857, in _fetch_all
    self._result_cache = list(self.iterator())
  File &quot;djangae-testapp/lib/django/db/models/query.py&quot;, line 220, in iterator
    for row in compiler.results_iter():
  File &quot;djangae-testapp/lib/django/db/models/sql/compiler.py&quot;, line 713, in results_iter
    for rows in self.execute_sql(MULTI):
  File &quot;djangae-testapp/lib/django/db/models/sql/compiler.py&quot;, line 786, in execute_sql
    cursor.execute(sql, params)
  File &quot;djangae-testapp/lib/django/db/backends/util.py&quot;, line 53, in execute
    return self.cursor.execute(sql, params)
  File &quot;djangae-testapp/lib/djangae/db/backends/appengine/base.py&quot;, line 85, in execute
    self.rowcount = self.last_select_command.execute() or -1
  File &quot;djangae-testapp/lib/djangae/db/backends/appengine/commands.py&quot;, line 510, in execute
    self._do_fetch()
  File &quot;djangae-testapp/lib/djangae/db/backends/appengine/commands.py&quot;, line 702, in _do_fetch
    limit=None if self.limits[1] is None else (self.limits[1] - (self.limits[0] or 0))
  File &quot;djangae-testapp/lib/djangae/db/backends/appengine/commands.py&quot;, line 716, in _run_query
    results = self.gae_query.Run(limit=limit, offset=start)
  File &quot;djangae-testapp/lib/djangae/db/backends/appengine/commands.py&quot;, line 261, in Run
    results = sorted((x for x in datastore.Get(self.queries_by_key.keys()) if x is not None), cmp=partial(utils.django_ordering_comparison, self.ordering))
  File &quot;djangae-testapp/lib/djangae/db/utils.py&quot;, line 236, in django_ordering_comparison
    if direction == ASCENDING and lhs[order] != rhs[order]:
KeyError: '__key__'
</pre>


This patch inserts '\__key__' items into datastore results and enables those kinds of queries work.

(I believe that this patch may fix the issue #195, but I have not tried this as of yet.)

Thanks.