### PR TITLE
Make sure we don't inherit the context cache when starting a transaction...

### DIFF
--- a/djangae/db/backends/appengine/caching.py
+++ b/djangae/db/backends/appengine/caching.py
@@ -130,6 +130,7 @@ def get_from_cache_by_key(key):
 
     ret = None
     if _context.context_enabled:
+        # It's safe to hit the context cache in a transaction as we don't inherit by default
         ret = _context.stack.top.get_entity_by_key(key)
         if ret is None and not datastore.IsInTransaction():
             if _context.memcache_enabled:
@@ -152,6 +153,7 @@ def get_from_cache(unique_identifier):
 
     ret = None
     if _context.context_enabled:
+        # It's safe to hit the context cache in a transaction as we don't inherit by default
         ret = _context.stack.top.get_entity(unique_identifier)
         if ret is None and not datastore.IsInTransaction():
             if _context.memcache_enabled:

--- a/djangae/db/backends/appengine/context.py
+++ b/djangae/db/backends/appengine/context.py
@@ -69,30 +69,42 @@ class Context(object):
 
         del self.reverse_cache[entity_or_key]
 
-    def get_entity(self, identifier):
+    def get_entity(self, identifier, inherit=False):
         cache = {}
 
-        for ctx in self._stack.stack:
-            cache.update(ctx.cache)
-            if ctx == self:
-                break;
+        if not inherit:
+            # Don't inherit the whole stack, just get from the top
+            return self.cache.get(identifier)
+        else:
+            # Inherit the entire stack
+            for ctx in self._stack.stack:
+                cache.update(ctx.cache)
+                if ctx == self:
+                    break;
 
-        return cache.get(identifier)
+            return cache.get(identifier)
 
-    def get_entity_by_key(self, key):
+    def get_entity_by_key(self, key, inherit=False):
         cache = {}
 
-        for ctx in self._stack.stack:
-            cache.update(ctx.reverse_cache)
-            if ctx == self:
-                break;
+        if not inherit:
+            try:
+                identifier = self.reverse_cache[key][0]
+            except KeyError:
+                return None
+            return self.get_entity(identifier, inherit)
+        else:
+            for ctx in self._stack.stack:
+                cache.update(ctx.reverse_cache)
+                if ctx == self:
+                    break;
 
-        try:
-            identifier = cache[key][0]  # Pick any identifier
-        except KeyError:
-            return None
+            try:
+                identifier = cache[key][0]  # Pick any identifier
+            except KeyError:
+                return None
 
-        return self.get_entity(identifier)
+            return self.get_entity(identifier, inherit)
 
 class ContextStack(object):
     """

--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -91,16 +91,12 @@ class AtomicDecorator(ContextDecorator):
                 while self.conn_stack:
                     _PushConnection(self.conn_stack.pop())
 
-                 # Clear the context cache at the end of a transaction
-                if exception:
-                    caching._context.stack.pop(discard=True)
-                else:
-                    caching._context.stack.pop(apply_staged=False, clear_staged=False)
+             # Clear the context cache at the end of a transaction
+            if exception:
+                caching._context.stack.pop(discard=True)
             else:
-                if exception:
-                    caching._context.stack.pop(discard=True)
-                else:
-                    caching._context.stack.pop(apply_staged=True, clear_staged=True)
+                caching._context.stack.pop(apply_staged=True, clear_staged=True)
+
 
     def __enter__(self):
         self._do_enter()


### PR DESCRIPTION
..., and apply cache changes as transactions commit

This fixes wrong behaviour if you load an entity outside a transaction, and then try to transactionally get()/save() within a transaction.