### PR TITLE
runserver supports the same commands than dev_appserver.py

### DIFF
--- a/djangae/management/commands/runserver.py
+++ b/djangae/management/commands/runserver.py
@@ -23,24 +23,36 @@ class Command(BaseRunserverCommand):
     """
     # We use this list to prevent user using certain dev_appserver options that
     # might collide with some Django settings.
-    BLACKLISTED_DEV_APPSERVER_OPTIONS = [
-        'port',
-        'host',
-        'threadsafe_override',
-        'php_executable_path',
-        'php_remote_debugging',
-        'python_startup_script',
-        'python_startup_args',
-        'mysql_host',
-        'mysql_port',
-        'mysql_user',
-        'mysql_password',
-        'mysql_socket',
-        'smtp_host',
-        'smtp_user',
-        'smtp_password',
-        'smtp_allow_tls',
-        'automatic_restart',
+    WHITELISTED_DEV_APPSERVER_OPTIONS = [
+        'A',
+        'admin_host',
+        'admin_port',
+        'auth_domain',
+        'storage_path',
+        'log_level',
+        'max_module_instances',
+        'use_mtime_file_watcher',
+        'appidentity_email_address',
+        'appidentity_private_key_path',
+        'blobstore_path',
+        'datastore_path',
+        'clear_datastore',
+        'datastore_consistency_policy',
+        'require_indexes',
+        'auto_id_policy',
+        'logs_path',
+        'show_mail_body',
+        'enable_sendmail',
+        'prospective_search_path',
+        'clear_prospective_search',
+        'search_indexes_path',
+        'clear_search_indexes',
+        'enable_task_running',
+        'allow_skipped_files',
+        'api_port',
+        'dev_appserver_log_level',
+        'skip_sdk_update_check',
+        'default_gcs_bucket_name',
     ]
 
     def __new__(cls, *args, **kwargs):
@@ -50,7 +62,7 @@ class Command(BaseRunserverCommand):
         instance = BaseRunserverCommand.__new__(cls, *args, **kwargs)
         sandbox_options = cls._get_sandbox_options()
         for option in sandbox_options:
-            if not option in self.BLACKLISTED_DEV_APPSERVER_OPTIONS:
+            if option in cls.WHITELISTED_DEV_APPSERVER_OPTIONS:
                 instance.option_list += (
                     make_option('--%s' % option, action='store', dest=option),
                 )

--- a/djangae/management/commands/runserver.py
+++ b/djangae/management/commands/runserver.py
@@ -11,6 +11,26 @@ from google.appengine.tools.sdk_update_checker import (
     _VersionList
 )
 
+# We use this list to prevent user using certain dev_appserver options that
+# might collide with some Django settings.
+BLACKLISTED_DEV_APPSERVER_OPTIONS = [
+    'threadsafe_override',
+    'php_executable_path',
+    'php_remote_debugging',
+    'python_startup_script',
+    'python_startup_args',
+    'mysql_host',
+    'mysql_port',
+    'mysql_user',
+    'mysql_password',
+    'mysql_socket',
+    'smtp_host',
+    'smtp_user',
+    'smtp_password',
+    'smtp_allow_tls',
+    'automatic_restart',
+]
+
 
 class Command(BaseRunserverCommand):
     """
@@ -29,9 +49,10 @@ class Command(BaseRunserverCommand):
         instance = BaseRunserverCommand.__new__(cls, *args, **kwargs)
         sandbox_options = cls._get_sandbox_options()
         for option in sandbox_options:
-            instance.option_list += (
-                make_option('--%s' % option, action='store', dest=option),
-            )
+            if not option in BLACKLISTED_DEV_APPSERVER_OPTIONS:
+                instance.option_list += (
+                    make_option('--%s' % option, action='store', dest=option),
+                )
         return instance
 
     @classmethod

--- a/djangae/management/commands/runserver.py
+++ b/djangae/management/commands/runserver.py
@@ -11,28 +11,6 @@ from google.appengine.tools.sdk_update_checker import (
     _VersionList
 )
 
-# We use this list to prevent user using certain dev_appserver options that
-# might collide with some Django settings.
-BLACKLISTED_DEV_APPSERVER_OPTIONS = [
-    'port',
-    'host',
-    'threadsafe_override',
-    'php_executable_path',
-    'php_remote_debugging',
-    'python_startup_script',
-    'python_startup_args',
-    'mysql_host',
-    'mysql_port',
-    'mysql_user',
-    'mysql_password',
-    'mysql_socket',
-    'smtp_host',
-    'smtp_user',
-    'smtp_password',
-    'smtp_allow_tls',
-    'automatic_restart',
-]
-
 
 class Command(BaseRunserverCommand):
     """
@@ -43,6 +21,27 @@ class Command(BaseRunserverCommand):
     dev_appserver that emulates the live environment your application
     will be deployed to.
     """
+    # We use this list to prevent user using certain dev_appserver options that
+    # might collide with some Django settings.
+    BLACKLISTED_DEV_APPSERVER_OPTIONS = [
+        'port',
+        'host',
+        'threadsafe_override',
+        'php_executable_path',
+        'php_remote_debugging',
+        'python_startup_script',
+        'python_startup_args',
+        'mysql_host',
+        'mysql_port',
+        'mysql_user',
+        'mysql_password',
+        'mysql_socket',
+        'smtp_host',
+        'smtp_user',
+        'smtp_password',
+        'smtp_allow_tls',
+        'automatic_restart',
+    ]
 
     def __new__(cls, *args, **kwargs):
         # We need to dynamically populate the `option_list` attribute
@@ -51,7 +50,7 @@ class Command(BaseRunserverCommand):
         instance = BaseRunserverCommand.__new__(cls, *args, **kwargs)
         sandbox_options = cls._get_sandbox_options()
         for option in sandbox_options:
-            if not option in BLACKLISTED_DEV_APPSERVER_OPTIONS:
+            if not option in self.BLACKLISTED_DEV_APPSERVER_OPTIONS:
                 instance.option_list += (
                     make_option('--%s' % option, action='store', dest=option),
                 )

--- a/djangae/management/commands/runserver.py
+++ b/djangae/management/commands/runserver.py
@@ -14,6 +14,8 @@ from google.appengine.tools.sdk_update_checker import (
 # We use this list to prevent user using certain dev_appserver options that
 # might collide with some Django settings.
 BLACKLISTED_DEV_APPSERVER_OPTIONS = [
+    'port',
+    'host',
     'threadsafe_override',
     'php_executable_path',
     'php_remote_debugging',
@@ -73,7 +75,7 @@ class Command(BaseRunserverCommand):
             if option in sandbox_options and value is not None:
                 self.gae_options[option] = value
 
-        super(Command, self).handle(addrport='', *args, **options)
+        super(Command, self).handle(addrport=addrport, *args, **options)
 
     def run(self, *args, **options):
         self.use_reloader = options.get("use_reloader")


### PR DESCRIPTION
So, the idea here is to "cheat" Django's command's attributes adding the options from the sandbox as new elements in `option_list`.

I'm doing it in the `__new__` method so `option_list` can still be extended if someone wanted to extend the runserver command and add more options to it.

I wanted to add something to the docs, but I'm not sure in what section it would fit?