### PR TITLE
Improve paginator

### DIFF
--- a/djangae/contrib/pagination/decorators.py
+++ b/djangae/contrib/pagination/decorators.py
@@ -50,6 +50,7 @@ def _field_name_for_ordering(ordering):
     new_field_name = "pagination_{}".format("_".join(names))
     return new_field_name
 
+
 class PaginatedModel(object):
     """
         A class decorator which automatically generates pre-calculated fields for pagination.
@@ -63,6 +64,13 @@ class PaginatedModel(object):
         is fast even when there are many pages.
     """
     def __init__(self, orderings):
+        # Allow orderings to be specified either as single fields, or tuples/lists of fields
+        _orderings = []
+        for ordering in orderings:
+            if isinstance(ordering, basestring):
+                _orderings.append((ordering,))
+            else:
+                orderings.append(ordering)
         self.orderings = orderings
 
     def __call__(self, cls):

--- a/djangae/contrib/pagination/decorators.py
+++ b/djangae/contrib/pagination/decorators.py
@@ -70,8 +70,8 @@ class PaginatedModel(object):
             if isinstance(ordering, basestring):
                 _orderings.append((ordering,))
             else:
-                orderings.append(ordering)
-        self.orderings = orderings
+                _orderings.append(ordering)
+        self.orderings = _orderings
 
     def __call__(self, cls):
         """

--- a/djangae/contrib/pagination/tests.py
+++ b/djangae/contrib/pagination/tests.py
@@ -11,8 +11,8 @@ from djangae.contrib.pagination import (
 from .paginator import queryset_identifier, _get_marker
 
 @paginated_model(orderings=[
-    ("first_name",),
-    ("last_name",),
+    "first_name", # single field declared as a string
+    ("last_name",), # single field declared as a tuple
     ("first_name", "last_name"),
     ("first_name", "-last_name"),
     ("created",),

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -6,6 +6,11 @@ Pagination on the datastore is *slow*. This is for a couple of reasons:
  - Counting on the datastore is slow; traditional pagination counts the dataset
  - Skipping results on the datastore is slow; if you slice a query, App Engine literally skips the entities up to the lower bound
 
+Djangae provides two pagination tools:
+
+1. `djangae.core.paginator`.  This just provides a `Paginator` class similar to Django's, mostly just for compatability.  It avoids the issue of counting large numbers by not supporting the counting aspects, but it doesn't solve the issue of offsets being slow.
+2. `djangae.contrib.pagination`.  This provides a complete pagination solution for the Datastore.  This article focusses on this.
+
 ## So, what does djangae.contrib.pagination do?
 
 This app provides two things that work together to efficiently paginate datasets on the datastore:
@@ -33,7 +38,7 @@ The query for page 2 can then be
 
 which avoids any slicing at all.  The whole query and offset is based on Datastore indexes, and is efficient.
 
-The `@paginated_model` decorator allows you to specify which fields on your model you want to order
+The `@paginated_model` decorator allows you to specify which field(s) on your model you want to order
 by (you can specify multiple orderings for a model) and generates the pre-calculated fields for you.
 The `DatastorePaginator` then seemlessly uses these pre-calculated fields and does the offset/limiting for you.
 
@@ -71,6 +76,8 @@ or rethink your design.
 Sure!
 
 ```
+from djangae.contrib.pagination import paginated_model
+
 @paginated_model(orderings=[
     ("first_name",),
     ("last_name",),

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -78,9 +78,11 @@ Sure!
 ```
 from djangae.contrib.pagination import paginated_model
 
+# The paginated_model decorator takes a list of orderings, where each ordering is a field name or a list of field names
+
 @paginated_model(orderings=[
-    ("first_name",),
-    ("last_name",),
+    "first_name",
+    "last_name",
     ("first_name", "last_name"),
     ("first_name", "-last_name")
 ])


### PR DESCRIPTION
* Allows `@paginated_model` to accept a single field name as an ordering, as well as a tuple/list of field names.
* Improved documentation.

This will close #303.