### PR TITLE
Speed up 'get_field_from_column' by caching fields

### DIFF
--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -31,7 +31,7 @@ from djangae.db.utils import (
     has_concrete_parents
 )
 from djangae.indexing import special_indexes_for_column, REQUIRES_SPECIAL_INDEXES, add_special_index
-from djangae.utils import on_production
+from djangae.utils import on_production, memoized
 from djangae.db import constraints, utils
 from djangae.db.backends.appengine import caching
 from djangae.db.unique_utils import query_is_unique
@@ -72,13 +72,12 @@ REVERSE_OP_MAP = {
 INEQUALITY_OPERATORS = frozenset(['>', '<', '<=', '>='])
 
 
+@memoized
 def get_field_from_column(model, column):
-    if not hasattr(model._meta, 'cached_fields'):
-        model._meta.cached_fields = {}
-        for field in model._meta.fields:
-            model._meta.cached_fields[field.column] = field     
-    
-    return model._meta.cached_fields.get(column, None)
+    for field in model._meta.fields:
+        if field.column == column:
+            return field
+    return None
 
 
 def field_conv_year_only(value):

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -73,11 +73,12 @@ INEQUALITY_OPERATORS = frozenset(['>', '<', '<=', '>='])
 
 
 def get_field_from_column(model, column):
-    #FIXME: memoize this
-    for field in model._meta.fields:
-        if field.column == column:
-            return field
-    return None
+    if not hasattr(model._meta, 'cached_fields'):
+        model._meta.cached_fields = {}
+        for field in model._meta.fields:
+            model._meta.cached_fields[field.column] = field     
+    
+    return model._meta.cached_fields.get(column, None)
 
 
 def field_conv_year_only(value):


### PR DESCRIPTION
This patch speed up 'get_field_from_column' by caching fields and executing loop only once for each model.

Thanks.