### PR TITLE
Fix relatedfield exact lookups

### DIFF
--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -525,7 +525,8 @@ class InstanceSetFieldTests(TestCase):
         self.assertEqual({other.pk}, main.related_things_ids)
         self.assertEqual(list(ISOther.objects.filter(pk__in=main.related_things_ids)), list(main.related_things.all()))
 
-        self.assertEqual([main], list(other.ismodel_set.all()))
+        self.assertItemsEqual([main], ISModel.objects.filter(related_things=other).all())
+        self.assertItemsEqual([main], list(other.ismodel_set.all()))
 
         main.related_things.remove(other)
         self.assertFalse(main.related_things_ids)


### PR DESCRIPTION
Turns out that querying on `filter(some_related_list_field=some_instance)` was dying, when actually this is the valid way to query (because fields are indexed with multiple values this is the right way is equality until we implement a more intuitive __contains lookup). I'm guessing until now people have been querying on `_ids` or something.