### PR TITLE
Make it possible to order by __scatter__

### DIFF
--- a/djangae/db/backends/appengine/compiler.py
+++ b/djangae/db/backends/appengine/compiler.py
@@ -34,7 +34,7 @@ class SQLCompiler(compiler.SQLCompiler):
         if name.startswith("__") and name.endswith("__"):
             name, order = get_order_dir(name, default_order)
             descending = True if order == 'DESC' else False
-            return [ OrderBy(Value('__scatter__'), descending=descending) ]
+            return [ (OrderBy(Value('__scatter__'), descending=descending), False) ]
 
         return super(SQLCompiler, self).find_ordering_name(
             name,

--- a/djangae/db/backends/appengine/compiler.py
+++ b/djangae/db/backends/appengine/compiler.py
@@ -2,9 +2,12 @@
 import django
 
 from django.db.models.sql import compiler
+
 try:
+    # This is only necessary for 1.8+
     from django.db.models.expressions import Value, OrderBy
 except ImportError:
+    # Ignore on 1.7
     pass
 
 from django.db.models.sql.query import get_order_dir
@@ -21,6 +24,10 @@ from .commands import (
 class SQLCompiler(compiler.SQLCompiler):
 
     def find_ordering_name(self, name, opts, alias=None, default_order='ASC', already_seen=None):
+        """
+            Seems not to be called on 1.7 when processing orderings (for some reason?),
+            overridden for __scatter__ on 1.8+
+        """
 
         # This allow special appengine properties (e.g. __scatter__) to be supplied as an ordering
         # even though they don't (and can't) exist as Django model fields

--- a/djangae/db/backends/appengine/compiler.py
+++ b/djangae/db/backends/appengine/compiler.py
@@ -2,6 +2,12 @@
 import django
 
 from django.db.models.sql import compiler
+try:
+    from django.db.models.expressions import Value, OrderBy
+except ImportError:
+    pass
+
+from django.db.models.sql.query import get_order_dir
 
 #DJANGAE
 from .commands import (
@@ -13,6 +19,24 @@ from .commands import (
 
 
 class SQLCompiler(compiler.SQLCompiler):
+
+    def find_ordering_name(self, name, opts, alias=None, default_order='ASC', already_seen=None):
+
+        # This allow special appengine properties (e.g. __scatter__) to be supplied as an ordering
+        # even though they don't (and can't) exist as Django model fields
+        if name.startswith("__") and name.endswith("__"):
+            name, order = get_order_dir(name, default_order)
+            descending = True if order == 'DESC' else False
+            return [ OrderBy(Value('__scatter__'), descending=descending) ]
+
+        return super(SQLCompiler, self).find_ordering_name(
+            name,
+            opts,
+            alias=alias,
+            default_order=default_order,
+            already_seen=already_seen
+        )
+
     def as_sql(self, with_limits=True, with_col_aliases=False, subquery=False):
         self.pre_sql_setup()
         self.refcounts_before = self.query.alias_refcount.copy()

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -633,6 +633,9 @@ def _extract_ordering_from_query_17(query):
             final.append("-" + pk_col if col.startswith("-") else pk_col)
         elif col == "?":
             raise NotSupportedError("Random ordering is not supported on the datastore")
+        elif col.lstrip("-").startswith("__") and col.endswith("__"):
+            # Allow stuff like __scatter__
+            final.append(col)
         elif "__" in col:
             continue
         else:

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 import re
 import random
+import logging
 
 from cStringIO import StringIO
 from string import letters
@@ -602,6 +603,13 @@ class BackendTests(TestCase):
         self.assertRaises(IntegerModel.DoesNotExist, IntegerModel.objects.get, integer_field=1000)
         i = IntegerModel.objects.get(pk=i.pk)
         self.assertEqual(1001, i.integer_field)
+
+    def test_ordering_by_scatter_property(self):
+        try:
+            list(TestFruit.objects.order_by("__scatter__"))
+        except:
+            logging.exception("Error sorting on __scatter__")
+            self.fail("Unable to sort on __scatter__ property like we should")
 
     def test_ordering_on_sparse_field(self):
         """


### PR DESCRIPTION
These changes allow us to order by special appengine properties (E.g __scatter__ or __key__) although it's mainly for __scatter__