### PR TITLE
Additional transaction tests

### DIFF
--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -8,3 +8,9 @@ class DjangaeConfig(AppConfig):
     def ready(self):
         from .patches.contenttypes import patch
         patch()
+
+        from djangae.db.backends.appengine.caching import reset_context
+        from django.core.signals import request_finished, request_started
+
+        request_finished.connect(reset_context)
+        request_started.connect(reset_context)

--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -12,5 +12,5 @@ class DjangaeConfig(AppConfig):
         from djangae.db.backends.appengine.caching import reset_context
         from django.core.signals import request_finished, request_started
 
-        request_finished.connect(reset_context)
-        request_started.connect(reset_context)
+        request_finished.connect(reset_context, dispatch_uid="request_finished_context_reset")
+        request_started.connect(reset_context, dispatch_uid="request_started_context_reset")

--- a/djangae/db/backends/appengine/caching.py
+++ b/djangae/db/backends/appengine/caching.py
@@ -166,8 +166,6 @@ def get_from_cache(unique_identifier):
     return ret
 
 
-@receiver(request_finished)
-@receiver(request_started)
 def reset_context(keep_disabled_flags=False, *args, **kwargs):
     """
         Called at the beginning and end of each request, resets the thread local

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -7,6 +7,17 @@ from .test_connector import TestUser, TestFruit
 
 
 class TransactionTests(TestCase):
+    def test_repeated_usage_in_a_loop(self):
+        pk = TestUser.objects.create(username="foo").pk
+        for i in xrange(4):
+            with transaction.atomic(xg=True):
+                TestUser.objects.get(pk=pk)
+                continue
+
+        with transaction.atomic(xg=True):
+            TestUser.objects.get(pk=pk)
+
+
     def test_atomic_decorator(self):
 
         @transaction.atomic


### PR DESCRIPTION
It seems that sometimes request_started/finished signals weren't connected properly resulting in strange behaviour across requests.