### PR TITLE
User pre-creation from Django admin

### DIFF
--- a/djangae/contrib/gauth/datastore/admin.py
+++ b/djangae/contrib/gauth/datastore/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django import forms
 
 # DJANGAE
 from djangae.contrib.gauth.datastore.models import (
@@ -6,5 +7,20 @@ from djangae.contrib.gauth.datastore.models import (
     Group
 )
 
-admin.site.register(GaeDatastoreUser)
+class UserAdminForm(forms.ModelForm):
+    username = forms.CharField(required=False)
+
+    def clean_username(self):
+        return self.cleaned_data['username'] or None
+
+@admin.register(GaeDatastoreUser)
+class UserAdmin(admin.ModelAdmin):
+    exclude = ('password',)
+    form = UserAdminForm
+
+    def save_model(self, request, user, form, change):
+        if not user.password:
+            user.set_password(None)
+        user.save()
+
 admin.site.register(Group)

--- a/djangae/contrib/gauth/datastore/admin.py
+++ b/djangae/contrib/gauth/datastore/admin.py
@@ -21,6 +21,6 @@ class UserAdmin(admin.ModelAdmin):
     def save_model(self, request, user, form, change):
         if not user.password:
             user.set_password(None)
-        user.save()
+            user.save()
 
 admin.site.register(Group)


### PR DESCRIPTION
Hide password field and make username optional.

See #522. This partially fixes #97.