### PR TITLE
Namespace support

### DIFF
--- a/djangae/contrib/mappers/pipes.py
+++ b/djangae/contrib/mappers/pipes.py
@@ -133,7 +133,7 @@ class MapReduceTask(object):
             'model': self.get_model_app_(),
             'kwargs': kwargs,
             'args': args,
-            'namespace': settings.DATABASES.get(self.db, {}).get('NAMESPACE', ''),
+            'namespace': settings.DATABASES.get(self.db, {}).get("NAMESPACE"),
         }
         if 'map' not in self.__class__.__dict__:
             raise Exception('No static map method defined on class {cls}'.format(self.__class__))

--- a/djangae/contrib/mappers/pipes.py
+++ b/djangae/contrib/mappers/pipes.py
@@ -18,7 +18,7 @@ class DjangaeMapperPipeline(MapperPipeline):
             this is the cleanest way that still gives us a working Pipeline that we can chain
         """
         if shards is None:
-          shards = parameters.config.SHARD_COUNT
+            shards = parameters.config.SHARD_COUNT
 
         mapreduce_id = control.start_map(
             job_name,

--- a/djangae/contrib/mappers/readers.py
+++ b/djangae/contrib/mappers/readers.py
@@ -15,10 +15,10 @@ class DjangoInputReader(input_readers.InputReader):
         self.start_id = start_id
         self.end_id = end_id
         self.raw_model = model
+        self.db = kwargs.pop('db', 'default')
         app, model = self.raw_model.split('.')
         self.model = apps.get_model(app, model)
         super(DjangoInputReader, self).__init__(*args, **kwargs)
-
 
     def __iter__(self):
         if self.start_id > self.end_id:
@@ -26,7 +26,7 @@ class DjangoInputReader(input_readers.InputReader):
             # the shard size caused each previous shard to process an additional model
             return
 
-        query = self.model.objects
+        query = self.model.objects.using(self.db)
 
         if self.start_id:
             query = query.filter(pk__gt=self.start_id).filter(pk__lte=self.end_id)
@@ -39,7 +39,6 @@ class DjangoInputReader(input_readers.InputReader):
             self.start_id = model.id
             yield model
 
-
     @classmethod
     def validate(cls, mapper_spec):
         if mapper_spec.input_reader_class() != cls:
@@ -49,7 +48,6 @@ class DjangoInputReader(input_readers.InputReader):
             if not param in params:
                 raise input_readers.BadReaderParamsError("Parameter missing: %s" % param)
 
-
     @classmethod
     def split_input(cls, mapper_spec):
         shard_count = mapper_spec.shard_count
@@ -57,12 +55,14 @@ class DjangoInputReader(input_readers.InputReader):
         # Grab the input parameters for the split
         params = input_readers._get_params(mapper_spec)
         logging.info("Params: %s" % params)
+
+        db = params['kwargs']['db']
         # Unpickle the query
         app, model = params['model'].split('.')
         model = apps.get_model(app, model)
 
         # Grab the lowest pk
-        query = model.objects.all()
+        query = model.objects.using(db).all()
         query = query.order_by('pk')
 
         try:
@@ -71,14 +71,14 @@ class DjangoInputReader(input_readers.InputReader):
             query = query.order_by('-pk')
             last_id = query.values_list('pk', flat=True)[:1][0]
         except IndexError:
-            return [DjangoInputReader(0,0, params['model'])]
+            return [DjangoInputReader(0, 0, params['model'], db=db)]
 
         pk_range = last_id - first_id
 
         logging.info("Query range: %s - %s = %s" % (first_id, last_id, pk_range))
 
         if pk_range < shard_count or shard_count == 1:
-            return [DjangoInputReader(first_id-1, last_id, params['model'])]
+            return [DjangoInputReader(first_id-1, last_id, params['model'], db=db)]
 
         readers = []
         max_shard_size = int(float(pk_range) / float(shard_count))
@@ -99,12 +99,11 @@ class DjangoInputReader(input_readers.InputReader):
                 shard_end_id = last_id
 
             logging.info("Creating shard: %s - %s" % (shard_start_id, shard_end_id))
-            reader = DjangoInputReader(shard_start_id, shard_end_id, params['model'])
+            reader = DjangoInputReader(shard_start_id, shard_end_id, params['model'], db=db)
             reader.shard_id = shard_id
             readers.append(reader)
             shard_id += 1
         return readers
-
 
     @classmethod
     def from_json(cls, input_shard_state):
@@ -112,18 +111,19 @@ class DjangoInputReader(input_readers.InputReader):
         end_id = input_shard_state['end']
         shard_id = input_shard_state['shard_id']
         model = input_shard_state['model']
+        db = input_shard_state['db']
 
-        reader = DjangoInputReader(start_id, end_id, model)
+        reader = DjangoInputReader(start_id, end_id, model, db=db)
         reader.shard_id = shard_id
         return reader
-
 
     def to_json(self):
         return {
             'start': self.start_id,
             'end': self.end_id,
             'shard_id': self.shard_id,
-            'model': self.raw_model
+            'model': self.raw_model,
+            'db': self.db,
         }
 
 

--- a/djangae/contrib/uniquetool/models.py
+++ b/djangae/contrib/uniquetool/models.py
@@ -215,7 +215,6 @@ class CleanMapper(RawMapperMixin, MapReduceTask):
         """ The Clean mapper maps over all UniqueMarker instances. """
 
         model = decode_model(model)
-        namespace = connection.settings_dict.get("NAMESPACE", "")
 
         if not entity.key().id_or_name().startswith(model._meta.db_table + "|"):
             # Only include markers which are for this model
@@ -234,7 +233,7 @@ class CleanMapper(RawMapperMixin, MapReduceTask):
             # Get the possible unique markers for the entity, if this one doesn't exist in that list then delete it
             instance = django_instance_to_entity(connection, model, instance._meta.fields, raw=True, instance=instance, check_null=False)
             identifiers = unique_identifiers_from_entity(model, instance, ignore_pk=True)
-            identifier_keys = [datastore.Key.from_path(UniqueMarker.kind(), i, namespace=namespace) for i in identifiers]
+            identifier_keys = [datastore.Key.from_path(UniqueMarker.kind(), i, namespace=entity["instance"].namespace()) for i in identifiers]
             if entity.key() not in identifier_keys:
                 logging.info("Deleting unique marker {} because the it no longer represents the associated instance state".format(entity.key().id_or_name()))
                 datastore.Delete(entity)

--- a/djangae/contrib/uniquetool/models.py
+++ b/djangae/contrib/uniquetool/models.py
@@ -134,7 +134,7 @@ class CheckRepairMapper(MapReduceTask):
         repair = kwargs.get("repair")
 
         alias = kwargs.get("db", "default")
-        namespace = settings.DATABASES.get(alias, {}).get("NAMESPACE", "")
+        namespace = settings.DATABASES.get(alias, {}).get("NAMESPACE")
         assert alias == (instance._state.db or "default")
         entity = django_instance_to_entity(connections[alias], type(instance), instance._meta.fields, raw=True, instance=instance, check_null=False)
         identifiers = unique_identifiers_from_entity(type(instance), entity, ignore_pk=True)
@@ -195,7 +195,7 @@ class RawMapperMixin(object):
             'keys_only': False,
             'kwargs': kwargs,
             'args': args,
-            'namespace': settings.DATABASES.get(self.db, {}).get('NAMESPACE', ''),
+            'namespace': settings.DATABASES.get(self.db, {}).get('NAMESPACE'),
         }
         mapper_parameters['_map'] = self.get_relative_path(self.map)
         pipe = DjangaeMapperPipeline(
@@ -221,7 +221,7 @@ class CleanMapper(RawMapperMixin, MapReduceTask):
         """ The Clean mapper maps over all UniqueMarker instances. """
 
         alias = kwargs.get("db", "default")
-        namespace = settings.DATABASES.get(alias, {}).get("NAMESPACE", "")
+        namespace = settings.DATABASES.get(alias, {}).get("NAMESPACE")
 
         model = decode_model(model)
         if not entity.key().id_or_name().startswith(model._meta.db_table + "|"):

--- a/djangae/contrib/uniquetool/models.py
+++ b/djangae/contrib/uniquetool/models.py
@@ -1,8 +1,9 @@
 import datetime
 import logging
 
+from django.conf import settings
 from django.apps import apps
-from django.db import models, connection
+from django.db import models, connections
 from django.dispatch import receiver
 from django.db.models.signals import post_save
 
@@ -55,6 +56,7 @@ class ActionLog(models.Model):
 class UniqueAction(models.Model):
     action_type = models.CharField(choices=ACTION_TYPES, max_length=100)
     model = models.CharField(max_length=100)
+    db = models.CharField(max_length=100, default='default')
     status = models.CharField(choices=ACTION_STATUSES, default=ACTION_STATUSES[0][0], editable=False, max_length=100)
     logs = RelatedSetField(ActionLog, editable=False)
 
@@ -99,10 +101,10 @@ def start_action(sender, instance, created, raw, **kwargs):
 
     if instance.action_type == "clean":
         kwargs.update(model=instance.model)
-        CleanMapper().start(**kwargs)
+        CleanMapper(db=instance.db).start(**kwargs)
     else:
         kwargs.update(repair=instance.action_type=="repair")
-        CheckRepairMapper(model=decode_model(instance.model)).start(**kwargs)
+        CheckRepairMapper(model=decode_model(instance.model), db=instance.db).start(**kwargs)
 
 
 def _finish(*args, **kwargs):
@@ -131,8 +133,10 @@ class CheckRepairMapper(MapReduceTask):
         action_id = kwargs.get("action_pk")
         repair = kwargs.get("repair")
 
-        namespace = connection.settings_dict.get("NAMESPACE", "")
-        entity = django_instance_to_entity(connection, type(instance), instance._meta.fields, raw=True, instance=instance, check_null=False)
+        alias = kwargs.get("db", "default")
+        namespace = settings.DATABASES.get(alias, {}).get("NAMESPACE", "")
+        assert alias == (instance._state.db or "default")
+        entity = django_instance_to_entity(connections[alias], type(instance), instance._meta.fields, raw=True, instance=instance, check_null=False)
         identifiers = unique_identifiers_from_entity(type(instance), entity, ignore_pk=True)
         identifier_keys = [datastore.Key.from_path(UniqueMarker.kind(), i, namespace=namespace) for i in identifiers]
 
@@ -185,11 +189,13 @@ class RawMapperMixin(object):
         return None
 
     def start(self, *args, **kwargs):
+        kwargs['db'] = self.db
         mapper_parameters = {
             'entity_kind': self.kind,
             'keys_only': False,
             'kwargs': kwargs,
             'args': args,
+            'namespace': settings.DATABASES.get(self.db, {}).get('NAMESPACE', ''),
         }
         mapper_parameters['_map'] = self.get_relative_path(self.map)
         pipe = DjangaeMapperPipeline(
@@ -214,25 +220,28 @@ class CleanMapper(RawMapperMixin, MapReduceTask):
     def map(entity, model, *args, **kwargs):
         """ The Clean mapper maps over all UniqueMarker instances. """
 
-        model = decode_model(model)
+        alias = kwargs.get("db", "default")
+        namespace = settings.DATABASES.get(alias, {}).get("NAMESPACE", "")
 
+        model = decode_model(model)
         if not entity.key().id_or_name().startswith(model._meta.db_table + "|"):
             # Only include markers which are for this model
             return
 
+        assert namespace == entity.namespace()
         with disable_cache():
             # At this point, the entity is a unique marker that is linked to an instance of 'model', now we should see if that instance exists!
             instance_id = entity["instance"].id_or_name()
             try:
-                instance = model.objects.get(pk=instance_id)
+                instance = model.objects.using(alias).get(pk=instance_id)
             except model.DoesNotExist:
                 logging.info("Deleting unique marker {} because the associated instance no longer exists".format(entity.key().id_or_name()))
                 datastore.Delete(entity)
                 return
 
             # Get the possible unique markers for the entity, if this one doesn't exist in that list then delete it
-            instance = django_instance_to_entity(connection, model, instance._meta.fields, raw=True, instance=instance, check_null=False)
-            identifiers = unique_identifiers_from_entity(model, instance, ignore_pk=True)
+            instance_entity = django_instance_to_entity(connections[alias], model, instance._meta.fields, raw=True, instance=instance, check_null=False)
+            identifiers = unique_identifiers_from_entity(model, instance_entity, ignore_pk=True)
             identifier_keys = [datastore.Key.from_path(UniqueMarker.kind(), i, namespace=entity["instance"].namespace()) for i in identifiers]
             if entity.key() not in identifier_keys:
                 logging.info("Deleting unique marker {} because the it no longer represents the associated instance state".format(entity.key().id_or_name()))

--- a/djangae/contrib/uniquetool/tests.py
+++ b/djangae/contrib/uniquetool/tests.py
@@ -1,6 +1,7 @@
 from hashlib import md5
 from django.db import models
 from django.conf import settings
+from unittest import skipIf
 
 from google.appengine.api import datastore, datastore_errors
 
@@ -9,7 +10,7 @@ from djangae.test import TestCase, process_task_queues
 from djangae.db.constraints import UniqueMarker, UniquenessMixin
 
 
-DEFAULT_NAMESPACE = settings.DATABASES["default"].get("NAMESPACE", "")
+DEFAULT_NAMESPACE = settings.DATABASES.get("default", {}).get("NAMESPACE", "")
 
 
 class TestModel(UniquenessMixin, models.Model):
@@ -27,6 +28,13 @@ class MapperTests(TestCase):
         super(MapperTests, self).setUp()
         self.i1 = TestModel.objects.create(name="name1", counter1=1, counter2=1)
         self.i2 = TestModel.objects.create(name="name3", counter1=1, counter2=2)
+        self.i3 = self.i4 = None
+
+    def tearDown(self):
+        if self.i3:
+            self.i3.delete()
+        if self.i4:
+            self.i4.delete()
 
     def test_check_ok(self):
         # A check should produce no errors.
@@ -180,3 +188,63 @@ class MapperTests(TestCase):
 
         self.assertRaises(datastore_errors.EntityNotFoundError, datastore.Get, new_marker.key())
         self.assertTrue(datastore.Get(marker_key))
+
+    @skipIf("ns1" not in settings.DATABASES, "This test is designed for the Djangae testapp settings")
+    def test_clean_removes_markers_with_different_values_on_non_default_namespace(self):
+        self.i3 = TestModel.objects.using("ns1").create(id=self.i1.pk, name="name1", counter1=1, counter2=1)
+        self.i4 = TestModel.objects.using("ns1").create(id=self.i2.pk, name="name3", counter1=1, counter2=2)
+
+        NS1_NAMESPACE = settings.DATABASES["ns1"]["NAMESPACE"]
+
+        marker1 = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i3.name).hexdigest())
+        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=NS1_NAMESPACE)
+        default_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=DEFAULT_NAMESPACE)
+        original_marker = datastore.Get(marker_key)
+        default_marker = datastore.Get(default_key)
+
+        marker2 = "{}|name:{}".format(TestModel._meta.db_table, md5("bananas").hexdigest())
+        new_marker = datastore.Entity(UniqueMarker.kind(), name=marker2, namespace=NS1_NAMESPACE)
+        new_marker.update(original_marker)
+        datastore.Put(new_marker)
+
+        # This allows us to test: 1) namespaced markers will check against their namespace models (not all of them)"
+        self.i1.delete()
+        #... 2) the mapper only cleans the desired namespace
+        datastore.Put(default_marker)
+
+        UniqueAction.objects.create(action_type="clean", model=encode_model(TestModel), db="ns1")
+        process_task_queues()
+
+        self.assertRaises(datastore_errors.EntityNotFoundError, datastore.Get, new_marker.key())
+        self.assertTrue(datastore.Get(default_marker.key()))
+        self.assertTrue(datastore.Get(marker_key))
+        datastore.Delete(default_marker)
+
+    @skipIf("ns1" not in settings.DATABASES, "This test is designed for the Djangae testapp settings")
+    def test_repair_missing_markers_on_non_default_namespace(self):
+        self.i3 = TestModel.objects.using("ns1").create(id=self.i1.pk, name="name1", counter1=1, counter2=1)
+        self.i4 = TestModel.objects.using("ns1").create(id=self.i2.pk, name="name3", counter1=1, counter2=2)
+        NS1_NAMESPACE = settings.DATABASES["ns1"]["NAMESPACE"]
+
+        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk, namespace=DEFAULT_NAMESPACE)
+        instance_key_ns1 = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk, namespace=NS1_NAMESPACE)
+        marker = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i2.name).hexdigest())
+        marker_key_default = datastore.Key.from_path(UniqueMarker.kind(), marker, namespace=DEFAULT_NAMESPACE)
+        marker_key_ns1 = datastore.Key.from_path(UniqueMarker.kind(), marker, namespace=NS1_NAMESPACE)
+        datastore.Delete(marker_key_ns1)
+        datastore.Delete(marker_key_default)
+
+        UniqueAction.objects.create(action_type="repair", model=encode_model(TestModel), db="ns1")
+        process_task_queues()
+
+        a = UniqueAction.objects.get()
+        self.assertEqual(a.status, "done")
+
+        # Is the missing marker for the default namespace left alone?
+        self.assertRaises(datastore_errors.EntityNotFoundError, datastore.Get, marker_key_default)
+        # Is the missing marker restored?
+        marker = datastore.Get(marker_key_ns1)
+        self.assertTrue(marker)
+        self.assertTrue(isinstance(marker["instance"], datastore.Key))
+        self.assertEqual(instance_key_ns1, marker["instance"])
+        self.assertTrue(marker["created"])

--- a/djangae/contrib/uniquetool/tests.py
+++ b/djangae/contrib/uniquetool/tests.py
@@ -10,7 +10,7 @@ from djangae.test import TestCase, process_task_queues
 from djangae.db.constraints import UniqueMarker, UniquenessMixin
 
 
-DEFAULT_NAMESPACE = settings.DATABASES.get("default", {}).get("NAMESPACE", "")
+DEFAULT_NAMESPACE = settings.DATABASES.get("default", {}).get("NAMESPACE")
 
 
 class TestModel(UniquenessMixin, models.Model):

--- a/djangae/contrib/uniquetool/tests.py
+++ b/djangae/contrib/uniquetool/tests.py
@@ -1,13 +1,15 @@
 from hashlib import md5
 from django.db import models
-from django.core.cache import cache
-from google.appengine.api import datastore, datastore_errors
+from django.conf import settings
 
-from djangae.db.caching import disable_cache
+from google.appengine.api import datastore, datastore_errors
 
 from .models import UniqueAction, encode_model
 from djangae.test import TestCase, process_task_queues
 from djangae.db.constraints import UniqueMarker, UniquenessMixin
+
+
+DEFAULT_NAMESPACE = settings.DATABASES["default"].get("NAMESPACE", "")
 
 
 class TestModel(UniquenessMixin, models.Model):
@@ -37,7 +39,7 @@ class MapperTests(TestCase):
 
     def test_check_missing_markers(self):
         marker1 = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i2.name).hexdigest())
-        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1)
+        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=DEFAULT_NAMESPACE)
         datastore.Delete(marker_key)
         UniqueAction.objects.create(action_type="check", model=encode_model(TestModel))
         process_task_queues()
@@ -46,14 +48,14 @@ class MapperTests(TestCase):
         self.assertEqual(a.status, "done")
         self.assertEqual(1, a.actionlog_set.count())
         error = a.actionlog_set.all()[0]
-        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk)
+        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk, namespace=DEFAULT_NAMESPACE)
         self.assertEqual(error.log_type, "missing_marker")
         self.assertEqual(error.instance_key, str(instance_key))
         self.assertEqual(error.marker_key, str(marker_key))
 
     def test_check_missing_instance_attr(self):
         marker1 = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i2.name).hexdigest())
-        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1)
+        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=DEFAULT_NAMESPACE)
         marker = datastore.Get(marker_key)
         marker['instance'] = None
         datastore.Put(marker)
@@ -65,15 +67,15 @@ class MapperTests(TestCase):
         self.assertEqual(a.status, "done")
         self.assertEqual(1, a.actionlog_set.count())
         error = a.actionlog_set.all()[0]
-        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk)
+        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk, namespace=DEFAULT_NAMESPACE)
         self.assertEqual(error.log_type, "missing_instance")
         self.assertEqual(error.instance_key, str(instance_key))
         self.assertEqual(error.marker_key, str(marker_key))
 
     def test_repair_missing_markers(self):
-        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk)
+        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk, namespace=DEFAULT_NAMESPACE)
         marker1 = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i2.name).hexdigest())
-        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1)
+        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=DEFAULT_NAMESPACE)
         datastore.Delete(marker_key)
         UniqueAction.objects.create(action_type="repair", model=encode_model(TestModel))
         process_task_queues()
@@ -89,10 +91,10 @@ class MapperTests(TestCase):
         self.assertTrue(marker["created"])
 
     def test_check_old_style_marker(self):
-        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk)
+        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk, namespace=DEFAULT_NAMESPACE)
 
         marker1 = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i2.name).hexdigest())
-        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1)
+        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=DEFAULT_NAMESPACE)
         marker = datastore.Get(marker_key)
         marker['instance'] = str(instance_key) #Make the instance a string
         datastore.Put(marker)
@@ -110,10 +112,10 @@ class MapperTests(TestCase):
         self.assertEqual(error.marker_key, str(marker_key))
 
     def test_repair_old_style_marker(self):
-        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk)
+        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk, namespace=DEFAULT_NAMESPACE)
 
         marker1 = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i2.name).hexdigest())
-        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1)
+        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=DEFAULT_NAMESPACE)
         marker = datastore.Get(marker_key)
         marker['instance'] = str(instance_key) #Make the instance a string
         datastore.Put(marker)
@@ -129,9 +131,9 @@ class MapperTests(TestCase):
         self.assertEqual(marker['instance'], instance_key)
 
     def test_repair_missing_instance_attr(self):
-        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk)
+        instance_key = datastore.Key.from_path(TestModel._meta.db_table, self.i2.pk, namespace=DEFAULT_NAMESPACE)
         marker1 = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i2.name).hexdigest())
-        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1)
+        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=DEFAULT_NAMESPACE)
         marker = datastore.Get(marker_key)
         marker['instance'] = None
         datastore.Put(marker)
@@ -148,11 +150,11 @@ class MapperTests(TestCase):
 
     def test_clean_after_instance_deleted(self):
         marker1 = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i1.name).hexdigest())
-        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1)
+        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=DEFAULT_NAMESPACE)
 
         self.assertTrue(datastore.Get(marker_key))
 
-        datastore.Delete(datastore.Key.from_path(TestModel._meta.db_table, self.i1.pk)) # Delete the first instance
+        datastore.Delete(datastore.Key.from_path(TestModel._meta.db_table, self.i1.pk, namespace=DEFAULT_NAMESPACE)) # Delete the first instance
 
         self.assertTrue(datastore.Get(marker_key))
 
@@ -163,13 +165,13 @@ class MapperTests(TestCase):
 
     def test_clean_removes_markers_with_different_values(self):
         marker1 = "{}|name:{}".format(TestModel._meta.db_table, md5(self.i1.name).hexdigest())
-        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1)
+        marker_key = datastore.Key.from_path(UniqueMarker.kind(), marker1, namespace=DEFAULT_NAMESPACE)
 
         original_marker = datastore.Get(marker_key)
 
         marker2 = "{}|name:{}".format(TestModel._meta.db_table, md5("bananas").hexdigest())
 
-        new_marker = datastore.Entity(UniqueMarker.kind(), name=marker2)
+        new_marker = datastore.Entity(UniqueMarker.kind(), name=marker2, namespace=DEFAULT_NAMESPACE)
         new_marker.update(original_marker)
         datastore.Put(new_marker)
 

--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -281,8 +281,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return value
 
     def sql_flush(self, style, tables, seqs, allow_cascade=False):
-        with active_namespace(self.connection.settings_dict.get("NAMESPACE")):
-            return [ FlushCommand(table) for table in tables ]
+        return [ FlushCommand(table, self.connection) for table in tables ]
 
     def prep_lookup_key(self, model, value, field):
         if isinstance(value, basestring):

--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -55,7 +55,7 @@ from .commands import (
 )
 
 from djangae.db.backends.appengine import dbapi as Database
-from .compiler import active_namespace
+
 
 class Connection(object):
     """ Dummy connection class """
@@ -86,24 +86,21 @@ class Cursor(object):
         self.last_delete_command = None
 
     def execute(self, sql, *params):
-        namespace = self.connection.ops.connection.settings_dict.get("NAMESPACE")
-
-        with active_namespace(namespace):
-            if isinstance(sql, SelectCommand):
-                # Also catches subclasses of SelectCommand (e.g Update)
-                self.last_select_command = sql
-                self.rowcount = self.last_select_command.execute() or -1
-            elif isinstance(sql, FlushCommand):
-                sql.execute()
-            elif isinstance(sql, UpdateCommand):
-                self.rowcount = sql.execute()
-            elif isinstance(sql, DeleteCommand):
-                self.rowcount = sql.execute()
-            elif isinstance(sql, InsertCommand):
-                self.connection.queries.append(sql)
-                self.returned_ids = sql.execute()
-            else:
-                raise Database.CouldBeSupportedError("Can't execute traditional SQL: '%s' (although perhaps we could make GQL work)", sql)
+        if isinstance(sql, SelectCommand):
+            # Also catches subclasses of SelectCommand (e.g Update)
+            self.last_select_command = sql
+            self.rowcount = self.last_select_command.execute() or -1
+        elif isinstance(sql, FlushCommand):
+            sql.execute()
+        elif isinstance(sql, UpdateCommand):
+            self.rowcount = sql.execute()
+        elif isinstance(sql, DeleteCommand):
+            self.rowcount = sql.execute()
+        elif isinstance(sql, InsertCommand):
+            self.connection.queries.append(sql)
+            self.returned_ids = sql.execute()
+        else:
+            raise Database.CouldBeSupportedError("Can't execute traditional SQL: '%s' (although perhaps we could make GQL work)", sql)
 
     def next(self):
         row = self.fetchone()

--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -87,7 +87,7 @@ class Cursor(object):
         self.last_delete_command = None
 
     def execute(self, sql, *params):
-        namespace = self.connection.ops.connection.settings_dict.get("NAMESPACE", "")
+        namespace = self.connection.ops.connection.settings_dict.get("NAMESPACE")
 
         with active_namespace(namespace):
             if isinstance(sql, SelectCommand):
@@ -281,7 +281,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return value
 
     def sql_flush(self, style, tables, seqs, allow_cascade=False):
-        with active_namespace(self.connection.settings_dict.get("NAMESPACE", "")):
+        with active_namespace(self.connection.settings_dict.get("NAMESPACE")):
             return [ FlushCommand(table) for table in tables ]
 
     def prep_lookup_key(self, model, value, field):
@@ -536,7 +536,7 @@ class DatabaseCreation(BaseDatabaseCreation):
 class DatabaseIntrospection(BaseDatabaseIntrospection):
     @datastore.NonTransactional
     def get_table_list(self, cursor):
-        with active_namespace(self.connection.settings_dict.get("NAMESPACE", "")):
+        with active_namespace(self.connection.settings_dict.get("NAMESPACE")):
             kinds = metadata.get_kinds()
             try:
                 from django.db.backends.base.introspection import TableInfo

--- a/djangae/db/backends/appengine/caching.py
+++ b/djangae/db/backends/appengine/caching.py
@@ -42,30 +42,31 @@ def ensure_context():
     context.stack = context.stack if hasattr(context, "stack") else ContextStack()
 
 
-def _apply_namespace(value_or_map):
-    namespace = namespace_manager.get_namespace()
-
+def _apply_namespace(value_or_map, namespace):
+    """ Add the given namespace to the given cache key(s). """
     if hasattr(value_or_map, "keys"):
-        return { "{}:{}".format(namespace, k):v for k,v in value_or_map.iteritems() }
+        return {"{}:{}".format(namespace, k): v for k, v in value_or_map.iteritems()}
     elif hasattr(value_or_map, "__iter__"):
-        return [ "{}:{}".format(namespace, x) for x in value_or_map ]
+        return ["{}:{}".format(namespace, x) for x in value_or_map]
     else:
         return "{}:{}".format(namespace, value_or_map)
 
+
 def _strip_namespace(value_or_map):
+    """ Remove the namespace part from the given cache key(s). """
     def _strip(value):
-        return value.split(":",1)[-1]
+        return value.split(":", 1)[-1]
 
     if hasattr(value_or_map, "keys"):
-        return { _strip(k):v for k,v in value_or_map.iteritems() }
+        return {_strip(k): v for k, v in value_or_map.iteritems()}
     elif hasattr(value_or_map, "__iter__"):
-        return [ _strip(x) for x in value_or_map ]
+        return [_strip(x) for x in value_or_map]
     else:
         return _strip(value_or_map)
 
 
-def _add_entity_to_memcache(model, mc_key_entity_map):
-    cache.set_many(_apply_namespace(mc_key_entity_map), timeout=CACHE_TIMEOUT_SECONDS)
+def _add_entity_to_memcache(model, mc_key_entity_map, namespace):
+    cache.set_many(_apply_namespace(mc_key_entity_map, namespace), timeout=CACHE_TIMEOUT_SECONDS)
 
 
 def _get_cache_key_and_model_from_datastore_key(key):
@@ -77,43 +78,47 @@ def _get_cache_key_and_model_from_datastore_key(key):
         raise AssertionError("Unable to locate model for db_table '{}' - item won't be evicted from the cache".format(key.kind()))
 
     # We build the cache key for the ID of the instance
-    cache_key =  "|".join([key.kind(), "{}:{}".format(model._meta.pk.column,  _format_value_for_identifier(key.id_or_name()))])
+    cache_key = "|".join(
+        [key.kind(), "{}:{}".format(model._meta.pk.column, _format_value_for_identifier(key.id_or_name()))]
+    )
 
     return (cache_key, model)
 
 
-def _remove_entities_from_memcache_by_key(keys):
+def _remove_entities_from_memcache_by_key(keys, namespace):
     """
