### PR TITLE
Made `@atomic` decorator work on instance methods.

### DIFF
--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -1,3 +1,5 @@
+import functools
+
 from google.appengine.api.datastore import (
     CreateTransactionOptions,
     _GetConnection,
@@ -15,6 +17,15 @@ from djangae.db.backends.appengine import caching
 class ContextDecorator(object):
     def __init__(self, func=None):
         self.func = func
+
+    def __get__(self, obj, objtype=None):
+        """ Implement descriptor protocol to support instance methods. """
+        # Invoked whenever this is accessed as an attribute of *another* object
+        # - as it is when wrapping an instance method: `instance.method` will be
+        # the ContextDecorator, so this is called.
+        # We make sure __call__ is passed the `instance`, which it will pass onto
+        # `self.func()`
+        return functools.partial(self.__call__, obj)
 
     def __call__(self, *args, **kwargs):
         def decorated(*_args, **_kwargs):

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -607,6 +607,15 @@ class TransactionTests(TestCase):
 
         self.assertEqual(0, TestUser.objects.count())
 
+        # Test on a class method: should pass correct number of args
+        class Cls(object):
+            @transaction.atomic
+            def txn(self, arg):
+                return arg
+
+        obj = Cls()
+        self.assertEqual(7, obj.txn(7))
+
     def test_interaction_with_datastore_txn(self):
         from google.appengine.ext import db
         from google.appengine.datastore.datastore_rpc import TransactionOptions
@@ -675,6 +684,15 @@ class TransactionTests(TestCase):
 
         self.assertEqual(0, TestUser.objects.count())
         self.assertEqual(0, TestFruit.objects.count())
+
+        # Test on a class method: should pass correct number of args
+        class Cls(object):
+            @transaction.atomic(xg=True)
+            def txn(self, arg):
+                return arg
+
+        obj = Cls()
+        self.assertEqual(7, obj.txn(7))
 
     def test_independent_argument(self):
         """


### PR DESCRIPTION
e.g.:

```python
class Cls(object):
    @transaction.atomic
    def txn(self, arg):
        ...
```

Which fails with `TypeError: txn() takes exactly 2 arguments (1 given)`, because in `ContextDecorator.__call__()`, `self` arg is always going to be the decorator itself, not the instance of the class the method was called on (and we swallow it anyway).

Extended a couple of tests to demonstrate this.

The only solution I could think of is with some descriptor magic. If the decorator is a descriptor, when it’s used on an instance method, `ContextDecorator.__get__()` will be used to access it, which is passed the instance it’s called on… so we can insert that instance into the args we call the func with (which becomes `self` inside the function).

Alternatively, an easy workaround is to just use `atomic` as a context manager inside the method:

```python
class Cls(object):
    def txn(self, arg):
        with transaction.atomic:
            ...
```

– but mo indentation, mo ugly.
