### PR TITLE
Signature for allow_migrate is different now. 

### DIFF
--- a/djangae/patches/contenttypes.py
+++ b/djangae/patches/contenttypes.py
@@ -201,11 +201,14 @@ def update_contenttypes(app, created_models, verbosity=2, db=DEFAULT_DB_ALIAS, *
     except LookupError:
         return
 
-    if hasattr(router, "allow_syncdb"):
+    if hasattr(router, "allow_syncdb"):  # Django <= 1.6
         if not router.allow_syncdb(db, ContentType):
             return
-    else:
+    elif hasattr(router, "allow_migrate_model"):  # Django >= 1.8
         if not router.allow_migrate_model(db, ContentType):
+            return
+    else:
+        if not router.allow_migrate(db, ContentType):  # Django == 1.7
             return
 
 

--- a/djangae/patches/contenttypes.py
+++ b/djangae/patches/contenttypes.py
@@ -205,7 +205,7 @@ def update_contenttypes(app, created_models, verbosity=2, db=DEFAULT_DB_ALIAS, *
         if not router.allow_syncdb(db, ContentType):
             return
     else:
-        if not router.allow_migrate(db, ContentType):
+        if not router.allow_migrate_model(db, ContentType):
             return
 
 


### PR DESCRIPTION
Default `allow_migrate` is now defined as:

```
def allow_migrate(self, db, app_label, **hints):
```

We should be using `allow_migrate_model` instead. 

Django docs: https://docs.djangoproject.com/en/1.8/topics/db/multi-db/#allow_migrate