### PR TITLE
Updated runserver command to use check(..) instead of validate(..).

### DIFF
--- a/djangae/management/commands/runserver.py
+++ b/djangae/management/commands/runserver.py
@@ -116,7 +116,7 @@ class Command(BaseRunserverCommand):
             sys.exit(1)
 
         self.stdout.write("Validating models...\n\n")
-        self.validate(display_num_errors=True)
+        self.check(display_num_errors=True)
         self.stdout.write((
             "%(started_at)s\n"
             "Django version %(version)s, using settings %(settings)r\n"


### PR DESCRIPTION
validate(..) was deprecated in Django 1.7, and has been removed in 1.9.
This change is incompatible with Django 1.6.