### PR TITLE
Cloud storage permissions

### DIFF
--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -225,7 +225,7 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
     """
     write_options = None
 
-    def __init__(self, bucket=None, google_acl='private'):
+    def __init__(self, bucket=None, google_acl=None):
         if not bucket:
             bucket = get_bucket_name()
         self.bucket = bucket
@@ -238,7 +238,9 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
             self.api_url = 'https://storage.googleapis.com'
 
         self.write_options = self.__class__.write_options or {}
-        self.write_options['x-goog-acl'] = google_acl
+        if google_acl:
+            # If you don't specify an acl means you get the default permissions.
+            self.write_options['x-goog-acl'] = google_acl
 
     def url(self, filename):
         quoted_filename = urllib.quote(self._add_bucket(filename))

--- a/testapp/install_deps.py
+++ b/testapp/install_deps.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import stat
 import subprocess

--- a/testapp/install_deps.py
+++ b/testapp/install_deps.py
@@ -15,7 +15,7 @@ TARGET_DIR = os.path.join(PROJECT_DIR, "libs")
 
 APPENGINE_TARGET_DIR = os.path.join(TARGET_DIR, "google_appengine")
 
-APPENGINE_SDK_VERSION = "1.9.26"
+APPENGINE_SDK_VERSION = "1.9.31"
 APPENGINE_SDK_FILENAME = "google_appengine_%s.zip" % APPENGINE_SDK_VERSION
 
 # Google move versions from 'featured' to 'deprecated' when they bring


### PR DESCRIPTION
Hi,

This change makes the Google Cloud Storage storage backend default to _not_ setting an ACL by default, which means GCS will apply the default ACL (which happens to be project-private if the bucket permissions have not been edited).

It is still possible to set an explicit ACL with the google_acl keyword argument.

https://cloud.google.com/storage/docs/access-control?hl=en#predefined-project-private