### PR TITLE
Force user precreation

### DIFF
--- a/djangae/contrib/gauth/common/backends.py
+++ b/djangae/contrib/gauth/common/backends.py
@@ -65,7 +65,7 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
                     user_is_admin = users.is_current_user_admin()
                     if force_pre_creation and not user_is_admin:
                         # Indicate to Django that this user is not allowed
-                        raise TypeError()
+                        return
                     return User.objects.create_user(user_id, email)
 
                 # If the existing user was precreated, update and reuse it

--- a/djangae/contrib/gauth/tests.py
+++ b/djangae/contrib/gauth/tests.py
@@ -94,8 +94,7 @@ class BackendTests(TestCase):
         google_user = users.User('1@example.com', _user_id='111111111100000000001')
         backend = AppEngineUserAPI()
 
-        with self.assertRaises(TypeError):
-            backend.authenticate(google_user=google_user,)
+        self.assertIsNone(backend.authenticate(google_user=google_user,))
         self.assertEqual(User.objects.count(), 0)
 
         # superusers don't need pre-creation of User object.

--- a/docs/gauth.md
+++ b/docs/gauth.md
@@ -61,6 +61,12 @@ When using Google Accounts-based authentication, the `username` field of the use
 
 Djangae allows you to pre-create users by specifying their email address.  First, you need to set `DJANGAE_ALLOW_USER_PRE_CREATION` to `True` in settings, and then you can create user objects which have an email address and a `username` of `None`.  Djangae then recognises these as pre-created users, and will populate the `username` with their Google `user_id` when they first log in.
 
+## Force user Pre-Creation
+
+If you want to prevent creating users for every single Google Account visiting your website, you can allow only pre-created users to be allowed to log in. To enable that you need to set `DJANGAE_FORCE_USER_PRE_CREATION` to `True` in your settings file. 
+
+Note: you don't need to pre-create User for GAE user admins.
+
 ### Username/password authentication
 
 As well as using Djangae's Google Accounts-based authentication, you can also use the standard authentication backend from django.contrib.auth.  They can work alongside each other.  Simply include both, like this:


### PR DESCRIPTION
DJANGAE_FORCE_USER_PRE_CREATION introduced

* if we want to prevent creation of Users every time someone logged with their Google Account hits our app, we can use DJANGAE_FORCE_USER_PRE_CREATION settings. Thanks to that we enforce that only pre-created users are allowed to log in.
* there is one exception: superusers always will have User object created.
* tests & documentation added.