### PR TITLE
Fix __year index lookup

### DIFF
--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -150,9 +150,6 @@ class WhereNode(object):
             indexer = REQUIRES_SPECIAL_INDEXES[operator]
             index_type = indexer.prepare_index_type(operator, value)
             value = indexer.prep_value_for_query(value)
-            if not indexer.validate_can_be_indexed(value, negated):
-                raise NotSupportedError("Unsupported special index or value '%s %s'" % (column, operator))
-
             column = indexer.indexed_column_name(column, value, index_type)
             operator = indexer.prep_query_operator(operator)
 

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1320,6 +1320,14 @@ class EdgeCaseTests(TestCase):
         user = TestUser.objects.get(id__iexact=str(self.u1.id))
         self.assertEqual("A", user.username)
 
+    def test_year(self):
+        user = TestUser.objects.create(username="Z", email="z@example.com")
+        user.last_login = datetime.datetime(2000,1,1,0,0,0)
+        user.save()
+
+        self.assertEqual(len(TestUser.objects.filter(last_login__year=3000)), 0)
+        self.assertEqual(TestUser.objects.filter(last_login__year=2000).first().pk, user.pk)
+
     def test_ordering(self):
         users = TestUser.objects.all().order_by("username")
 

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -423,11 +423,9 @@ class BackendTests(TestCase):
             list(TestUser.objects.filter(pk=1))
             self.assertEqual(1, get_mock.call_count)
 
-        #FIXME: Issue #80
-        with self.assertRaises(NotSupportedError):
-            with sleuth.switch("djangae.db.backends.appengine.commands.datastore.MultiQuery.Run", lambda *args, **kwargs: []) as query_mock:
-                list(TestUser.objects.exclude(username__startswith="test"))
-                self.assertEqual(1, query_mock.call_count)
+        with sleuth.switch("djangae.db.backends.appengine.commands.datastore.MultiQuery.Run", lambda *args, **kwargs: []) as query_mock:
+            list(TestUser.objects.exclude(username__startswith="test"))
+            self.assertEqual(1, query_mock.call_count)
 
         with sleuth.switch("djangae.db.backends.appengine.commands.datastore.Get", lambda *args, **kwargs: []) as get_mock:
             list(TestUser.objects.filter(pk__in=[1, 2, 3, 4, 5, 6, 7, 8]).

--- a/testapp/djangaeidx.yaml
+++ b/testapp/djangaeidx.yaml
@@ -25,6 +25,7 @@ djangae_testfruit:
   color: [icontains, contains, iexact, iendswith, endswith, istartswith, startswith]
 djangae_testuser:
   username: [iexact, contains, startswith]
+  last_login: [year]
 djangae_user:
   username: [iexact]
 lookup_article:


### PR DESCRIPTION
So this pull request is fixing the __year lookup, that was throwing UnSupportedError for a while, and that bug was hidden by our setup to automatically skip Django tests that throw UnSupportedError.

We incorrectly validated query value [here](https://github.com/potatolondon/djangae/commit/632113d03ccd34c05116723fe4f141677f37c725#diff-5f1fd58426c71048b283812e6198689eR122). The value in this case was an integer (year), and `validate_can_be_indexed` method checks for datetime (that's a correct check, but for **indexing**, not lookup). 

I also added a test for `__year`, and fixed another failing test that was hidden because of that bug.