### PR TITLE
Remove extra "db" parameter from mappers

### DIFF
--- a/djangae/contrib/mappers/pipes.py
+++ b/djangae/contrib/mappers/pipes.py
@@ -132,12 +132,12 @@ class MapReduceTask(object):
         # starting the task, or as a class-level attribute on the task.
         queue_name = kwargs.pop('queue_name', self.queue_name)
 
-        kwargs['db'] = self.db
         mapper_parameters = {
             'model': self.get_model_app_(),
             'kwargs': kwargs,
             'args': args,
             'namespace': settings.DATABASES.get(self.db, {}).get("NAMESPACE"),
+            'db': self.db
         }
         if 'map' not in self.__class__.__dict__:
             raise Exception('No static map method defined on class {cls}'.format(self.__class__))

--- a/djangae/contrib/mappers/readers.py
+++ b/djangae/contrib/mappers/readers.py
@@ -56,7 +56,7 @@ class DjangoInputReader(input_readers.InputReader):
         params = input_readers._get_params(mapper_spec)
         logging.info("Params: %s" % params)
 
-        db = params['kwargs']['db']
+        db = params['db']
         # Unpickle the query
         app, model = params['model'].split('.')
         model = apps.get_model(app, model)


### PR DESCRIPTION
This fixes an bad API change which added "db" as a kwarg to all mapper functions - this was introduced with the namespace support merge. Apologies if this broke your mappers!