### PR TITLE
Fixed number of results per page

### DIFF
--- a/djangae/contrib/pagination/paginator.py
+++ b/djangae/contrib/pagination/paginator.py
@@ -189,7 +189,7 @@ class Paginator(paginator.Paginator):
         known_count = ((number - 1) * self.per_page) + len(results)
         _update_known_count(self.queryset_id, known_count)
 
-        page = self._get_page(results[:top], number, self)
+        page = self._get_page(results[:self.per_page], number, self)
 
         if len(page.object_list) > self.per_page-1:
             index = self.per_page-1


### PR DESCRIPTION
Not 100% sure about the contrib.paginator code, but this looks like a bug to me, as `results` is previously sliced.