### PR TITLE
models patch for GCS and custom app domain

### DIFF
--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -9,6 +9,9 @@ class DjangaeConfig(AppConfig):
         from .patches.contenttypes import patch
         patch(sender=self)
 
+        from .patches import models
+        models.patch()
+
         from djangae.db.backends.appengine.caching import reset_context
         from django.core.signals import request_finished, request_started
 

--- a/djangae/patches/models.py
+++ b/djangae/patches/models.py
@@ -1,0 +1,12 @@
+def patch():
+    """
+    Disable creation of foreign key constraints, unsupported from Google Cloud SQL
+    """
+    from django.db.models import get_apps, get_models
+    from django.db.models.fields.related import RelatedField
+
+    for app in get_apps():
+        for model in get_models(app):
+            for field in model._meta.get_fields(include_parents=False):
+                if isinstance(field, RelatedField):
+                    field.db_constraint = False

--- a/djangae/patches/models.py
+++ b/djangae/patches/models.py
@@ -7,6 +7,8 @@ def patch():
 
     for app in get_apps():
         for model in get_models(app):
-            for field in model._meta.get_fields(include_parents=False):
+            fields = model._meta.get_fields(include_parents=False)\
+                if hasattr(model._meta, 'get_fields') else model._meta.fields
+            for field in fields:
                 if isinstance(field, RelatedField):
                     field.db_constraint = False

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -9,6 +9,7 @@ import logging
 import urllib
 import djangae.utils as utils
 from .utils import port_is_open, get_next_available_port
+from django.conf import settings
 
 _SCRIPT_NAME = 'dev_appserver.py'
 
@@ -183,7 +184,12 @@ def _remote(configuration=None, remote_api_stub=None, apiproxy_stub_map=None, **
     else:
         app_id = configuration.app_id
 
-    os.environ['HTTP_HOST'] = '{0}.appspot.com'.format(app_id)
+    server_name = settings.DJANGAE_REMOTE_SERVER_NAME\
+        if hasattr(settings, 'DJANGAE_REMOTE_SERVER_NAME') else '{0}.appspot.com'.format(app_id)
+    server_is_secure = settings.DJANGAE_REMOTE_SERVER_IS_SECURE\
+        if hasattr(settings, 'DJANGAE_REMOTE_SERVER_IS_SECURE') else True
+
+    os.environ['HTTP_HOST'] = server_name
     os.environ['DEFAULT_VERSION_HOSTNAME'] = os.environ['HTTP_HOST']
 
     try:
@@ -208,8 +214,8 @@ def _remote(configuration=None, remote_api_stub=None, apiproxy_stub_map=None, **
             app_id=None,
             path='/_ah/remote_api',
             auth_func=params,
-            servername='{0}.appspot.com'.format(app_id),
-            secure=True,
+            servername=server_name,
+            secure=server_is_secure,
             save_cookies=True,
             rpc_server_factory=factory
         )
@@ -219,8 +225,8 @@ def _remote(configuration=None, remote_api_stub=None, apiproxy_stub_map=None, **
             None,
             '/_ah/remote_api',
             auth_func,
-            servername='{0}.appspot.com'.format(app_id),
-            secure=True,
+            servername=server_name,
+            secure=server_is_secure,
         )
 
     ps1 = getattr(sys, 'ps1', None)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,6 +70,12 @@ It is recommended that for improved security you add `djangae.contrib.security.m
 
 > **It is highly recommended that you read the section on [Unique Constraints](db_backend/#unique-constraint-checking)**
 
+## Configuration
+
+```python DJANGAE_REMOTE_SERVER_NAME ``` Specify the custom domain your app is running on (eg. foo.bar.com). Default to {app_id}.appspost.com
+
+```python DJANGAE_REMOTE_SERVER_IS_SECURE ``` True if you app is running on https. Default to True
+
 ## Deployment
 
 Create a Google App Engine project. 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,6 +30,13 @@ In `app.yaml` add the following handlers:
   script: YOUR_DJANGO_APP.wsgi.application
 ```
 
+If you are planning to use remote management commands, in `app.yaml` add the following handler:
+
+```yml
+* url: /_ah/remote_api(/.*)?
+  script: google.appengine.ext.remote_api.handler.application
+```
+
 Make your `manage.py` look something like this:
 
 ```python


### PR DESCRIPTION
models patch for GCS: prevent creation of foreign key constraints. now you can use syncdb and migrate on remote sandbox

custom app domain: added parameters to specify a custom gc domain (http or https)