### PR TITLE
Added additional pagination tests, fixed paginator bug

### DIFF
--- a/djangae/contrib/pagination/paginator.py
+++ b/djangae/contrib/pagination/paginator.py
@@ -169,10 +169,14 @@ class Paginator(paginator.Paginator):
         next_page = results[top:]
         next_page_counter = number + 1
         while next_page:
+            if len(next_page) >= self.per_page-1:
+                index = self.per_page-1
+            else:
+                index = len(next_page)-1
             _store_marker(
                 self.queryset_id,
                 next_page_counter,
-                getattr(next_page[self.per_page-1], self.field_required)
+                getattr(next_page[index], self.field_required)
             )
             next_page_counter += 1
             next_page = next_page[self.per_page:]
@@ -185,10 +189,14 @@ class Paginator(paginator.Paginator):
 
         page = self._get_page(results[:top], number, self)
 
+        if len(page.object_list) >= self.per_page-1:
+            index = self.per_page-1
+        else:
+            index = len(page.object_list)-1
         _store_marker(
             self.queryset_id,
             number,
-            getattr(page.object_list[self.per_page-1], self.field_required)
+            getattr(page.object_list[index], self.field_required)
         )
 
         return page

--- a/djangae/contrib/pagination/tests.py
+++ b/djangae/contrib/pagination/tests.py
@@ -149,3 +149,14 @@ class DatastorePaginatorTests(TestCase):
         with self.assertRaises(PaginationOrderingRequired):
             paginator = Paginator(TestUser.objects.all().order_by("-first_name", "last_name"), 1) # 1 item per page
             list(paginator.page(1).object_list)
+
+        # test paging when last page has less than per_page objects
+        paginator = Paginator(TestUser.objects.all().order_by("first_name"), 3) # 3 items per page
+        self.assertEqual(
+            sorted([self.u1.pk, self.u2.pk, self.u3.pk]),
+            sorted([x.pk for x in paginator.page(1).object_list])
+        )
+        self.assertEqual(
+            sorted([self.u4.pk]),
+            sorted([x.pk for x in paginator.page(2).object_list])
+        )


### PR DESCRIPTION
Sooo... if you paginated your objects in a way that the last page has less objects than your `per_page` variable, then it threw an `out of range` error. I added some tests and fixed it. :gift: 