### PR TITLE
Get-by-key when key is an empty string fails

### DIFF
--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -27,7 +27,7 @@ from google.appengine.api.datastore_types import Blob, Text
 from google.appengine.ext.db import metadata
 from google.appengine.datastore import datastore_stub_util
 from google.appengine.api.datastore import Key
-from google.appengine.api import datastore
+from google.appengine.api import datastore, datastore_errors
 
 #DJANGAE
 from djangae.db.utils import (
@@ -251,7 +251,11 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def prep_lookup_value(self, model, value, field, column=None):
         if field.primary_key and (not column or column == model._meta.pk.column):
-            return self.prep_lookup_key(model, value, field)
+            try:
+                return self.prep_lookup_key(model, value, field)
+            except datastore_errors.BadValueError:
+                # A key couldn't be constructed from this value
+                return None
 
         db_type = field.db_type(self.connection)
 

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -784,7 +784,11 @@ class SelectCommand(object):
                         raise EmptyResultSet()
 
                     if not isinstance(value, datastore.Key):
-                        value = get_datastore_key(self.model, value)
+                        try:
+                            value = get_datastore_key(self.model, value)
+                        except (datastore_errors.BadValueError, datastore_errors.BadArgumentError):
+                            # A key couldn't be constructed from this value, so no such entity can exist
+                            raise EmptyResultSet()
 
                 key = "%s %s" % (column, op)
                 try:

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1132,6 +1132,10 @@ class EdgeCaseTests(TestCase):
         self.assertEqual(2, len(results))
         self.assertItemsEqual(["A", "B"], [x.username for x in results])
 
+        # Test querying for an empty string on primary_key field
+        with self.assertRaises(TestFruit.DoesNotExist):
+            TestFruit.objects.get(name='')
+
     def test_or_queryset(self):
         """
             This constructs an OR query, this is currently broken in the parse_where_and_check_projection

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1132,9 +1132,26 @@ class EdgeCaseTests(TestCase):
         self.assertEqual(2, len(results))
         self.assertItemsEqual(["A", "B"], [x.username for x in results])
 
-        # Test querying for an empty string on primary_key field
+    def test_empty_string_key(self):
+        # Creating
+        with self.assertRaises(IntegrityError):
+            TestFruit.objects.create(name='')
+
+        # Getting
         with self.assertRaises(TestFruit.DoesNotExist):
             TestFruit.objects.get(name='')
+
+        # Filtering
+        results = list(TestFruit.objects.filter(name=''))
+        self.assertItemsEqual([], results)
+
+        # Combined filtering
+        results = list(TestFruit.objects.filter(name='', color='red'))
+        self.assertItemsEqual([], results)
+
+        # IN query
+        results = list(TestFruit.objects.filter(name__in=['', 'apple']))
+        self.assertItemsEqual([self.apple], results)
 
     def test_or_queryset(self):
         """


### PR DESCRIPTION
Test case attached.

Should throw `DoesNotExist` but results in the following stack trace:

```
Traceback (most recent call last):
  File "...djangae/djangae/tests/test_connector.py", line 1137, in test_unusual_queries
    TestFruit.objects.get(name='')
  File "...djangae/testapp/libs/django/db/models/manager.py", line 151, in get
    return self.get_queryset().get(*args, **kwargs)
  File "...djangae/testapp/libs/django/db/models/query.py", line 304, in get
    num = len(clone)
  File "...djangae/testapp/libs/django/db/models/query.py", line 77, in __len__
    self._fetch_all()
  File "...djangae/testapp/libs/django/db/models/query.py", line 857, in _fetch_all
    self._result_cache = list(self.iterator())
  File "...djangae/testapp/libs/django/db/models/query.py", line 220, in iterator
    for row in compiler.results_iter():
  File "...djangae/testapp/libs/django/db/models/sql/compiler.py", line 713, in results_iter
    for rows in self.execute_sql(MULTI):
  File "...djangae/testapp/libs/django/db/models/sql/compiler.py", line 776, in execute_sql
    sql, params = self.as_sql()
  File "...djangae/djangae/db/backends/appengine/compiler.py", line 25, in as_sql
    self.query
  File "...djangae/djangae/db/backends/appengine/commands.py", line 644, in __init__
    self.where, columns, self.excluded_pks = parse_dnf(query.where, self.connection, ordering=self.ordering)
  File "...djangae/djangae/db/backends/appengine/dnf.py", line 209, in parse_dnf
    excluded_pks = set() if should_in_memory_exclude else None
  File "...djangae/djangae/db/backends/appengine/dnf.py", line 266, in parse_tree
    parsed_node, _columns, excluded_pks = parse_tree(child, connection, filtered_columns, excluded_pks, negated)
  File "...djangae/djangae/db/backends/appengine/dnf.py", line 261, in parse_tree
    node, negated, is_pk_filter = process_node(node, connection, negated=negated)
  File "...djangae/djangae/db/backends/appengine/dnf.py", line 149, in process_node
Added a test to demonstrate that get-by-key when key is an empty string fails.
    return ('LIT', parse_constraint(node, connection, negated)), negated, is_pk
  File "...djangae/djangae/db/backends/appengine/commands.py", line 210, in parse_constraint
    value = [ connection.ops.prep_lookup_value(field.model, x, field, column=column) for x in value]
  File "...djangae/djangae/db/backends/appengine/base.py", line 254, in prep_lookup_value
    return self.prep_lookup_key(model, value, field)
  File "...djangae/djangae/db/backends/appengine/base.py", line 231, in prep_lookup_key
    value = get_datastore_key(model, value)
  File "...djangae/djangae/db/utils.py", line 231, in get_datastore_key
    return Key.from_path(kind, pk)
  File "...djangae/testapp/libs/google_appengine/google/appengine/api/datastore_types.py", line 522, in from_path
    ValidateString(id_or_name, 'name')
  File "...djangae/testapp/libs/google_appengine/google/appengine/api/datastore_types.py", line 181, in ValidateString
    raise exception('%s must not be empty.' % name)
BadValueError: name must not be empty.
```

I’ll try and come up with a fix. Feel free to raise a PR against stucox/djangae/get-by-empty-string-pk if you have any ideas!
