### PR TITLE
Local blobstore service

### DIFF
--- a/djangae/blobstore_service.py
+++ b/djangae/blobstore_service.py
@@ -1,0 +1,43 @@
+import os
+import threading
+import logging
+
+
+blobstore_service = None
+server = None
+
+
+def start_blobstore_service():
+    """
+        When the blobstore files API was deprecated, the blobstore storage was switched
+        to use a POST request to the upload handler when storing files uploaded via Django.
+
+        Unfortunately this breaks in the local sandbox when you aren't running the dev_appserver
+        because there is no server to handle the blobstore upload. So, this service is kicked
+        off by the local sandbox and only handles blobstore uploads. When runserver kicks in
+        this service is stopped.
+    """
+    global blobstore_service
+    global server
+
+    from wsgiref.simple_server import make_server, demo_app
+    from google.appengine.tools.devappserver2.blob_upload import Application
+
+    port = int(os.environ['SERVER_PORT'])
+    logging.info("Starting blobstore service on port %s", port)
+    server = make_server('', port, Application(demo_app))
+    blobstore_service = threading.Thread(target=server.serve_forever)
+    blobstore_service.daemon = True
+    blobstore_service.start()
+
+
+def stop_blobstore_service():
+    global blobstore_service
+    global server
+
+    if not blobstore_service:
+        return
+
+    server.shutdown()
+    blobstore_service.join(5)
+    blobstore_service = None

--- a/djangae/blobstore_service.py
+++ b/djangae/blobstore_service.py
@@ -37,8 +37,9 @@ def start_blobstore_service():
         return response
 
     port = int(os.environ['SERVER_PORT'])
-    logging.info("Starting blobstore service on port %s", port)
-    server = make_server('', port, Application(handler))
+    host = os.environ['SERVER_NAME']
+    logging.info("Starting blobstore service on %s:%s", host, port)
+    server = make_server(host, port, Application(handler))
     blobstore_service = threading.Thread(target=server.serve_forever)
     blobstore_service.daemon = True
     blobstore_service.start()

--- a/djangae/management/commands/runserver.py
+++ b/djangae/management/commands/runserver.py
@@ -34,9 +34,12 @@ class Command(BaseRunserverCommand):
 
         from djangae.utils import find_project_root
         from djangae.sandbox import _find_sdk_from_python_path
+        from djangae.blobstore_service import stop_blobstore_service
 
         from django.conf import settings
         from django.utils import translation
+
+        stop_blobstore_service()
 
         # Check for app.yaml
         expected_path = os.path.join(find_project_root(), "app.yaml")

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -122,10 +122,14 @@ def _local(devappserver2=None, configuration=None, options=None, wsgi_request_in
     _API_SERVER = devappserver2.DevelopmentServer._create_api_server(
         request_data, storage_path, options, configuration)
 
+    from .blobstore_service import start_blobstore_service, stop_blobstore_service
+
+    start_blobstore_service()
     try:
         yield
     finally:
         os.environ = original_environ
+        stop_blobstore_service()
 
 
 @contextlib.contextmanager
@@ -254,6 +258,7 @@ def activate(sandbox_name, add_sdk_to_path=False, **overrides):
     # The argparser is the easiest way to get the default options.
     options = devappserver2.PARSER.parse_args([project_root])
     options.enable_task_running = False # Disable task running by default, it won't work without a running server
+    options.skip_sdk_update_check = True
 
     for option in overrides:
         if not hasattr(options, option):

--- a/djangae/tests/test_storage.py
+++ b/djangae/tests/test_storage.py
@@ -5,83 +5,18 @@ import os
 import urlparse
 
 from google.appengine.api import urlfetch
-from google.appengine.tools.devappserver2 import blob_upload, blob_image
 
 from django.core.files.base import File, ContentFile
-from django.core.wsgi import get_wsgi_application
-from django.http import HttpResponse
 
 from djangae.storage import BlobstoreStorage
 from djangae.test import TestCase
-from djangae.wsgi import DjangaeApplication
 
 
 # _URL_STRING_MAP is {'GET': 1, etc} so reverse dict to convert int to string
 URL_INT_TO_STRING_MAP = {v: k for k, v in urlfetch._URL_STRING_MAP.items()}
 
-_fetch = urlfetch.fetch  # Reference to original: will be wrapped later
-
-
-def urlfetch_wrapper(url, payload=None, method=urlfetch.GET, headers={},
-                     validate_certificate=None, **kwargs):
-    """ Wrapper for urlfetch to route blobstore URLs to test handlers. """
-    # Need to include validate_certificate in args ^^ because
-    # AppEngineSecurityMiddleware will introspect it.
-
-    _, _, path, _, query, _ = urlparse.urlparse(url)
-
-    # Only special treatment for blobstore URLs
-    if path.startswith('/_ah/upload/'):
-        # Blobstore upload handler is a WSGI application. `forward_app=...`
-        # tells it to route the _subsequent_ POST back to Django
-        application = DjangaeApplication(get_wsgi_application())
-        app = blob_upload.Application(forward_app=application)
-
-    elif path.startswith('/_ah/img/'):
-        # Blobstore image handler is a WSGI app too
-        app = blob_image.Application()
-
-    else:
-        # Not a blobstore URL – use standard urlfetch
-        return _fetch(url, payload, method, headers,
-                      validate_certificate=validate_certificate, **kwargs)
-
-    environ = {
-        'SERVER_NAME':    'testserver',
-        'SERVER_PORT':    '80',
-        'CONTENT_TYPE':   headers.get('Content-Type', None),
-        'PATH_INFO':      path,
-        'QUERY_STRING':   query,
-        'REQUEST_METHOD': URL_INT_TO_STRING_MAP[method],
-    }
-    if payload:
-        environ.update({
-            'CONTENT_LENGTH': len(payload),
-            'wsgi.input':     cStringIO.StringIO(payload),
-        })
-    response = HttpResponse()
-
-    # A dummy start_response is fine because we’re just populating
-    # an HttpResponse
-    for s in app(environ, start_response=lambda *args: None):
-        response.write(s)
-
-    return response
-
 
 class BlobstoreStorageTests(TestCase):
-
-    # In tests urlfetch hits real URLs, so patching to correctly route to the
-    # blobstore upload handler. Can’t use sleuth because it wraps the function,
-    # which confuses `replace_default_argument()` in SecurityMiddleware.
-    def setUp(self):
-        super(BlobstoreStorageTests, self).setUp()
-        urlfetch.fetch = urlfetch_wrapper
-
-    def tearDown(self):
-        urlfetch.fetch = _fetch
-        super(BlobstoreStorageTests, self).tearDown()
-
     def test_basic_actions(self):
 
         storage = BlobstoreStorage()

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -54,6 +54,8 @@ if django.VERSION >= (1, 7, 0, 0, 0):
     INSTALLED_APPS.remove('djangae')
     INSTALLED_APPS = ['djangae'] + INSTALLED_APPS
 
+TO_TEST = []
+
 if "test" in sys.argv:
     import sys
     import tempfile


### PR DESCRIPTION
This PR adds a local wsgi handler which emulates the blobstore service when running the local sandbox. This allows the BlobstoreStorage backend to function when running management commands, tests etc.