### PR TITLE
1 6 memcache backport

### DIFF
--- a/djangae/db/backends/appengine/caching.py
+++ b/djangae/db/backends/appengine/caching.py
@@ -1,19 +1,27 @@
 import logging
 import threading
+import itertools
 
 from google.appengine.api import datastore
 
 from django.conf import settings
 from django.core.cache import cache
-from django.core.signals import request_finished, request_started
-from django.dispatch import receiver
 from djangae.db import utils
 from djangae.db.unique_utils import unique_identifiers_from_entity, _format_value_for_identifier
 from djangae.db.backends.appengine.context import ContextStack
 
 logger = logging.getLogger("djangae")
 
-_context = threading.local()
+_context = None
+
+def get_context():
+    global _context
+
+    if not _context:
+        _context = threading.local()
+
+    return _context
+
 
 CACHE_TIMEOUT_SECONDS = getattr(settings, "DJANGAE_CACHE_TIMEOUT_SECONDS", 60 * 60)
 CACHE_ENABLED = getattr(settings, "DJANGAE_CACHE_ENABLED", True)
@@ -26,13 +34,15 @@ class CachingSituation:
 
 
 def ensure_context():
-    _context.memcache_enabled = getattr(_context, "memcache_enabled", True)
-    _context.context_enabled = getattr(_context, "context_enabled", True)
-    _context.stack = _context.stack if hasattr(_context, "stack") else ContextStack()
+    context = get_context()
+
+    context.memcache_enabled = getattr(context, "memcache_enabled", True)
+    context.context_enabled = getattr(context, "context_enabled", True)
+    context.stack = context.stack if hasattr(context, "stack") else ContextStack()
 
 
-def _add_entity_to_memcache(model, entity, identifiers):
-    cache.set_many({ x: entity for x in identifiers}, timeout=CACHE_TIMEOUT_SECONDS)
+def _add_entity_to_memcache(model, mc_key_entity_map):
+    cache.set_many(mc_key_entity_map, timeout=CACHE_TIMEOUT_SECONDS)
 
 
 def _get_cache_key_and_model_from_datastore_key(key):
@@ -44,28 +54,36 @@ def _get_cache_key_and_model_from_datastore_key(key):
         raise AssertionError("Unable to locate model for db_table '{}' - item won't be evicted from the cache".format(key.kind()))
 
     # We build the cache key for the ID of the instance
-    cache_key =  "|".join([key.kind(), "{}:{}".format(model._meta.pk.column,  _format_value_for_identifier(key.id_or_name()))])
+    cache_key = "|".join(
+        [key.kind(), "{}:{}".format(model._meta.pk.column, _format_value_for_identifier(key.id_or_name()))]
+    )
 
     return (cache_key, model)
 
 
-def _remove_entity_from_memcache_by_key(key):
+def _remove_entities_from_memcache_by_key(keys):
     """
+        Given an iterable of datastore.Key objects, remove the corresponding entities from memcache.
         Note, if the key of the entity got evicted from the cache, it's possible that stale cache
         entries would be left behind. Remember if you need pure atomicity then use disable_cache() or a
         transaction.
     """
+    # Key -> model
+    cache_keys = dict(
+        _get_cache_key_and_model_from_datastore_key(key) for key in keys
+    )
+    entities = cache.get_many(cache_keys.keys())
 
-    cache_key, model = _get_cache_key_and_model_from_datastore_key(key)
-    entity = cache.get(cache_key)
+    if entities:
+        identifiers = [
+            unique_identifiers_from_entity(cache_keys[key], entity)
+            for key, entity in entities.items()
+        ]
+        cache.delete_many(itertools.chain(*identifiers))
 
-    if entity:
-        identifiers = unique_identifiers_from_entity(model, entity)
-        cache.delete_many(identifiers)
 
-
-def _get_entity_from_memcache(identifier):
-    return cache.get(identifier)
+def _get_entity_from_memcache(cache_key):
+    return cache.get(cache_key)
 
 
 def _get_entity_from_memcache_by_key(key):
