### PR TITLE
Support contains lookups on values that have an isoformat method

### DIFF
--- a/djangae/indexing.py
+++ b/djangae/indexing.py
@@ -226,6 +226,10 @@ class ContainsIndexer(Indexer):
     def prep_value_for_database(self, value):
         result = []
         if value:
+            # If this a date or a datetime, or something that supports isoformat, then use that
+            if hasattr(value, "isoformat"):
+                value = value.isoformat()
+
             if self.number_of_permutations(value) > MAX_COLUMNS_PER_SPECIAL_INDEX*500:
                 raise ValueError("Can't index for contains query, this value is too long and has too many permutations. \
                     You can increase the DJANGAE_MAX_COLUMNS_PER_SPECIAL_INDEX setting to fix that. Use with caution.")

--- a/djangae/tests/tests.py
+++ b/djangae/tests/tests.py
@@ -265,6 +265,13 @@ class SpecialIndexesModel(models.Model):
         app_label = "djangae"
 
 
+class DateTimeModel(models.Model):
+    datetime_field = models.DateTimeField(auto_now_add=True)
+    date_field = models.DateField(auto_now_add=True)
+
+    class Meta:
+        app_label = "djangae"
+
 class PaginatorModel(models.Model):
     foo = models.IntegerField()
 
@@ -1085,6 +1092,19 @@ class EdgeCaseTests(TestCase):
 
         qs = TestUser.objects.filter(username__startswith='Hello') &  TestUser.objects.filter(username__startswith='Goodbye')
         self.assertEqual(0, qs.count())
+
+    def test_datetime_contains(self):
+        """
+            Django allows for __contains on datetime field, so that you can search for a specific
+            date. This is probably just because SQL allows querying it on a string, and contains just
+            turns into a like query. This test just makes sure we behave the same
+        """
+
+        instance = DateTimeModel.objects.create() # Create a DateTimeModel, it has auto_now stuff
+
+        # Make sure that if we query a datetime on a date it is properly returned
+        self.assertItemsEqual([instance], DateTimeModel.objects.filter(datetime_field__contains=instance.datetime_field.date()))
+        self.assertItemsEqual([instance], DateTimeModel.objects.filter(date_field__contains=instance.date_field.year))
 
     def test_combinations_of_special_indexes(self):
         qs = TestUser.objects.filter(username__iexact='Hello') | TestUser.objects.filter(username__contains='ood')


### PR DESCRIPTION
Django supports this on SQL automatically as SQL allows string comparisons with dates and datetimes. This now works by indexing the isoformat of the date or datetime.