### PR TITLE
fix for `!=` queries: groupby requires a sorted list

### DIFF
--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -178,8 +178,11 @@ class QueryByKeys(object):
             return result
 
         self.model = model
+
+        # groupby requires that the iterable is sorted by the given key before grouping
         self.queries = sorted(queries, key=_get_key)
         self.queries_by_key = { a: list(b) for a, b in groupby(self.queries, _get_key) }
+
         self.ordering = ordering
         self._Query__kind = queries[0]._Query__kind
 

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -178,8 +178,8 @@ class QueryByKeys(object):
             return result
 
         self.model = model
-        self.queries = queries
-        self.queries_by_key = { a: list(b) for a, b in groupby(queries, _get_key) }
+        self.queries = sorted(queries, key=_get_key)
+        self.queries_by_key = { a: list(b) for a, b in groupby(self.queries, _get_key) }
         self.ordering = ordering
         self._Query__kind = queries[0]._Query__kind
 


### PR DESCRIPTION
This fixes the bug where `Model.objects.filter(**kwargs)` and `Model.objects.exclude(**kwargs)` are not always disjoint sets.