@@ -74,10 +92,8 @@ def _get_entity_from_memcache_by_key(key):
     return cache.get(cache_key)
 
 
-def add_entity_to_cache(model, entity, situation):
+def add_entities_to_cache(model, entities, situation, skip_memcache=False):
     ensure_context()
-
-    identifiers = unique_identifiers_from_entity(model, entity)
 
     # Don't cache on Get if we are inside a transaction, even in the context
     # This is because transactions don't see the current state of the datastore
@@ -87,42 +103,56 @@ def add_entity_to_cache(model, entity, situation):
 
     if situation in (CachingSituation.DATASTORE_PUT, CachingSituation.DATASTORE_GET_PUT) and datastore.IsInTransaction():
         # We have to wipe the entity from memcache
-        if entity.key():
-            _remove_entity_from_memcache_by_key(entity.key())
+        _remove_entities_from_memcache_by_key([entity.key() for entity in entities if entity.key()])
 
-    _context.stack.top.cache_entity(identifiers, entity, situation)
+    identifiers = [
+        unique_identifiers_from_entity(model, entity) for entity in entities
+    ]
+
+    for ent_identifiers, entity in zip(identifiers, entities):
+        get_context().stack.top.cache_entity(ent_identifiers, entity, situation)
 
     # Only cache in memcache of we are doing a GET (outside a transaction) or PUT (outside a transaction)
     # the exception is GET_PUT - which we do in our own transaction so we have to ignore that!
-    if (not datastore.IsInTransaction() and situation in (CachingSituation.DATASTORE_GET, CachingSituation.DATASTORE_PUT)) or \
-            situation == CachingSituation.DATASTORE_GET_PUT:
+    if (
+        (
+            not datastore.IsInTransaction()
+            and situation in (CachingSituation.DATASTORE_GET, CachingSituation.DATASTORE_PUT)
+        )
+        or situation == CachingSituation.DATASTORE_GET_PUT
+    ):
 
-        _add_entity_to_memcache(model, entity, identifiers)
+        if not skip_memcache:
+
+            mc_key_entity_map = {}
+            for ent_identifiers, entity in zip(identifiers, entities):
+                mc_key_entity_map.update({
+                    identifier: entity for identifier in ent_identifiers
+                })
+            _add_entity_to_memcache(model, mc_key_entity_map)
 
 
-def remove_entity_from_cache(entity):
-    key = entity.key()
-    remove_entity_from_cache_by_key(key)
-
-
-def remove_entity_from_cache_by_key(key, memcache_only=False):
+def remove_entities_from_cache_by_key(keys, memcache_only=False):
     """
-        Removes an entity from all caches (both context and memcache)
-        or just memcache if specified
+        Given an iterable of datastore.Keys objects, remove the corresponding entities from caches,
+        both context and memcache, or just memcache if specified.
     """
     ensure_context()
 
     if not memcache_only:
-        for identifier in _context.stack.top.reverse_cache.get(key, []):
-            if identifier in _context.stack.top.cache:
-                del _context.stack.top.cache[identifier]
+        for key in keys:
+            identifiers = _context.stack.top.reverse_cache.get(key, [])
+            for identifier in identifiers:
+                if identifier in _context.stack.top.cache:
+                    del _context.stack.top.cache[identifier]
 
-    _remove_entity_from_memcache_by_key(key)
+    _remove_entities_from_memcache_by_key(keys)
 
 
 def get_from_cache_by_key(key):
     """
-        Return an entity from the context cache, falling back to memcache when possible
+        Given a datastore.Key, return an
+        entity from the context cache, falling back to memcache when possible.
     """
 
     ensure_context()
@@ -137,6 +167,14 @@ def get_from_cache_by_key(key):
         if ret is None and not datastore.IsInTransaction():
             if _context.memcache_enabled:
                 ret = _get_entity_from_memcache_by_key(key)
