### PR TITLE
Only quote the bucket and filename for a Cloud Storage URL

### DIFF
--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -241,9 +241,8 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
         self.write_options['x-goog-acl'] = google_acl
 
     def url(self, filename):
-        return urllib.quote(
-            '{0}{1}'.format(self.api_url, self._add_bucket(filename))
-        )
+        quoted_filename = urllib.quote(self._add_bucket(filename))
+        return '{0}{1}'.format(self.api_url, quoted_filename)
 
     def _open(self, name, mode='r'):
         # Handle 'rb' as 'r'.


### PR DESCRIPTION
Otherwise, when doing `field.url` we get things like `https%3A//storage.googleapis.com/<file>` and we can't use it as `href` in a link.