+        Given an iterable of datastore.Key objects, remove the corresponding entities from memcache.
         Note, if the key of the entity got evicted from the cache, it's possible that stale cache
         entries would be left behind. Remember if you need pure atomicity then use disable_cache() or a
         transaction.
+        In theory the keys should all have the same namespace as `namespace`.
     """
-
     # Key -> model
     cache_keys = dict(
         _get_cache_key_and_model_from_datastore_key(key) for key in keys
     )
-    entities = _strip_namespace(cache.get_many(_apply_namespace(cache_keys.keys())))
+    entities = _strip_namespace(cache.get_many(_apply_namespace(cache_keys.keys(), namespace)))
 
     if entities:
         identifiers = [
             unique_identifiers_from_entity(cache_keys[key], entity)
             for key, entity in entities.items()
         ]
-        cache.delete_many(_apply_namespace(itertools.chain(*identifiers)))
+        cache.delete_many(_apply_namespace(itertools.chain(*identifiers), namespace))
 
 
-def _get_entity_from_memcache(identifier):
-    return cache.get(_apply_namespace(identifier))
+def _get_entity_from_memcache(cache_key):
+    return cache.get(cache_key)
 
 
 def _get_entity_from_memcache_by_key(key):
     # We build the cache key for the ID of the instance
     cache_key, _ = _get_cache_key_and_model_from_datastore_key(key)
-    return cache.get(_apply_namespace(cache_key))
+    namespace = key.namespace() or None
+    return cache.get(_apply_namespace(cache_key, namespace))
 
 
-def add_entities_to_cache(model, entities, situation, skip_memcache=False):
+def add_entities_to_cache(model, entities, situation, namespace, skip_memcache=False):
     ensure_context()
 
     # Don't cache on Get if we are inside a transaction, even in the context
@@ -124,19 +129,24 @@ def add_entities_to_cache(model, entities, situation, skip_memcache=False):
 
     if situation in (CachingSituation.DATASTORE_PUT, CachingSituation.DATASTORE_GET_PUT) and datastore.IsInTransaction():
         # We have to wipe the entity from memcache
-        _remove_entities_from_memcache_by_key([entity.key() for entity in entities if entity.key()])
+        _remove_entities_from_memcache_by_key([entity.key() for entity in entities if entity.key()], namespace)
 
     identifiers = [
         unique_identifiers_from_entity(model, entity) for entity in entities
     ]
 
     for ent_identifiers, entity in zip(identifiers, entities):
-        get_context().stack.top.cache_entity(_apply_namespace(ent_identifiers), entity, situation)
+        get_context().stack.top.cache_entity(_apply_namespace(ent_identifiers, namespace), entity, situation)
 
     # Only cache in memcache of we are doing a GET (outside a transaction) or PUT (outside a transaction)
     # the exception is GET_PUT - which we do in our own transaction so we have to ignore that!
-    if (not datastore.IsInTransaction() and situation in (CachingSituation.DATASTORE_GET, CachingSituation.DATASTORE_PUT)) or \
-            situation == CachingSituation.DATASTORE_GET_PUT:
+    if (
+        (
+            not datastore.IsInTransaction()
+            and situation in (CachingSituation.DATASTORE_GET, CachingSituation.DATASTORE_PUT)
+        )
+        or situation == CachingSituation.DATASTORE_GET_PUT
+    ):
 
         if not skip_memcache:
 
@@ -145,18 +155,13 @@ def add_entities_to_cache(model, entities, situation, skip_memcache=False):
                 mc_key_entity_map.update({
                     identifier: entity for identifier in ent_identifiers
                 })
-            _add_entity_to_memcache(model, mc_key_entity_map)
+            _add_entity_to_memcache(model, mc_key_entity_map, namespace)
 
 
-def remove_entities_from_cache(entities):
-    keys = [entity.key() for entity in entities if entity.key()]
-    remove_entities_from_cache_by_key(keys)
-
-
-def remove_entities_from_cache_by_key(keys, memcache_only=False):
+def remove_entities_from_cache_by_key(keys, namespace, memcache_only=False):
     """
