### PR TITLE
Json serialize set fields

### DIFF
--- a/djangae/patches/json.py
+++ b/djangae/patches/json.py
@@ -4,8 +4,8 @@ def additional_type_handler(func):
     @wraps(func)
     def _wrapper(self, o):
         if isinstance(o, set):
-            # Return a string representing a set
-            return "{" + ",".join([str(x) for x in o]) + "}"
+            # Treat sets as lists.
+            return list(o)
         else:
             return func(self, o)
 

--- a/djangae/tests/test_serializers.py
+++ b/djangae/tests/test_serializers.py
@@ -1,0 +1,17 @@
+import json
+
+from djangae.test import TestCase
+
+
+class JSONEncoderTestCase(TestCase):
+    def test_encodes_sets_as_lists(self):
+        # Django's built-in encoder does lists, but not sets. Djangae patches
+        # it to make lists from sets, which is needed for SetField.
+        from django.core.serializers.json import DjangoJSONEncoder
+
+        encoder = DjangoJSONEncoder()
+        obj = {'test': set(['foo', 'bar', 'baz'])}
+        data = encoder.encode(obj)
+        result = json.loads(data)
+
+        self.assertIsInstance(result['test'], list)


### PR DESCRIPTION
This patch changes the serialization behaviour so that SetField instances, and any sets, are encoded as lists. Previously there were encoded as a string literal using the set literal syntax.

This fixes #554 .