+                if ret:
+                    # Add back into the context cache
+                    add_entities_to_cache(
+                        utils.get_model_from_db_table(ret.key().kind()),
+                        [ret],
+                        CachingSituation.DATASTORE_GET,
+                        skip_memcache=True # Don't put in memcache, we just got it from there!
+                    )
     elif _context.memcache_enabled and not datastore.IsInTransaction():
         ret = _get_entity_from_memcache_by_key(key)
 
@@ -149,25 +187,34 @@ def get_from_cache(unique_identifier):
     """
 
     ensure_context()
+    context = get_context()
 
     if not CACHE_ENABLED:
         return None
 
+    cache_key = unique_identifier
     ret = None
-    if _context.context_enabled:
+    if context.context_enabled:
         # It's safe to hit the context cache, because a new one was pushed on the stack at the start of the transaction
-        ret = _context.stack.top.get_entity(unique_identifier)
+        ret = context.stack.top.get_entity(cache_key)
         if ret is None and not datastore.IsInTransaction():
-            if _context.memcache_enabled:
-                ret = _get_entity_from_memcache(unique_identifier)
-    elif _context.memcache_enabled and not datastore.IsInTransaction():
-        ret = _get_entity_from_memcache(unique_identifier)
+            if context.memcache_enabled:
+                ret = _get_entity_from_memcache(cache_key)
+                if ret:
+                    # Add back into the context cache
+                    add_entities_to_cache(
+                        utils.get_model_from_db_table(ret.key().kind()),
+                        [ret],
+                        CachingSituation.DATASTORE_GET,
+                        skip_memcache=True # Don't put in memcache, we just got it from there!
+                    )
+
+    elif context.memcache_enabled and not datastore.IsInTransaction():
+        ret = _get_entity_from_memcache(cache_key)
 
     return ret
 
 
-@receiver(request_finished)
-@receiver(request_started)
 def reset_context(keep_disabled_flags=False, *args, **kwargs):
     """
         Called at the beginning and end of each request, resets the thread local
@@ -175,15 +222,15 @@ def reset_context(keep_disabled_flags=False, *args, **kwargs):
         flags will be preserved, this is really only useful for testing.
     """
 
-    memcache_enabled = getattr(_context, "memcache_enabled", True)
-    context_enabled = getattr(_context, "context_enabled", True)
+    context = get_context()
 
-    for attr in ("stack", "memcache_enabled", "context_enabled"):
-        if hasattr(_context, attr):
-            delattr(_context, attr)
+    memcache_enabled = getattr(context, "memcache_enabled", True)
+    context_enabled = getattr(context, "context_enabled", True)
 
-    ensure_context()
+    context.memcache_enabled = True
+    context.context_enabled = True
+    context.stack = ContextStack()
 
     if keep_disabled_flags:
-        _context.memcache_enabled = memcache_enabled
-        _context.context_enabled = context_enabled
+        context.memcache_enabled = memcache_enabled
+        context.context_enabled = context_enabled

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -280,50 +280,123 @@ def _get_key(query):
     return query["__key__ ="]
 
 class QueryByKeys(object):
+    """ Does the most efficient fetching possible for when we have the keys of the entities we want. """
+
     def __init__(self, model, queries, ordering):
+        # `queries` should be filtered by __key__
+
+        def _get_key(query):
+            result = query["__key__ ="]
+            return result
+
         self.model = model
-        self.queries = queries
-        self.queries_by_key = { a: list(b) for a, b in groupby(queries, lambda x: _get_key(x)) }
+
+        # groupby requires that the iterable is sorted by the given key before grouping
+        self.queries = sorted(queries, key=_get_key)
+        self.queries_by_key = { a: list(b) for a, b in groupby(self.queries, _get_key) }
+
         self.ordering = ordering
         self._Query__kind = queries[0]._Query__kind
 
     def Run(self, limit=None, offset=None):
-        assert not self.queries[0]._Query__ancestor_pb #FIXME: We don't handle this yet
+        """
+            Here are the options:
 
