### PR TITLE
Resolved two failing tests in Djangae for Django 1.7

### DIFF
--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -18,7 +18,7 @@ from django.utils.encoding import smart_str, force_unicode
 from django.test.client import encode_multipart, MULTIPART_CONTENT, BOUNDARY
 
 from google.appengine.api import urlfetch
-from google.appengine.api.images import get_serving_url, NotImageError
+from google.appengine.api.images import get_serving_url, NotImageError, BlobKeyRequiredError
 from google.appengine.ext.blobstore import (
     BlobInfo,
     BlobKey,
@@ -140,7 +140,7 @@ class BlobstoreStorage(Storage):
             # down an argument saying whether it should be secure or not
             url = get_serving_url(self._get_blobinfo(name))
             return re.sub("http://", "//", url)
-        except NotImageError:
+        except (NotImageError, BlobKeyRequiredError):
             return None
 
     def created_time(self, name):

--- a/djangae/test_runner.py
+++ b/djangae/test_runner.py
@@ -131,6 +131,10 @@ class DjangaeTestSuiteRunner(DiscoverRunner):
 
         new_tests = []
 
+        # Django's DiscoveryRunner can create duplicate tests when passing
+        # extra_tests argument. Getting rid of that:
+        suite._tests = list(set(suite._tests))
+
         for i, test in enumerate(suite._tests):
 
             # https://docs.djangoproject.com/en/1.7/topics/testing/advanced/#django.test.TransactionTestCase.available_apps

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -151,6 +151,6 @@ DJANGAE_SEQUENTIAL_IDS_IN_TESTS = True
 DJANGAE_SIMULATE_CONTENTTYPES = True
 
 TEST_RUNNER = 'djangae.test_runner.SkipUnsupportedRunner'
-DJANGAE_ADDITIONAL_TEST_APPS = ["djangae"] + TO_TEST
+DJANGAE_ADDITIONAL_TEST_APPS = ["djangae"]
 
 from djangae.contrib.gauth.settings import *


### PR DESCRIPTION
There were two failing tests in `model_forms.tests.FileAndImageFieldTests`. This makes them pass + removes duplicated tests from the test suite (one of them was failing because tests were duplicated in the test suite). 