### PR TITLE
Getting rid of RemovedInDjango19Warning deprecation warnings

### DIFF
--- a/djangae/contrib/gauth/datastore/management/__init__.py
+++ b/djangae/contrib/gauth/datastore/management/__init__.py
@@ -1,5 +1,4 @@
 from django.db.models import signals
-from django.db.models.loading import UnavailableApp
 
 # Disconnect the django.contrib.auth signal
 from django.contrib.auth.management import create_permissions
@@ -13,7 +12,7 @@ def create_permissions_wrapper(*args, **kwargs):
     try:
         if not issubclass(get_user_model(), PermissionsMixin):
             create_permissions(*args, **kwargs)
-    except UnavailableApp:
+    except LookupError:
         # If the user model doesn't exist, do nothing (this is what Django's create_permissions does)
         return
 

--- a/djangae/contrib/gauth/datastore/permissions.py
+++ b/djangae/contrib/gauth/datastore/permissions.py
@@ -1,4 +1,4 @@
-from django.db.models.loading import get_apps, get_models
+from django.apps import apps
 from django.contrib.auth import get_permission_codename
 
 
@@ -22,15 +22,13 @@ def get_permission_choices():
 
     result = getattr(settings, "MANUAL_PERMISSIONS", [])
 
-    for app in get_apps():
-        for model in get_models(app):
-            for action in AUTO_PERMISSIONS:
-                opts = model._meta
-                result.append((
-                    '%s.%s' % (opts.app_label, get_permission_codename(action, opts)),
-                    'Can %s %s' % (action, opts.verbose_name_raw)
-                ))
+    for model in apps.get_models():
+        for action in AUTO_PERMISSIONS:
+            opts = model._meta
+            result.append((
+                '%s.%s' % (opts.app_label, get_permission_codename(action, opts)),
+                'Can %s %s' % (action, opts.verbose_name_raw)
+            ))
 
     PERMISSIONS_LIST = sorted(result)
     return PERMISSIONS_LIST
-

--- a/djangae/contrib/mappers/readers.py
+++ b/djangae/contrib/mappers/readers.py
@@ -1,7 +1,7 @@
 from mapreduce import input_readers
 import itertools
 import logging
-from django.db.models.loading import cache as model_cache
+from django.apps import apps
 from djangae import utils
 from djangae.storage import UniversalNewLineBlobReader
 
@@ -16,7 +16,7 @@ class DjangoInputReader(input_readers.InputReader):
         self.end_id = end_id
         self.raw_model = model
         app, model = self.raw_model.split('.')
-        self.model = model_cache.get_model(app, model)
+        self.model = apps.get_model(app, model)
         super(DjangoInputReader, self).__init__(*args, **kwargs)
 
 
@@ -59,7 +59,7 @@ class DjangoInputReader(input_readers.InputReader):
         logging.info("Params: %s" % params)
         # Unpickle the query
         app, model = params['model'].split('.')
-        model = model_cache.get_model(app, model)
+        model = apps.get_model(app, model)
 
         # Grab the lowest pk
         query = model.objects.all()

--- a/djangae/contrib/uniquetool/models.py
+++ b/djangae/contrib/uniquetool/models.py
@@ -1,10 +1,10 @@
 import datetime
 import logging
 
+from django.apps import apps
 from django.db import models, connection
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from django.db.models.loading import cache as model_cache
 
 from google.appengine.api import datastore
 from google.appengine.ext import deferred
@@ -42,7 +42,7 @@ def encode_model(model):
     return "%s,%s" % (model._meta.app_label, model._meta.model_name)
 
 def decode_model(model_str):
-    return model_cache.get_model(*model_str.split(','))
+    return apps.get_model(*model_str.split(','))
 
 
 class ActionLog(models.Model):

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -7,12 +7,10 @@ import warnings
 
 #LIBRARIES
 import django
+from django.apps import apps
 from django.conf import settings
 from django.db import models
-try:
-    from django.db.backends.util import format_number
-except ImportError:
-    from django.db.backends.utils import format_number
+from django.db.backends.utils import format_number
 from django.db import IntegrityError
 from django.utils import timezone
 from google.appengine.api import datastore
@@ -46,10 +44,7 @@ def get_model_from_db_table(db_table):
         "include_swapped": True
     }
 
-    if django.VERSION[1] == 6:
-        kwargs["only_installed"] = False
-
-    for model in models.get_models(**kwargs):
+    for model in apps.get_models(**kwargs):
         if model._meta.db_table == db_table:
             return model
 

--- a/djangae/patches/contenttypes.py
+++ b/djangae/patches/contenttypes.py
@@ -5,8 +5,8 @@ from itertools import chain
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import DEFAULT_DB_ALIAS, router, connections
-from django.db.models import get_model, get_models, signals, Manager, get_apps
-from django.db.models.loading import UnavailableApp
+from django.db.models import signals, Manager
+from django.apps import apps
 from django.utils.encoding import smart_text
 from django.utils import six
 from django.utils.six.moves import input
@@ -58,7 +58,7 @@ class SimulatedContentTypeManager(Manager):
         self._update_queries(models)
 
         if not hasattr(self._store, "content_types"):
-            all_models = [ (x._meta.app_label, x._meta.model_name, x) for x in chain(*[ get_models(y) for y in get_apps() ]) ]
+            all_models = [ (x._meta.app_label, x._meta.model_name, x) for x in apps.get_models() ]
 
             self._update_queries([(x[0], x[1]) for x in all_models])
 
@@ -197,8 +197,8 @@ def update_contenttypes(app, created_models, verbosity=2, db=DEFAULT_DB_ALIAS, *
         print("Running Djangae version of update_contenttypes on {}".format(app))
 
     try:
-        get_model('contenttypes', 'ContentType')
-    except UnavailableApp:
+        apps.get_model('contenttypes', 'ContentType')
+    except LookupError:
         return
 
     if hasattr(router, "allow_syncdb"):
@@ -210,7 +210,7 @@ def update_contenttypes(app, created_models, verbosity=2, db=DEFAULT_DB_ALIAS, *
 
 
     ContentType.objects.clear_cache()
-    app_models = get_models(app)
+    app_models = apps.get_models(app)
     if not app_models:
         return
     # They all have the same app_label, get the first one.

--- a/djangae/test_runner.py
+++ b/djangae/test_runner.py
@@ -108,7 +108,7 @@ class DjangaeTestSuiteRunner(DiscoverRunner):
             djangae tests to your app, but you can of course override that.
         """
         from django.conf import settings
-        from django.utils.importlib import import_module
+        from importlib import import_module
 
         ADDITIONAL_APPS = getattr(settings, "DJANGAE_ADDITIONAL_TEST_APPS", ("djangae",))
         extra_tests = []

--- a/djangae/views.py
+++ b/djangae/views.py
@@ -1,10 +1,10 @@
 import os
 import logging
+from importlib import import_module
 
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseServerError
 from django.views.decorators.http import require_POST
-from django.utils.importlib import import_module
 from django.views.decorators.csrf import csrf_exempt
 
 from djangae.utils import on_production


### PR DESCRIPTION
This is branched off query-construction-refactor, to make sure that this PR won't create more failing tests. I tested it locally, and it returns the same numer of broken tests ;) 