### PR TITLE
Validate fields when inserting

### DIFF
--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -793,6 +793,15 @@ class InsertCommand(object):
                 # We zip() self.entities and self.included_keys in execute(), so they should be the same length
                 self.included_keys.append(None)
 
+            # We don't use the values returned, but this does make sure we're
+            # doing the same validation as Django. See issue #493 for an
+            # example of how not doing this can mess things up
+            for field in fields:
+                field.get_db_prep_save(
+                    getattr(obj, field.attname) if raw else field.pre_save(obj, True),
+                    connection=connection,
+                )
+
             self.entities.append(
                 django_instance_to_entity(connection, model, fields, raw, obj)
             )

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1239,6 +1239,13 @@ class EdgeCaseTests(TestCase):
             perms = list(Permission.objects.all().values_list("user__username", "perm"))
             self.assertEqual("A", perms[0][0])
 
+    def test_invalid_id_value_on_insert(self):
+        user = TestUser.objects.get(username="A")
+        # pass in a User object as if it's an int
+        permission = Permission(user_id=user, perm="test_perm")
+        with self.assertRaises(TypeError):
+            permission.save(force_insert=True)
+
     def test_values_list_on_pk_does_keys_only_query(self):
         from google.appengine.api.datastore import Query
 


### PR DESCRIPTION
Djangae should raise an error if it's given a stupid value for a field when creating (as Django does).

Fixes #493 