-        # FIXME: What if the query options differ?
+            1. Single key, hit memcache
+            2. Multikey projection, async MultiQueries with ancestors chained
+            3. Full select, datastore get
+        """
+
         opts = self.queries[0]._Query__query_options
+        key_count = len(self.queries_by_key)
+
+        cache = True
 
         results = None
+        if key_count == 1:
+            # FIXME: Potentially could use get_multi in memcache and the make a query
+            # for whatever remains
+            key = self.queries_by_key.keys()[0]
+            result = caching.get_from_cache_by_key(key)
+            if result is not None:
+                results = [ result ]
+                cache = False # Don't update cache, we just got it from there
 
-        # If we have a single key lookup going on, just hit the cache
-        if len(self.queries_by_key) == 1:
-            keys = self.queries_by_key.keys()
-            ret = caching.get_from_cache_by_key(keys[0])
-            if ret is not None:
-                results = [ret]
-
-        # If there was nothing in the cache, or we had more than one key, then use Get()
         if results is None:
-            keys = self.queries_by_key.keys()
-            results = datastore.Get(keys)
-            for result in results:
-                if result is None:
+            if opts.projection:
+                cache = False # Don't cache projection results!
+
+                # Assumes projection ancestor queries are faster than a datastore Get
+                # due to lower traffic over the RPC. This should be faster for queries with
+                # < 30 keys (which is the most common case), and faster if the entities are
+                # larger and there are many results, but there is probably a slower middle ground
+                # because the larger number of RPC calls. Still, if performance is an issue the
+                # user can just do a normal get() rather than values/values_list/only/defer
+
+                to_fetch = (offset or 0) + limit if limit else None
+                additional_cols = set([ x[0] for x in self.ordering if x[0] not in opts.projection])
+
+                multi_query = []
+                final_queries = []
+                orderings = self.queries[0]._Query__orderings
+                for key, queries in self.queries_by_key.iteritems():
+                    for query in queries:
+                        if additional_cols:
+                            # We need to include additional orderings in the projection so that we can
+                            # sort them in memory. Annoyingly that means reinstantiating the queries
+                            query = Query(
+                                kind=query._Query__kind,
+                                filters=query,
+                                projection=list(opts.projection).extend(list(additional_cols))
+                            )
+
+                        query.Ancestor(key) # Make this an ancestor query
+                        multi_query.append(query)
+                        if len(multi_query) == 30:
+                            final_queries.append(datastore.MultiQuery(multi_query, orderings).Run(limit=to_fetch))
+                            multi_query = []
+                else:
+                    if len(multi_query) == 1:
+                        final_queries.append(multi_query[0].Run(limit=to_fetch))
+                    elif multi_query:
+                        final_queries.append(datastore.MultiQuery(multi_query, orderings).Run(limit=to_fetch))
+
+                results = chain(*final_queries)
+            else:
+                results = datastore.Get(self.queries_by_key.keys())
+
+        def iter_results(results):
+            returned = 0
+            # This is safe, because Django is fetching all results any way :(
+            sorted_results = sorted(results, cmp=partial(utils.django_ordering_comparison, self.ordering))
+            sorted_results = [result for result in sorted_results if result is not None]
+            if cache and sorted_results:
+                caching.add_entities_to_cache(
+                    self.model,
+                    sorted_results,
+                    caching.CachingSituation.DATASTORE_GET,
+                )
+
+            for result in sorted_results:
+
+                if not any([ utils.entity_matches_query(result, qry) for qry in self.queries_by_key[result.key()]]):
                     continue
-                caching.add_entity_to_cache(self.model, result, caching.CachingSituation.DATASTORE_GET)
-            results = sorted((x for x in results if x is not None), cmp=partial(utils.django_ordering_comparison, self.ordering))
 
-        results = [
-            _convert_entity_based_on_query_options(x, opts)
-            for x in results if any([ utils.entity_matches_query(x, qry) for qry in self.queries_by_key[x.key()]])
-        ]
+                if offset and returned < offset:
+                    # Skip entities based on offset
+                    returned += 1
+                    continue
+                else:
 
-        if offset:
-            results = results[offset:]
+                    yield _convert_entity_based_on_query_options(result, opts)
 
-        if limit is not None:
-            results = results[:limit]
+                    returned += 1
 
-        return iter(results)
+                    # If there is a limit, we might be done!
+                    if limit is not None and returned == (offset or 0) + limit:
+                        break
+
+        return iter_results(results)
 
     def Count(self, limit, offset):
         return len([ x for x in self.Run(limit, offset) ])
@@ -1042,7 +1115,11 @@ class InsertCommand(object):
                             results.append(datastore.Put(ent))
                             if not was_in_transaction:
                                 # We can cache if we weren't in a transaction before this little nested one
-                                caching.add_entity_to_cache(self.model, ent, caching.CachingSituation.DATASTORE_GET_PUT)
+                                caching.add_entities_to_cache(
+                                    self.model,
+                                    [ent],
+                                    caching.CachingSituation.DATASTORE_GET_PUT
+                                )
                         except:
                             # Make sure we delete any created markers before we re-raise
                             constraints.release_markers(markers)
@@ -1060,8 +1137,11 @@ class InsertCommand(object):
             if not constraints.constraint_checks_enabled(self.model):
                 # Fast path, just bulk insert
                 results = datastore.Put(self.entities)
-                for entity in self.entities:
-                    caching.add_entity_to_cache(self.model, entity, caching.CachingSituation.DATASTORE_PUT)
+                caching.add_entities_to_cache(
+                    self.model,
+                    self.entities,
+                    caching.CachingSituation.DATASTORE_PUT
+                )
                 return results
             else:
                 markers = []
@@ -1069,10 +1149,13 @@ class InsertCommand(object):
                     #FIXME: We should rearrange this so that each entity is handled individually like above. We'll
                     # lose insert performance, but gain consistency on errors which is more important
                     markers = constraints.acquire_bulk(self.model, self.entities)
-
                     results = datastore.Put(self.entities)
-                    for entity in self.entities:
-                        caching.add_entity_to_cache(self.model, entity, caching.CachingSituation.DATASTORE_PUT)
+
+                    caching.add_entities_to_cache(
+                        self.model,
+                        self.entities,
+                        caching.CachingSituation.DATASTORE_PUT
+                    )
 
                 except:
                     to_delete = chain(*markers)
@@ -1112,14 +1195,15 @@ class DeleteCommand(object):
         if not queries:
             return
 
-        for entity in QueryByKeys(self.select.model, queries, []).Run():
+        model = self.select.model
+        for entity in QueryByKeys(model, queries, []).Run():
             keys.append(entity.key())
 
             # Delete constraints if that's enabled
-            if constraints.constraint_checks_enabled(self.select.model):
-                constraints.release(self.select.model, entity)
+            if constraints.constraint_checks_enabled(model):
+                constraints.release(model, entity)
 
-            caching.remove_entity_from_cache_by_key(entity.key())
+        caching.remove_entities_from_cache_by_key(keys)
         datastore.Delete(keys)
 
     def lower(self):
@@ -1144,7 +1228,7 @@ class UpdateCommand(object):
 
     @db.transactional
     def _update_entity(self, key):
-        caching.remove_entity_from_cache_by_key(key)
+        caching.remove_entities_from_cache_by_key([key])
 
         try:
             result = datastore.Get(key)
@@ -1182,7 +1266,11 @@ class UpdateCommand(object):
         if not constraints.constraint_checks_enabled(self.model):
             # The fast path, no constraint checking
             datastore.Put(result)
-            caching.add_entity_to_cache(self.model, result, caching.CachingSituation.DATASTORE_PUT)
+            caching.add_entities_to_cache(
+                self.model,
+                [result],
+                caching.CachingSituation.DATASTORE_PUT
+            )
         else:
             to_acquire, to_release = constraints.get_markers_for_update(self.model, original, result)
 
@@ -1190,7 +1278,11 @@ class UpdateCommand(object):
             constraints.acquire_identifiers(to_acquire, result.key())
             try:
                 datastore.Put(result)
-                caching.add_entity_to_cache(self.model, result, caching.CachingSituation.DATASTORE_PUT)
+                caching.add_entities_to_cache(
+                    self.model,
+                    [result],
+                    caching.CachingSituation.DATASTORE_PUT,
+                )
             except:
                 constraints.release_identifiers(to_acquire)
                 raise

--- a/djangae/db/backends/appengine/context.py
+++ b/djangae/db/backends/appengine/context.py
@@ -119,8 +119,11 @@ class ContextStack(object):
         if apply_staged:
             while self.staged:
                 to_apply = self.staged.pop()
-                for key in to_apply.reverse_cache.keys():
-                    caching.remove_entity_from_cache_by_key(key, memcache_only=True)
+                keys = to_apply.reverse_cache.keys()
+                if keys:
+                    caching.remove_entities_from_cache_by_key(
+                        keys, memcache_only=True
+                    )
 
                 self.top.apply(to_apply)
 

--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -1,5 +1,6 @@
 import copy
 import functools
+import threading
 
 from google.appengine.api.datastore import (
     CreateTransactionOptions,
@@ -21,26 +22,30 @@ def in_atomic_block():
 
 
 class ContextDecorator(object):
-    """ Base class for objects creating dual purpose decorators and context managers.
-        Sub classes need to define __enter__ and __exit__ to define the desired functionality;
-        these methods will be called whether the object is used as a decorator or a context manager.
-        Possible usages for subclasses:
-
-        @my_context_decorator
-        def my_function():
-            pass
-
-        @my_context_decorator()
-        def my_function():
-            pass
-
-        with my_context_decorator():
-            pass
     """
-    def __init__(self, func=None):
-        # If this has been used as `@decorator` without parenthesis, then the decorated function
-        # will be passed in here.
+        A thread-safe ContextDecorator. Subclasses should implement classmethods
+        called _do_enter(state, decorator_args) and _do_exit(state, decorator_args, exception)
+
+        state is a thread.local which can store state for each enter/exit. Decorator args holds
+        any arguments passed into the decorator or context manager when called.
+    """
+    VALID_ARGUMENTS = ()
+
+    def __init__(self, func=None, **kwargs):
+        # Func will be passed in if this has been called without parenthesis
+        # as a @decorator
+
+        # Make sure only valid decorator arguments were passed in
+        if len(kwargs) > len(self.__class__.VALID_ARGUMENTS):
+            raise ValueError("Unexpected decorator arguments: {}".format(
+                set(kwargs.keys()) - set(self.__class__.VALID_ARGUMENTS))
+            )
+
         self.func = func
