### PR TITLE
Handles TransformationError exception when getting blob's URL

### DIFF
--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -18,7 +18,12 @@ from django.utils.encoding import smart_str, force_unicode
 from django.test.client import encode_multipart, MULTIPART_CONTENT, BOUNDARY
 
 from google.appengine.api import urlfetch
-from google.appengine.api.images import get_serving_url, NotImageError, BlobKeyRequiredError
+from google.appengine.api.images import (
+    get_serving_url,
+    NotImageError,
+    BlobKeyRequiredError,
+    TransformationError,
+)
 from google.appengine.ext.blobstore import (
     BlobInfo,
     BlobKey,
@@ -140,7 +145,7 @@ class BlobstoreStorage(Storage):
             # down an argument saying whether it should be secure or not
             url = get_serving_url(self._get_blobinfo(name))
             return re.sub("http://", "//", url)
-        except (NotImageError, BlobKeyRequiredError):
+        except (NotImageError, BlobKeyRequiredError, TransformationError):
             return None
 
     def created_time(self, name):

--- a/djangae/tests/test_storage.py
+++ b/djangae/tests/test_storage.py
@@ -5,9 +5,11 @@ import os
 import urlparse
 
 from google.appengine.api import urlfetch
+from google.appengine.api.images import TransformationError
 
 from django.core.files.base import File, ContentFile
 
+from djangae.contrib import sleuth
 from djangae.storage import BlobstoreStorage
 from djangae.test import TestCase
 
@@ -57,3 +59,8 @@ class BlobstoreStorageTests(TestCase):
         storage = BlobstoreStorage()
         f2 = ContentFile('nameless-content')
         storage.save('tmp2', f2)
+
+    def test_transformation_error(self):
+        storage = BlobstoreStorage()
+        with sleuth.detonate('djangae.storage.get_serving_url', TransformationError):
+            self.assertIsNone(storage.url('thing'))


### PR DESCRIPTION
When uploading PDFs for instance, the Storage backend uses PIL's `get_serving_url` which raises a `TransformationError` exception as the file can't be transformed to image. This makes it a bit more fool-proof.