### PR TITLE
Patch serialization to backport a serialization bugfix

### DIFF
--- a/djangae/fields/iterable.py
+++ b/djangae/fields/iterable.py
@@ -117,6 +117,19 @@ class IterableField(models.Field):
         if value is None:
             return self._iterable_type([])
 
+        # Deal with deserialization from a string
+        if isinstance(value, basestring):
+            if not (value.startswith("[") and value.endswith("]")):
+                raise ValidationError(
+                    "Invalid input for {0} instance".format(type(self).__name__))
+
+            value = value[1:-1].strip()
+
+            if not value:
+                return self._iterable_type([])
+
+            value = [v.strip('\'" ') for v in value.split(',')]
+
         # Because a set cannot be defined in JSON, we must allow a list to be passed as the value
         # of a SetField, as otherwise SetField data can't be loaded from fixtures
         if not hasattr(value, "__iter__"): # Allows list/set, not string

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -225,7 +225,7 @@ class RelatedSetField(RelatedField):
             if not value:
                 return set()
 
-            ids = [ self.rel.to._meta.pk.to_python(x) for x in value.split(",") ]
+            ids = [ self.rel.to._meta.pk.to_python(x.rstrip('L')) for x in value.split(",") ]
 
             # Annoyingly Django special cases FK and M2M in the Python deserialization code,
             # to assign to the attname, whereas all other fields (including this one) are required to

--- a/djangae/patches/__init__.py
+++ b/djangae/patches/__init__.py
@@ -1,3 +1,5 @@
+from distutils.version import StrictVersion
+import django
 from django.conf import settings
 
 
@@ -5,3 +7,7 @@ def patch():
     if 'django.contrib.contenttypes' in settings.INSTALLED_APPS:
         from . import contenttypes
         contenttypes.patch()
+
+    if StrictVersion(django.get_version()) < StrictVersion('1.8'):
+        from . import serialization
+        serialization.patch()

--- a/djangae/patches/serialization.py
+++ b/djangae/patches/serialization.py
@@ -1,0 +1,27 @@
+from django.utils.encoding import is_protected_type
+
+
+def handle_fk_field_patch(self, obj, field):
+    """
+    Patches the handle_fk_field() method in order to make sure that the field's
+    `value_to_string()` is called.
+
+    This is fixed in Django 1.8.
+    """
+    if self.use_natural_foreign_keys and hasattr(field.rel.to, 'natural_key'):
+        related = getattr(obj, field.name)
+        if related:
+            value = related.natural_key()
+        else:
+            value = None
+    else:
+        value = getattr(obj, field.get_attname())
+        if not is_protected_type(value):
+            value = field.value_to_string(obj)
+    self._current[field.name] = value
+
+
+def patch():
+    from django.core.serializers.python import Serializer as OriginalSerializer
+
+    OriginalSerializer.handle_fk_field = handle_fk_field_patch

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -308,6 +308,7 @@ class InstanceSetFieldTests(TestCase):
         i2 = ISOther.objects.create(pk=2)
 
         self.assertEqual(set([i1, i2]), ISModel._meta.get_field("related_things").to_python("[1, 2]"))
+        self.assertEqual(set([i1, i2]), ISModel._meta.get_field("related_things").to_python("[1, 2L]"))
 
     def test_basic_usage(self):
         main = ISModel.objects.create()

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.contrib.contenttypes.models import ContentType
 
 # DJANGAE
+from django.core.exceptions import ValidationError
 from djangae.db import transaction
 from djangae.fields import (
     ComputedCharField,
@@ -252,8 +253,11 @@ class IterableFieldTests(TestCase):
 
         instance.list_field = None
 
+        instance.list_field = "['One', 'Two']"
+        self.assertEqual(["One", "Two"], instance.list_field)
+
         # Or anything else for that matter!
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             instance.list_field = "Bananas"
             instance.save()
 
@@ -274,8 +278,11 @@ class IterableFieldTests(TestCase):
 
         instance.set_field = None
 
+        instance.set_field = "['One', 'Two']"
+        self.assertEqual(set(["One", "Two"]), instance.set_field)
+
         # Or anything else for that matter!
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             instance.set_field = "Bananas"
             instance.save()
 


### PR DESCRIPTION
Patch the PythonSerializer.handle_fk_field method to backport a fix added in Django 1.8. This was making dumpdata fail when it tried to serialize a RelatedSetField containing FKs.

Fix IterableField deserialization by adding string handing to the to_python method.

Fix case where deserialization to RelatedSetField of a long (999L) number would not parse.