### PR TITLE
Fixing runserver command for the new App Engine SDK 1.9.19

### DIFF
--- a/djangae/management/commands/runserver.py
+++ b/djangae/management/commands/runserver.py
@@ -5,6 +5,11 @@ from django.core.management.commands.runserver import BaseRunserverCommand
 from datetime import datetime
 
 from google.appengine.tools.devappserver2 import shutdown
+from google.appengine.tools.sdk_update_checker import (
+    GetVersionObject,
+    _VersionList
+)
+
 
 class Command(BaseRunserverCommand):
     """
@@ -78,6 +83,11 @@ class Command(BaseRunserverCommand):
 
         if self.addr != sandbox._OPTIONS.host:
             sandbox._OPTIONS.host = sandbox._OPTIONS.admin_host = sandbox._OPTIONS.api_host = self.addr
+
+        # External port is a new flag introduced in 1.9.19
+        current_version = _VersionList(GetVersionObject()['release'])
+        if current_version >= _VersionList('1.9.19'):
+            sandbox._OPTIONS.external_port = None
 
         sandbox._OPTIONS.automatic_restart = self.use_reloader
 

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -64,11 +64,13 @@ def _create_dispatcher(configuration, options):
     from google.appengine.tools.devappserver2.devappserver2 import (
         DevelopmentServer, _LOG_LEVEL_TO_RUNTIME_CONSTANT
     )
+    from google.appengine.tools.sdk_update_checker import GetVersionObject, \
+                                                          _VersionList
 
     if hasattr(_create_dispatcher, "singleton"):
         return _create_dispatcher.singleton
 
-    _create_dispatcher.singleton = dispatcher.Dispatcher(
+    dispatcher_args = [
         configuration,
         options.host,
         options.port,
@@ -86,7 +88,14 @@ def _create_dispatcher(configuration, options):
         options.allow_skipped_files,
         DevelopmentServer._create_module_to_setting(options.threadsafe_override,
                                        configuration, '--threadsafe_override')
-    )
+    ]
+
+    # External port is a new flag introduced in 1.9.19
+    current_version = _VersionList(GetVersionObject()['release'])
+    if current_version >= _VersionList('1.9.19'):
+        dispatcher_args.append(options.external_port)
+
+    _create_dispatcher.singleton = dispatcher.Dispatcher(*dispatcher_args)
 
     return _create_dispatcher.singleton
 


### PR DESCRIPTION
Adding the `--external-port` flag depending on the SDK version. Newer versions need it to be passed in. #307