+        self.decorator_args = { x: kwargs.get(x) for x in self.__class__.VALID_ARGUMENTS }
+        # Add thread local state for variables that change per-call rather than
+        # per insantiation of the decorator
+        self.state = threading.local()
 
     def __get__(self, obj, objtype=None):
         """ Implement descriptor protocol to support instance methods. """
@@ -52,20 +57,33 @@ class ContextDecorator(object):
         return functools.partial(self.__call__, obj)
 
     def __call__(self, *args, **kwargs):
-        # This method is only called if this has been used as a decorator (not as a context manager)
-        def decorated(*_args, **_kwargs):
-            # To allow subclasses to use attributes on `self` in a thread-safe way, we need to make
-            # a copy of ourself here
-            with copy.deepcopy(self):
-                return self.func(*_args, **_kwargs)
+        # Called if this has been used as a decorator not as a context manager
 
-        # If this has been used as `@decorator` without parenthesis
+        def decorated(*_args, **_kwargs):
+            decorator_args = self.decorator_args.copy()
+            exception = False
+            try:
+                self.__class__._do_enter(self.state, decorator_args)
+                try:
+                    return self.func(*_args, **_kwargs)
+                except:
+                    exception = True
+                    raise
+            finally:
+                self.__class__._do_exit(self.state, decorator_args, exception)
+
         if not self.func:
+            # We were instantiated with args
             self.func = args[0]
             return decorated
+        else:
+            return decorated(*args, **kwargs)
 
-        # Else... if this has been used as `@decorator()` with parenthesis
-        return decorated(*args, **kwargs)
+    def __enter__(self):
+        self.__class__._do_enter(self.state, self.decorator_args.copy())
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.__class__._do_exit(self.state, self.decorator_args.copy(), exc_type)
 
 
 class TransactionFailedError(Exception):
@@ -73,109 +91,115 @@ class TransactionFailedError(Exception):
 
 
 class AtomicDecorator(ContextDecorator):
-    def __init__(self, func=None, xg=False, independent=False, mandatory=False):
-        self.independent = independent
-        self.xg = xg
-        self.mandatory = mandatory
-        self.conn_stack = []
-        self.transaction_started = False
-        super(AtomicDecorator, self).__init__(func)
+    VALID_ARGUMENTS = ("xg", "independent", "mandatory")
 
-    def _do_enter(self):
-        if IsInTransaction():
-            if self.independent:
-                self.conn_stack.append(_PopConnection())
-                try:
-                    return self._do_enter()
-                except:
-                    _PushConnection(self.conn_stack.pop())
-                    raise
-            else:
-                # App Engine doesn't support nested transactions, so if there is a nested
-                # atomic() call we just don't do anything. This is how RunInTransaction does it
-                return
-        elif self.mandatory:
+    @classmethod
+    def _do_enter(cls, state, decorator_args):
+        mandatory = decorator_args.get("mandatory", False)
+        independent = decorator_args.get("independent", False)
+        xg = decorator_args.get("xg", False)
+
+        # Reset the state
+        state.conn_stack = []
+        state.transaction_started = False
+        state.original_stack = None
+
+        if independent:
+            # Unwind the connection stack and store it on the state so that
+            # we can replace it on exit
+            while in_atomic_block():
+                state.conn_stack.append(_PopConnection())
+            state.original_stack = copy.deepcopy(caching.get_context().stack)
+
+        elif in_atomic_block():
+            # App Engine doesn't support nested transactions, so if there is a nested
+            # atomic() call we just don't do anything. This is how RunInTransaction does it
+            return
+        elif mandatory:
             raise TransactionFailedError("You've specified that an outer transaction is mandatory, but one doesn't exist")
 
         options = CreateTransactionOptions(
-            xg=self.xg,
-            propagation=TransactionOptions.INDEPENDENT if self.independent else None
+            xg=xg,
+            propagation=TransactionOptions.INDEPENDENT if independent else None
         )
 
         conn = _GetConnection()