-        Removes an entity from all caches (both context and memcache)
-        or just memcache if specified
+        Given an iterable of datastore.Keys objects, remove the corresponding entities from caches,
+        both context and memcache, or just memcache if specified.
     """
     ensure_context()
 
@@ -167,12 +172,13 @@ def remove_entities_from_cache_by_key(keys, memcache_only=False):
                 if identifier in _context.stack.top.cache:
                     del _context.stack.top.cache[identifier]
 
-    _remove_entities_from_memcache_by_key(keys)
+    _remove_entities_from_memcache_by_key(keys, namespace)
 
 
 def get_from_cache_by_key(key):
     """
-        Return an entity from the context cache, falling back to memcache when possible
+        Given a datastore.Key (which should already have the namespace applied to it), return an
+        entity from the context cache, falling back to memcache when possible.
     """
 
     ensure_context()
@@ -180,6 +186,7 @@ def get_from_cache_by_key(key):
     if not CACHE_ENABLED:
         return None
 
+    namespace = key.namespace() or None
     ret = None
     if _context.context_enabled:
         # It's safe to hit the context cache, because a new one was pushed on the stack at the start of the transaction
@@ -193,6 +200,7 @@ def get_from_cache_by_key(key):
                         utils.get_model_from_db_table(ret.key().kind()),
                         [ret],
                         CachingSituation.DATASTORE_GET,
+                        namespace,
                         skip_memcache=True # Don't put in memcache, we just got it from there!
                     )
     elif _context.memcache_enabled and not datastore.IsInTransaction():
@@ -201,7 +209,7 @@ def get_from_cache_by_key(key):
     return ret
 
 
-def get_from_cache(unique_identifier):
+def get_from_cache(unique_identifier, namespace):
     """
         Return an entity from the context cache, falling back to memcache when possible
     """
@@ -212,24 +220,26 @@ def get_from_cache(unique_identifier):
     if not CACHE_ENABLED:
         return None
 
+    cache_key = _apply_namespace(unique_identifier, namespace)
     ret = None
     if context.context_enabled:
         # It's safe to hit the context cache, because a new one was pushed on the stack at the start of the transaction
-        ret = context.stack.top.get_entity(_apply_namespace(unique_identifier))
+        ret = context.stack.top.get_entity(cache_key)
         if ret is None and not datastore.IsInTransaction():
             if context.memcache_enabled:
-                ret = _get_entity_from_memcache(unique_identifier)
+                ret = _get_entity_from_memcache(cache_key)
                 if ret:
                     # Add back into the context cache
                     add_entities_to_cache(
                         utils.get_model_from_db_table(ret.key().kind()),
                         [ret],
                         CachingSituation.DATASTORE_GET,
+                        namespace,
                         skip_memcache=True # Don't put in memcache, we just got it from there!
                     )
 
     elif context.memcache_enabled and not datastore.IsInTransaction():
-        ret = _get_entity_from_memcache(unique_identifier)
+        ret = _get_entity_from_memcache(cache_key)
 
     return ret
 

--- a/djangae/db/backends/appengine/caching.py
+++ b/djangae/db/backends/appengine/caching.py
@@ -162,7 +162,8 @@ def remove_entities_from_cache_by_key(keys, memcache_only=False):
 
     if not memcache_only:
         for key in keys:
-            for identifier in _context.stack.top.reverse_cache.get(_apply_namespace(key), []):
+            identifiers = _context.stack.top.reverse_cache.get(key, [])
+            for identifier in identifiers:
                 if identifier in _context.stack.top.cache:
                     del _context.stack.top.cache[identifier]
 
@@ -182,7 +183,7 @@ def get_from_cache_by_key(key):
     ret = None
     if _context.context_enabled:
         # It's safe to hit the context cache, because a new one was pushed on the stack at the start of the transaction
-        ret = _context.stack.top.get_entity_by_key(_apply_namespace(key))
+        ret = _context.stack.top.get_entity_by_key(key)
         if ret is None and not datastore.IsInTransaction():
             if _context.memcache_enabled:
                 ret = _get_entity_from_memcache_by_key(key)

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -803,7 +803,7 @@ class InsertCommand(object):
         self.entities = []
         self.included_keys = []
 
-        namespace = connection.ops.connection.settings_dict.get("NAMESPACE", "")
+        namespace = connection.ops.connection.settings_dict.get("NAMESPACE")
 
         for obj in self.objs:
             if self.has_pk:

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -1046,7 +1046,12 @@ class UpdateCommand(object):
         # fails inside this transaction. Given as we are just using MockInstance so that we can
         # call django_instance_to_entity it on it with the subset of fields we pass in,
         # what we have is fine.
-        instance = MockInstance(**instance_kwargs)
+        meta = self.model._meta
+        instance = MockInstance(
+            _original=MockInstance(_meta=meta, **result),
+            _meta=meta,
+            **instance_kwargs
+        )
 
         # We need to add to the class attribute, rather than replace it!
         original_class = result.get(POLYMODEL_CLASS_ATTRIBUTE, [])

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -803,8 +803,8 @@ class FlushCommand(object):
         while query.Count():
             datastore.Delete(query.Run())
 
-        # TODO: ideally we would only clear the objects for the table that was flushed, but we have
-        # no way of doing that
+        # TODO: ideally we would only clear the cached objects for the table that was flushed, but
+        # we have no way of doing that
         cache.clear()
         clear_context_cache()
 

--- a/djangae/db/backends/appengine/compiler.py
+++ b/djangae/db/backends/appengine/compiler.py
@@ -1,6 +1,5 @@
 #LIBRARIES
 import django
-import contextlib
 
 from django.db.models.sql import compiler
 
@@ -11,17 +10,6 @@ from .commands import (
     UpdateCommand,
     DeleteCommand
 )
-
-@contextlib.contextmanager
-def active_namespace(namespace):
-    from google.appengine.api import namespace_manager
-
-    try:
-        original_namespace = namespace_manager.get_namespace()
-        namespace_manager.set_namespace(namespace)
-        yield
-    finally:
-        namespace_manager.set_namespace(original_namespace)
 
 
 class SQLCompiler(compiler.SQLCompiler):

--- a/djangae/db/backends/appengine/compiler.py
+++ b/djangae/db/backends/appengine/compiler.py
@@ -17,10 +17,11 @@ def active_namespace(namespace):
     from google.appengine.api import namespace_manager
 
     try:
+        original_namespace = namespace_manager.get_namespace()
         namespace_manager.set_namespace(namespace)
         yield
     finally:
-        namespace_manager.set_namespace('')
+        namespace_manager.set_namespace(original_namespace)
 
 
 class SQLCompiler(compiler.SQLCompiler):

--- a/djangae/db/backends/appengine/context.py
+++ b/djangae/db/backends/appengine/context.py
@@ -119,9 +119,14 @@ class ContextStack(object):
         if apply_staged:
             while self.staged:
                 to_apply = self.staged.pop()
-                caching.remove_entities_from_cache_by_key(
-                    to_apply.reverse_cache.keys(), memcache_only=True
-                )
+                keys = to_apply.reverse_cache.keys()
+                if keys:
+                    # This assumes that all keys are in the same namespace, which is almost definitely
+                    # going to be the case, but it feels a bit dirty
+                    namespace = keys[0].namespace() or None
+                    caching.remove_entities_from_cache_by_key(
+                        keys, namespace=namespace, memcache_only=True
+                    )
 
                 self.top.apply(to_apply)
 

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -100,7 +100,7 @@ class WhereNode(object):
     def append_child(self, node):
         self.children.append(node)
 
-    def set_leaf(self, column, operator, value, is_pk_field, negated, target_field=None):
+    def set_leaf(self, column, operator, value, is_pk_field, negated, namespace, target_field=None):
         assert column
         assert operator
         assert isinstance(is_pk_field, bool)
@@ -122,7 +122,7 @@ class WhereNode(object):
 
             if isinstance(value, (list, tuple)):
                 value = [
-                    datastore.Key.from_path(table, x)
+                    datastore.Key.from_path(table, x, namespace=namespace)
                     for x in value if x
                 ]
             else:
@@ -141,7 +141,7 @@ class WhereNode(object):
                     value = datastore.Key.from_path('', 1)
                     operator = '<'
                 else:
-                    value = datastore.Key.from_path(table, value)
+                    value = datastore.Key.from_path(table, value, namespace=namespace)
             column = "__key__"
 
         # Do any special index conversions necessary to perform this lookup
@@ -957,6 +957,7 @@ def _django_17_query_walk_leaf(node, negated, new_parent, connection, model):
         rhs,
         is_pk_field=field==model._meta.pk,
         negated=negated,
+        namespace=connection.ops.connection.settings_dict.get("NAMESPACE"),
         target_field=node.lhs.target,
     )
 

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -6,6 +6,7 @@ from django.core.exceptions import NON_FIELD_ERRORS
 from google.appengine.ext import db
 from google.appengine.api.datastore import Key, Delete
 from google.appengine.datastore.datastore_rpc import TransactionOptions
+from google.appengine.api import namespace_manager
 
 from .unique_utils import unique_identifiers_from_entity
 from .utils import key_exists
@@ -56,7 +57,7 @@ class UniqueMarker(db.Model):
 def acquire_identifiers(identifiers, entity_key):
     @db.transactional(propagation=TransactionOptions.INDEPENDENT, xg=True)
     def acquire_marker(identifier):
-        identifier_key = Key.from_path(UniqueMarker.kind(), identifier)
+        identifier_key = Key.from_path(UniqueMarker.kind(), identifier, namespace=namespace_manager.get_namespace())
 
         marker = UniqueMarker.get(identifier_key)
         if marker:
@@ -159,7 +160,7 @@ def release_identifiers(identifiers):
 
     @db.non_transactional
     def delete():
-        keys = [Key.from_path(UniqueMarker.kind(), x) for x in identifiers]
+        keys = [Key.from_path(UniqueMarker.kind(), x, namespace=namespace_manager.get_namespace()) for x in identifiers]
         Delete(keys)
 
     delete()

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -6,7 +6,6 @@ from django.core.exceptions import NON_FIELD_ERRORS
 from google.appengine.ext import db
 from google.appengine.api.datastore import Key, Delete
 from google.appengine.datastore.datastore_rpc import TransactionOptions
-from google.appengine.api import namespace_manager
 
 from .unique_utils import unique_identifiers_from_entity
 from .utils import key_exists
@@ -57,7 +56,9 @@ class UniqueMarker(db.Model):
 def acquire_identifiers(identifiers, entity_key):
     @db.transactional(propagation=TransactionOptions.INDEPENDENT, xg=True)
     def acquire_marker(identifier):
-        identifier_key = Key.from_path(UniqueMarker.kind(), identifier, namespace=namespace_manager.get_namespace())
+        # Key.from_path expects None for an empty namespace, but Key.namespace() returns ''
+        namespace = entity_key.namespace() or None
+        identifier_key = Key.from_path(UniqueMarker.kind(), identifier, namespace=namespace)
 
         marker = UniqueMarker.get(identifier_key)
         if marker:
@@ -156,11 +157,11 @@ def release_markers(markers):
     [delete(x) for x in markers]
 
 
-def release_identifiers(identifiers):
+def release_identifiers(identifiers, namespace):
 
     @db.non_transactional
     def delete():
-        keys = [Key.from_path(UniqueMarker.kind(), x, namespace=namespace_manager.get_namespace()) for x in identifiers]
+        keys = [Key.from_path(UniqueMarker.kind(), x, namespace=namespace) for x in identifiers]
         Delete(keys)
 
     delete()
@@ -169,7 +170,9 @@ def release_identifiers(identifiers):
 
 def release(model, entity):
     identifiers = unique_identifiers_from_entity(model, entity, ignore_pk=True)
-    release_identifiers(identifiers)
+    # Key.from_path expects None for an empty namespace, but Key.namespace() returns ''
+    namespace = entity.key().namespace() or None
+    release_identifiers(identifiers, namespace=namespace)
 
 
 class UniquenessMixin(object):

--- a/djangae/db/unique_utils.py
+++ b/djangae/db/unique_utils.py
@@ -23,7 +23,7 @@ def _format_value_for_identifier(value):
 
 def unique_identifiers_from_entity(model, entity, ignore_pk=False, ignore_null_values=True):
     """
