### PR TITLE
Fix relatedsetfield deserialize

### DIFF
--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -213,7 +213,11 @@ class RelatedSetField(RelatedField):
 
             value = value[1:-1].strip()
             ids = [ self.rel.to._meta.pk.to_python(x) for x in value.split(",") ]
-            return set(ids)
+
+            # Annoyingly Django special cases FK and M2M in the Python deserialization code,
+            # to assign to the attname, whereas all other fields (including this one) are required to
+            # populate field.name instead. So we have to query here... we have no choice :(
+            return set(self.rel.to._default_manager.db_manager('default').filter(pk__in=ids))
 
         return set(value)
 

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1742,7 +1742,10 @@ class IterableFieldTests(TestCase):
 class InstanceSetFieldTests(TestCase):
 
     def test_deserialization(self):
-        self.assertEqual(set([1, 2]), ISModel._meta.get_field("related_things").to_python("[1, 2]"))
+        i1 = ISOther.objects.create(pk=1)
+        i2 = ISOther.objects.create(pk=2)
+
+        self.assertEqual(set([i1, i2]), ISModel._meta.get_field("related_things").to_python("[1, 2]"))
 
     def test_basic_usage(self):
         main = ISModel.objects.create()

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -33,7 +33,7 @@ ALLOWED_HOSTS = []
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
-    'djangae.contrib.gauth',
+    'djangae.contrib.gauth.datastore',
     'djangae.contrib.security',
     'django.contrib.contenttypes',
     'django.contrib.sessions',


### PR DESCRIPTION
Turns out that we need to return the actual instances, because we can't do what FK and M2M do as they are special cased in the Python Deserializer :(