### PR TITLE
Make sure we set the default even on an update (Django doesn't do this)

### DIFF
--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -151,6 +151,11 @@ def django_instance_to_entity(connection, model, fields, raw, instance, check_nu
     def value_from_instance(_instance, _field):
         value = get_prepared_db_value(connection, _instance, _field, raw)
 
+        # If value is None, but there is a default, then we should populate it
+        # Otherwise thing get hairy when you add new fields to models
+        if value is None and _field.has_default():
+            value = connection.ops.value_for_db(_field.get_default(), _field)
+
         if check_null and (not _field.null and not _field.primary_key) and value is None:
             raise IntegrityError("You can't set %s (a non-nullable "
                                      "field) to None!" % _field.name)

--- a/djangae/tests/tests.py
+++ b/djangae/tests/tests.py
@@ -99,7 +99,7 @@ class UniqueModelWithLongPK(models.Model):
 
 
 class IntegerModel(models.Model):
-    integer_field = models.IntegerField(default=0)
+    integer_field = models.IntegerField()
 
     class Meta:
         app_label = "djangae"
@@ -315,6 +315,22 @@ class BackendTests(TestCase):
         # query then it's a match
         entity["name"] = [ "Bob", "Fred", "Dave" ]
         self.assertTrue(entity_matches_query(entity, query))  # ListField test
+
+    def test_defaults(self):
+        fruit = TestFruit.objects.create(name="Apple", color="Red")
+        self.assertEqual("Unknown", fruit.origin)
+
+        instance = datastore.Get(datastore.Key.from_path(TestFruit._meta.db_table, fruit.pk))
+        del instance["origin"]
+        datastore.Put(instance)
+
+        fruit = TestFruit.objects.get()
+        self.assertIsNone(fruit.origin)
+        fruit.save()
+
+        fruit = TestFruit.objects.get()
+        self.assertEqual("Unknown", fruit.origin)
+
 
     def test_get_or_create(self):
         """


### PR DESCRIPTION
Django doesn't call get_default() on an update, this is problematic on a schemaless database because we have no UPDATE query that could pre-populate it for us, so we always call get_default if the field is not-nullable, has a value of None, and has a default