-        Given an instance, this function returns a list of identifiers that represent
+        Given an instance, this function returns a list of identifier strings that represent
         unique field/value combinations.
     """
     from djangae.db.utils import get_top_concrete_parent

--- a/djangae/db/unique_utils.py
+++ b/djangae/db/unique_utils.py
@@ -26,6 +26,8 @@ def unique_identifiers_from_entity(model, entity, ignore_pk=False, ignore_null_v
         Given an instance, this function returns a list of identifiers that represent
         unique field/value combinations.
     """
+    from djangae.db.utils import get_top_concrete_parent
+
     unique_combinations = _unique_combinations(model, ignore_pk)
 
     meta = model._meta
@@ -64,7 +66,7 @@ def unique_identifiers_from_entity(model, entity, ignore_pk=False, ignore_null_v
 
         if include_combination:
             for ident in combo_identifiers:
-                identifiers.append(model._meta.db_table + "|" + "|".join(ident))
+                identifiers.append(get_top_concrete_parent(model)._meta.db_table + "|" + "|".join(ident))
 
     return identifiers
 

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -230,7 +230,7 @@ def django_instance_to_entity(connection, model, fields, raw, instance, check_nu
         else:
             raise ValueError("Invalid primary key value")
 
-    namespace = connection.settings_dict.get("NAMESPACE", "")
+    namespace = connection.settings_dict.get("NAMESPACE")
     entity = datastore.Entity(db_table, namespace=namespace, **kwargs)
     entity.update(field_values)
 

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -277,7 +277,7 @@ class MockInstance(object):
 
 
 def key_exists(key):
-    qry = Query(keys_only=True)
+    qry = Query(keys_only=True, namespace=key.namespace())
     qry.Ancestor(key)
     return qry.Count(limit=1) > 0
 

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -240,12 +240,12 @@ def django_instance_to_entity(connection, model, fields, raw, instance, check_nu
     return entity
 
 
-def get_datastore_key(model, pk):
+def get_datastore_key(model, pk, namespace):
     """ Return a datastore.Key for the given model and primary key.
     """
 
     kind = get_top_concrete_parent(model)._meta.db_table
-    return Key.from_path(kind, pk)
+    return Key.from_path(kind, pk, namespace=namespace)
 
 
 class MockInstance(object):

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -230,7 +230,8 @@ def django_instance_to_entity(connection, model, fields, raw, instance, check_nu
         else:
             raise ValueError("Invalid primary key value")
 
-    entity = datastore.Entity(db_table, **kwargs)
+    namespace = connection.settings_dict.get("NAMESPACE", "")
+    entity = datastore.Entity(db_table, namespace=namespace, **kwargs)
     entity.update(field_values)
 
     classes = get_concrete_db_tables(model)

--- a/djangae/tests/test_caching.py
+++ b/djangae/tests/test_caching.py
@@ -18,7 +18,7 @@ from djangae.db.caching import disable_cache, clear_context_cache
 from djangae.db.backends.appengine.compiler import active_namespace
 
 
-DEFAULT_NAMESPACE = settings.DATABASES["default"].get("NAMESPACE", "")
+DEFAULT_NAMESPACE = settings.DATABASES["default"].get("NAMESPACE")
 
 
 class FakeEntity(dict):

--- a/djangae/tests/test_caching.py
+++ b/djangae/tests/test_caching.py
@@ -15,7 +15,7 @@ from djangae.db import unique_utils
 from djangae.db import transaction
 from djangae.db.backends.appengine.context import ContextStack
 from djangae.db.backends.appengine import caching
-from djangae.db.caching import disable_cache, clear_context_cache
+from djangae.db.caching import disable_cache, clear_context_cache, _apply_namespace
 
 
 class FakeEntity(dict):
@@ -205,7 +205,12 @@ class MemcacheCachingTests(TestCase):
         entity_data = {
             "field1": "old",
         }
-        identifiers = unique_utils.unique_identifiers_from_entity(CachingTestModel, FakeEntity(entity_data, id=222))
+
+        identifiers = _apply_namespace(
+            unique_utils.unique_identifiers_from_entity(
+                CachingTestModel, FakeEntity(entity_data, id=222)
+            )
+        )
 
         for identifier in identifiers:
             self.assertIsNone(cache.get(identifier))

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -43,7 +43,7 @@ from djangae.core import paginator
 from djangae.db.backends.appengine.compiler import active_namespace
 
 
-DEFAULT_NAMESPACE = settings.DATABASES["default"].get("NAMESPACE", "")
+DEFAULT_NAMESPACE = settings.DATABASES["default"].get("NAMESPACE")
 
 
 try:

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1661,7 +1661,14 @@ class NamespaceTests(TestCase):
         self.assertEqual(0, TestFruit.objects.using("ns1").filter(name="Orange", color="Orange").count())
 
     def test_no_database_namespace_defaults_to_empty(self):
-        pass
+        """
+            Test that creating an object without a namespace makes one that is
+            retrievable with just a kind and ID
+        """
+
+        TestFruit.objects.create(name="Apple", color="Red")
+        key = datastore.Key.from_path(TestFruit._meta.db_table, "Apple")
+        self.assertTrue(datastore.Get([key])[0])
 
 
 def deferred_func():

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -9,6 +9,7 @@ from hashlib import md5
 from unittest import skipIf
 
 # LIBRARIES
+import django
 from django.conf import settings
 from django.core.files.uploadhandler import StopFutureHandlers
 from django.core.cache import cache
@@ -684,7 +685,7 @@ class BackendTests(TestCase):
         self.assertEqual(durations_as_3.duration_field, td3)
         self.assertEqual(durations_as_3.duration_field_nullable, td3)
         # And just for good measure, check the raw value in the datastore
-        key = datastore.Key.from_path(DurationModel._meta.db_table, durations_as_3.pk)
+        key = datastore.Key.from_path(DurationModel._meta.db_table, durations_as_3.pk, namespace=DEFAULT_NAMESPACE)
         entity = datastore.Get(key)
         self.assertTrue(isinstance(entity['duration_field'], (int, long)))
 

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -775,7 +775,9 @@ class ConstraintTests(TestCase):
 
         from djangae.db.backends.appengine.commands import FlushCommand
 
-        FlushCommand(ModelWithUniques._meta.db_table).execute()
+        with active_namespace(DEFAULT_NAMESPACE):
+            FlushCommand(ModelWithUniques._meta.db_table).execute()
+
         ModelWithUniques.objects.create(name="One")
 
         with self.assertRaises(IntegrityError):
@@ -901,12 +903,13 @@ class ConstraintTests(TestCase):
         self.assertEqual(0, datastore.Query(UniqueMarker.kind()).Count() - initial_count)
 
     def test_delete_clears_markers(self):
-        initial_count = datastore.Query(UniqueMarker.kind()).Count()
+        with active_namespace(DEFAULT_NAMESPACE):
+            initial_count = datastore.Query(UniqueMarker.kind()).Count()
 
-        instance = ModelWithUniques.objects.create(name="One")
-        self.assertEqual(1, datastore.Query(UniqueMarker.kind()).Count() - initial_count)
-        instance.delete()
-        self.assertEqual(0, datastore.Query(UniqueMarker.kind()).Count() - initial_count)
+            instance = ModelWithUniques.objects.create(name="One")
+            self.assertEqual(1, datastore.Query(UniqueMarker.kind()).Count() - initial_count)
+            instance.delete()
+            self.assertEqual(0, datastore.Query(UniqueMarker.kind()).Count() - initial_count)
 
     @override_settings(DJANGAE_DISABLE_CONSTRAINT_CHECKS=True)
     def test_constraints_disabled_doesnt_create_or_check_markers(self):

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1697,7 +1697,7 @@ class NamespaceTests(TestCase):
             retrievable with just a kind and ID
         """
 
-        TestFruit.objects.create(name="Apple", color="Red")
+        TestFruit.objects.using("nonamespace").create(name="Apple", color="Red")
         key = datastore.Key.from_path(TestFruit._meta.db_table, "Apple")
         self.assertTrue(datastore.Get([key])[0])
 

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1670,6 +1670,7 @@ class TestSpecialIndexers(TestCase):
 
 
 class NamespaceTests(TestCase):
+    multi_db = True
 
     @skipIf("ns1" not in settings.DATABASES, "This test is designed for the Djangae testapp settings")
     def test_database_specific_namespaces(self):

--- a/djangae/tests/test_query_transform.py
+++ b/djangae/tests/test_query_transform.py
@@ -1,10 +1,16 @@
+# LIBRARIES
+from django.db import models, connections, connection as default_connection
 from django.db.models.sql.datastructures import EmptyResultSet
-from django.db import models, connections
-from djangae.test import TestCase
-from djangae.db.backends.appengine.query import transform_query, Query, WhereNode
 from django.db.models.query import Q
-
 from google.appengine.api import datastore
+
+# DJANGAE
+from djangae.db.backends.appengine.query import transform_query, Query, WhereNode
+from djangae.test import TestCase
+
+
+DEFAULT_NAMESPACE = default_connection.ops.connection.settings_dict.get("NAMESPACE")
+
 
 class TransformTestModel(models.Model):
     field1 = models.CharField(max_length=255)
@@ -438,9 +444,9 @@ class QueryNormalizationTests(TestCase):
         self.assertEqual("__key__", query.where.children[1].column)
         self.assertEqual("__key__", query.where.children[2].column)
         self.assertEqual({
-                datastore.Key.from_path(TestUser._meta.db_table, 1),
-                datastore.Key.from_path(TestUser._meta.db_table, 2),
-                datastore.Key.from_path(TestUser._meta.db_table, 3),
+                datastore.Key.from_path(TestUser._meta.db_table, 1, namespace=DEFAULT_NAMESPACE),
+                datastore.Key.from_path(TestUser._meta.db_table, 2, namespace=DEFAULT_NAMESPACE),
+                datastore.Key.from_path(TestUser._meta.db_table, 3, namespace=DEFAULT_NAMESPACE),
             }, {
                 query.where.children[0].value,
                 query.where.children[1].value,
@@ -465,9 +471,9 @@ class QueryNormalizationTests(TestCase):
         self.assertEqual("test", query.where.children[0].children[1].value)
 
         self.assertEqual({
-                datastore.Key.from_path(TestUser._meta.db_table, 1),
-                datastore.Key.from_path(TestUser._meta.db_table, 2),
-                datastore.Key.from_path(TestUser._meta.db_table, 3),
+                datastore.Key.from_path(TestUser._meta.db_table, 1, namespace=DEFAULT_NAMESPACE),
+                datastore.Key.from_path(TestUser._meta.db_table, 2, namespace=DEFAULT_NAMESPACE),
+                datastore.Key.from_path(TestUser._meta.db_table, 3, namespace=DEFAULT_NAMESPACE),
             }, {
                 query.where.children[0].children[0].value,
                 query.where.children[1].children[0].value,

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -214,7 +214,6 @@ multiple database support. To configure multiple datastore namespaces, you can a
 DATABASES = {
     'default': {
         'ENGINE': 'djangae.db.backends.appengine'
-        'NAMESPACE': 'default'
     },
     'archive': {
         'ENGINE': 'djangae.db.backends.appengine'
@@ -222,6 +221,8 @@ DATABASES = {
     }
 }
 ```
+
+If you do not specify a `NAMESPACE` for a connection, then the Datastore's default namespace will be used (i.e. no namespace).
 
 You can make use of Django's routers, the `using()` method, and the `save(using='...')` in the same way as normal multi-database support.
 

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -203,6 +203,31 @@ The following functions are available to manage transactions:
  - `djangae.db.transaction.in_atomic_block` - Returns True if inside a transaction, False otherwise
 
 
+## Multiple Namespaces (Experimental)
+
+**Namespace support is new and experimental, please make sure your code is well tested and report any bugs**
+
+It's possible to create separate "databases" on the datastore via "namespaces". This is supported in Djangae through the normal Django
+multiple database support. To configure multiple datastore namespaces, you can add an optional "NAMESPACE" to the DATABASES setting:
+
+```
+DATABASES = {
+    'default': {
+        'ENGINE': 'djangae.db.backends.appengine'
+        'NAMESPACE': 'default'
+    },
+    'archive': {
+        'ENGINE': 'djangae.db.backends.appengine'
+        'NAMESPACE': 'archive'
+    }
+}
+```
+
+You can make use of Django's routers, the `using()` method, and the `save(using='...')` in the same way as normal multi-database support.
+
+Cross-namespace foreign keys aren't supported. Also namespaces effect caching keys and unique markers (which are also restricted to a namespace).
+
+
 ## Migrations
 
 The App Engine Datastore is a schemaless database, so the idea of migrations in the normal Django sense doesn't really apply in the same way.
@@ -217,3 +242,4 @@ However, there are some behaviours of the Datastore which mean that in some case
 * If you remove a model field, the underlying Datastore entities will still contain the value until they are re-saved.  When you re-save each instance of the model the underlying entity will be overwritten, wiping out the removed field, but if you want to immediately destroy some sensitive data or reduce your used storage quota then simplying removing the field from the model will have no effect.
 
 For these reasons there is a legitimate case for implementing some kind of variant of the Django migration system for Datastore-backed models.  See the [migrations ticket on GitHub](https://github.com/potatolondon/djangae/issues/438) for more info.
+

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -118,7 +118,12 @@ WSGI_APPLICATION = 'testapp.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'djangae.db.backends.appengine'
+        'ENGINE': 'djangae.db.backends.appengine',
+        'NAMESPACE': 'bananas'
+    },
+    "ns1": {
+        'ENGINE': 'djangae.db.backends.appengine',
+        'NAMESPACE': 'ns1',
     }
 }
 

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -119,11 +119,15 @@ WSGI_APPLICATION = 'testapp.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'djangae.db.backends.appengine',
+        'NAMESPACE': 'customdefaultnamespace',
     },
     "ns1": {
         'ENGINE': 'djangae.db.backends.appengine',
         'NAMESPACE': 'ns1namespace',
-    }
+    },
+    "nonamespace": {
+        'ENGINE': 'djangae.db.backends.appengine',
+    },
 }
 
 # Internationalization

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -119,7 +119,6 @@ WSGI_APPLICATION = 'testapp.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'djangae.db.backends.appengine',
-        'NAMESPACE': 'bananas'
     },
     "ns1": {
         'ENGINE': 'djangae.db.backends.appengine',

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -122,7 +122,7 @@ DATABASES = {
     },
     "ns1": {
         'ENGINE': 'djangae.db.backends.appengine',
-        'NAMESPACE': 'ns1',
+        'NAMESPACE': 'ns1namespace',
     }
 }
 


### PR DESCRIPTION
This PR adds multiple datastore connections using namespaces. Note that like Django databases, cross-namespace foreign keys are not support.

This introduces a slight backwards incompatibility in the cache key naming (all cache keys now start with a namespace and a ":", if there is no namespace the cache key starts with a ":") so if you deploy to an existing version you will need to flush the cache.