-
-        self.transaction_started = True
         new_conn = conn.new_transaction(options)
-
-        _PushConnection(None)
-        _SetConnection(new_conn)
+        _PushConnection(new_conn)
 
         assert(_GetConnection())
 
         # Clear the context cache at the start of a transaction
         caching.ensure_context()
-        caching._context.stack.push()
+        caching.get_context().stack.push()
+        state.transaction_started = True
 
-    def _do_exit(self, exception):
-        if not self.transaction_started:
-            # If we didn't start a transaction, then don't roll back or anything
-            return
+    @classmethod
+    def _do_exit(cls, state, decorator_args, exception):
+        independent = decorator_args.get("independent", False)
 
         try:
-            if exception:
-                _GetConnection().rollback()
-            else:
-                if not _GetConnection().commit():
-                    raise TransactionFailedError()
+            if state.transaction_started:
+                if exception:
+                    _GetConnection().rollback()
+                else:
+                    if not _GetConnection().commit():
+                        raise TransactionFailedError()
         finally:
-            _PopConnection()
+            if state.transaction_started:
+                _PopConnection()
 
-            if self.independent:
-                while self.conn_stack:
-                    _PushConnection(self.conn_stack.pop())
+                 # Clear the context cache at the end of a transaction
+                if exception:
+                    caching.get_context().stack.pop(discard=True)
+                else:
+                    caching.get_context().stack.pop(apply_staged=True, clear_staged=True)
 
