### PR TITLE
Fix up SDK path detection to deal with multiple 'google' packages on the...

### DIFF
--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -34,7 +34,7 @@ def _disable_sqlite_stub_logging():
 
 def _find_sdk_from_python_path():
     import google.appengine
-    return os.path.abspath(os.path.dirname(google.__path__[0]))
+    return os.path.abspath(os.path.dirname(os.path.dirname(google.appengine.__path__[0])))
 
 
 def _find_sdk_from_path():

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -34,6 +34,8 @@ def _disable_sqlite_stub_logging():
 
 def _find_sdk_from_python_path():
     import google.appengine
+    # Make sure we get the path of the 'google' module which contains 'appengine', as it's possible
+    # that there are several.
     return os.path.abspath(os.path.dirname(os.path.dirname(google.appengine.__path__[0])))
 
 


### PR DESCRIPTION
... PYTHONPATH

If you have a 'google' package elsewhere that doesn't have an appengine module, `google.__path__` will return two results, but only one of them is correct, the previous code might pick the wrong one.

This commit looks for the path of the appengine module, not the google one.