### PR TITLE
Provide limited options for on_delete on RelatedSetField and RelatedL…

### DIFF
--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -362,21 +362,6 @@ class RelatedIteratorField(ForeignObject):
         """
         return str(list(self._get_val_from_obj(obj)))
 
-    def save_form_data(self, instance, data):
-        getattr(instance, self.attname).clear() #Wipe out existing things
-
-        for value in data:
-            if isinstance(value, self.rel.to):
-                field = getattr(instance, self.name)
-            else:
-                field = getattr(instance, self.attname)
-
-            if hasattr(field, "append"):
-                # ListField
-                field.append(value)
-            else:
-                # SetField
-                field.add(value)
 
     def formfield(self, **kwargs):
         db = kwargs.pop('using', None)
@@ -430,6 +415,17 @@ class RelatedSetField(RelatedIteratorField):
 
         return set(value)
 
+    def save_form_data(self, instance, data):
+        setattr(instance, self.name, set()) #Wipe out existing things
+        for value in data:
+            if isinstance(value, self.rel.to):
+                field = getattr(instance, self.name)
+            else:
+                field = getattr(instance, self.attname)
+
+            # SetField
+            field.add(value)
+
 
 class RelatedListField(RelatedIteratorField):
 
@@ -464,6 +460,17 @@ class RelatedListField(RelatedIteratorField):
             return list(self.rel.to._default_manager.db_manager('default').filter(pk__in=ids))
 
         return list(value)
+
+    def save_form_data(self, instance, data):
+        setattr(instance, self.name, []) #Wipe out existing things
+        for value in data:
+            if isinstance(value, self.rel.to):
+                field = getattr(instance, self.name)
+            else:
+                field = getattr(instance, self.attname)
+
+            # SetField
+            field.append(value)
 
 
 class GRCreator(property):

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -367,9 +367,16 @@ class RelatedIteratorField(ForeignObject):
 
         for value in data:
             if isinstance(value, self.rel.to):
-                getattr(instance, self.name).add(value)
+                field = getattr(instance, self.name)
             else:
-                getattr(instance, self.attname).add(value)
+                field = getattr(instance, self.attname)
+
+            if hasattr(field, "append"):
+                # ListField
+                field.append(value)
+            else:
+                # SetField
+                field.add(value)
 
     def formfield(self, **kwargs):
         db = kwargs.pop('using', None)

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -357,6 +357,28 @@ class IterableFieldTests(TestCase):
         self.assertRaises(TypeError, IterableFieldModel, list_field=1)
         self.assertRaises(TypeError, IterableFieldModel, set_field=1)
 
+
+class RelatedListFieldModelTests(TestCase):
+
+    def test_can_update_related_field_from_form(self):
+        related = ISOther.objects.create()
+        thing = ISModel.objects.create(related_list=[related])
+        before_list = thing.related_list
+        thing.related_list.field.save_form_data(thing, [])
+        self.assertNotEqual(before_list.all(), thing.related_list.all())
+
+
+class RelatedSetFieldModelTests(TestCase):
+
+    def test_can_update_related_field_from_form(self):
+        related = ISOther.objects.create()
+        thing = ISModel.objects.create(related_things={related})
+        before_set = thing.related_things
+        thing.related_list.field.save_form_data(thing, set())
+        thing.save()
+        self.assertNotEqual(before_set.all(), thing.related_things.all())
+
+
 class InstanceListFieldTests(TestCase):
 
     def test_deserialization(self):

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -366,6 +366,18 @@ class InstanceListFieldTests(TestCase):
         # happens to order it correctly
         self.assertItemsEqual([i1, i2], ISModel._meta.get_field("related_list").to_python("[1, 2]"))
 
+    def test_default_on_delete_does_nothing(self):
+        child = ISOther.objects.create(pk=1)
+        parent = ISModel.objects.create(related_list=[child])
+
+        child.delete()
+
+        try:
+            parent = ISModel.objects.get(pk=parent.pk)
+            self.assertEqual([1], parent.related_list_ids)
+        except ISModel.DoesNotExist:
+            self.fail("Parent instance was deleted, apparently by on_delete=CASCADE")
+
     def test_save_and_load_empty(self):
         """
         Create a main object with no related items,


### PR DESCRIPTION
…istField

Also add a test to show that CASCADE delete definitely doesn't happen by default and that
the default behaviour is to DO_NOTHING