### PR TITLE
`django_ordering_comparison` can’t handle datetimes with null values

### DIFF
--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -262,8 +262,9 @@ def key_exists(key):
     return qry.Count(limit=1) > 0
 
 
+# Null-friendly comparison functions
+
 def lt(x, y):
-    """ x < y comparison which handles Nones """
     if x is None and y is not None:
         return True
     elif x is not None and y is None:
@@ -273,13 +274,20 @@ def lt(x, y):
 
 
 def gt(x, y):
-    """ x > y comparison which handles Nones """
     if x is None and y is not None:
         return False
     elif x is not None and y is None:
         return True
     else:
         return x > y
+
+
+def gte(x, y):
+    return not lt(x, y)
+
+
+def lte(x, y):
+    return not gt(x, y)
 
 
 def django_ordering_comparison(ordering, lhs, rhs):
@@ -306,10 +314,6 @@ def entity_matches_query(entity, query):
         Return True if the entity would potentially be returned by the datastore
         query
     """
-
-    gte = lambda x, y: not lt(x, y)
-    lte = lambda x, y: not gt(x, y)
-
     OPERATORS = {
         "=": lambda x, y: x == y,
         "<": lt,

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -262,6 +262,26 @@ def key_exists(key):
     return qry.Count(limit=1) > 0
 
 
+def lt(x, y):
+    """ x < y comparison which handles Nones """
+    if x is None and y is not None:
+        return True
+    elif x is not None and y is None:
+        return False
+    else:
+        return x < y
+
+
+def gt(x, y):
+    """ x > y comparison which handles Nones """
+    if x is None and y is not None:
+        return False
+    elif x is not None and y is None:
+        return True
+    else:
+        return x > y
+
+
 def django_ordering_comparison(ordering, lhs, rhs):
     if not ordering:
         return -1  # Really doesn't matter
@@ -274,9 +294,9 @@ def django_ordering_comparison(ordering, lhs, rhs):
         rhs_value = rhs.key() if order == "__key__" else rhs[order]
 
         if direction == ASCENDING and lhs_value != rhs_value:
-            return -1 if lhs_value < rhs_value else 1
+            return -1 if lt(lhs_value, rhs_value) else 1
         elif direction == DESCENDING and lhs_value != rhs_value:
-            return 1 if lhs_value < rhs_value else -1
+            return 1 if lt(lhs_value, rhs_value) else -1
 
     return 0
 
@@ -286,22 +306,6 @@ def entity_matches_query(entity, query):
         Return True if the entity would potentially be returned by the datastore
         query
     """
-
-    def lt(x, y):
-        if x is None and y is not None:
-            return True
-        elif x is not None and y is None:
-            return False
-        else:
-            return x < y
-
-    def gt(x, y):
-        if x is None and y is not None:
-            return False
-        elif x is not None and y is None:
-            return True
-        else:
-            return x > y
 
     gte = lambda x, y: not lt(x, y)
     lte = lambda x, y: not gt(x, y)

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -508,6 +508,14 @@ class BackendTests(TestCase):
         self.assertItemsEqual([obj], date_set.dates.exclude(date=None))
         self.assertItemsEqual([obj], date_set.dates.exclude(time=None))
 
+        # sorting should work too
+        self.assertItemsEqual([obj], date_set.dates.order_by('datetime'))
+        self.assertItemsEqual([obj], date_set.dates.order_by('-datetime'))
+        self.assertItemsEqual([obj], date_set.dates.order_by('date'))
+        self.assertItemsEqual([obj], date_set.dates.order_by('-date'))
+        self.assertItemsEqual([obj], date_set.dates.order_by('time'))
+        self.assertItemsEqual([obj], date_set.dates.order_by('-time'))
+
 
 class ModelFormsetTest(TestCase):
     def test_reproduce_index_error(self):

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -509,12 +509,12 @@ class BackendTests(TestCase):
         self.assertItemsEqual([obj], date_set.dates.exclude(time=None))
 
         # sorting should work too
-        self.assertItemsEqual([obj], date_set.dates.order_by('datetime'))
-        self.assertItemsEqual([obj], date_set.dates.order_by('-datetime'))
-        self.assertItemsEqual([obj], date_set.dates.order_by('date'))
-        self.assertItemsEqual([obj], date_set.dates.order_by('-date'))
-        self.assertItemsEqual([obj], date_set.dates.order_by('time'))
-        self.assertItemsEqual([obj], date_set.dates.order_by('-time'))
+        self.assertItemsEqual([obj, empty_obj], date_set.dates.order_by('datetime'))
+        self.assertItemsEqual([empty_obj, obj], date_set.dates.order_by('-datetime'))
+        self.assertItemsEqual([obj, empty_obj], date_set.dates.order_by('date'))
+        self.assertItemsEqual([empty_obj, obj], date_set.dates.order_by('-date'))
+        self.assertItemsEqual([obj, empty_obj], date_set.dates.order_by('time'))
+        self.assertItemsEqual([empty_obj, obj], date_set.dates.order_by('-time'))
 
 
 class ModelFormsetTest(TestCase):


### PR DESCRIPTION
Test to reproduce attached.

Will collaborate with @asendecka to add a fix to this PR.
