### PR TITLE
Fixed a stack underflow with nested transactions using the `@atomic` decorator

### DIFF
--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -108,6 +108,8 @@ class AtomicDecorator(ContextDecorator):
             else:
                 caching._context.stack.pop(apply_staged=True, clear_staged=True)
 
+            # Reset this; in case this method is called again
+            self.transaction_started = False
 
     def __enter__(self):
         self._do_enter()


### PR DESCRIPTION
`transaction_started` was only set `False` in `__init__()`, which is fine for single-use context managers, but when decorating functions/methods it can leave the decorated method in a state where it thinks it’s still in a transaction after it finishes.

In certain nesting patterns `__exit__()` gets confused, and ultimately pops a few too many times and drops its load on the floor.
