### PR TITLE
Fixing edgecase where we would store a bad user object instead of swi…

### DIFF
--- a/djangae/contrib/gauth/common/backends.py
+++ b/djangae/contrib/gauth/common/backends.py
@@ -54,7 +54,7 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
 
         if google_user:
             user_id = google_user.user_id()
-            email = google_user.email().lower()
+            email = BaseUserManager.normalize_email(google_user.email())
             try:
                 return User.objects.get(username=user_id)
             except User.DoesNotExist:


### PR DESCRIPTION
…tching id's

Users with uppercase emails were saved in 2 steps (first a lowercase version in the authentication code, and then a fixed version in our middleware). This caused migrating user id's break on users with uppercase letters.