-             # Clear the context cache at the end of a transaction
-            if exception:
-                caching._context.stack.pop(discard=True)
-            else:
-                caching._context.stack.pop(apply_staged=True, clear_staged=True)
+            # If we were in an independent transaction, put everything back
+            # the way it was!
+            if independent:
+                while state.conn_stack:
+                    _PushConnection(state.conn_stack.pop())
 
-            # Reset this; in case this method is called again
-            self.transaction_started = False
+                # Restore the in-context cache as it was
+                caching.get_context().stack = state.original_stack
 
-    def __enter__(self):
-        self._do_enter()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self._do_exit(exc_type)
 
 atomic = AtomicDecorator
 commit_on_success = AtomicDecorator  # Alias to the old Django name for this kinda thing
 
 
 class NonAtomicDecorator(ContextDecorator):
-    def _do_enter(self):
-        self._original_connection = None
+    @classmethod
+    def _do_enter(cls, state, decorator_args):
+        state.conn_stack = []
 
+        # We aren't in a transaction, do nothing!
         if not in_atomic_block():
-            return # Do nothing if we aren't even in a transaction
+            return
 
-        self._original_connection = _PopConnection()
-        self._original_context = copy.deepcopy(caching._context)
+        # Store the current in-context stack
+        state.original_stack = copy.deepcopy(caching.get_context().stack)
 
-        while len(caching._context.stack.stack) > 1:
-            caching._context.stack.pop(discard=True)
+        # Similar to independent transactions, unwind the connection statck
+        # until we aren't in a transaction
+        while in_atomic_block():
+            state.conn_stack.append(_PopConnection())
 
+        # Unwind the in-context stack
+        while len(caching.get_context().stack.stack) > 1:
+            caching.get_context().stack.pop(discard=True)
 
-    def _do_exit(self, exception):
-        if self._original_connection:
-            _PushConnection(self._original_connection)
-            caching._context = self._original_context
+    @classmethod
+    def _do_exit(cls, state, decorator_args, exception):
+        if not state.conn_stack:
+            return
 
-    def __enter__(self):
-        self._do_enter()
+        # Restore the connection stack
+        while state.conn_stack:
+            _PushConnection(state.conn_stack.pop())
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        self._do_exit(exc_type)
+        caching.get_context().stack = state.original_stack
+
 
 non_atomic = NonAtomicDecorator

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -298,8 +298,15 @@ def django_ordering_comparison(ordering, lhs, rhs):
     DESCENDING = 2
 
     for order, direction in ordering:
-        lhs_value = lhs.key() if order == "__key__" else lhs[order]
-        rhs_value = rhs.key() if order == "__key__" else rhs[order]
+        if lhs is not None:
+            lhs_value = lhs.key() if order == "__key__" else lhs.get(order)
+        else:
+            lhs_value = None
+
+        if rhs is not None:
+            rhs_value = rhs.key() if order == "__key__" else rhs.get(order)
+        else:
+            rhs_value = None
 
         if direction == ASCENDING and lhs_value != rhs_value:
             return -1 if lt(lhs_value, rhs_value) else 1

--- a/djangae/models.py
+++ b/djangae/models.py
@@ -9,3 +9,11 @@ class CounterShard(models.Model):
 
 # Apply our django patches
 patches.patch()
+
+
+# Make sure we clear the context cache properly
+from djangae.db.backends.appengine.caching import reset_context
+from django.core.signals import request_finished, request_started
+
+request_finished.connect(reset_context, dispatch_uid="request_finished_context_reset")
+request_started.connect(reset_context, dispatch_uid="request_started_context_reset")


### PR DESCRIPTION
This backports the latest caching, transaction and context code from HEAD to the 1-6-support branch. This is necessary because the previous caching code is broken, buggy and causes huge performance issues. We don't really support 1.6 any more (AT ALL!) but there are people using this code in the wild still and the backport was fairly trivial so I did it anyway.

This PR also includes the latest QueryByKeys implementation - it seemed silly not to improve this at the same time!

If you are using Djangae on Django 1.6. **Don't.**