### PR TITLE
Don't allow ordering by a TextField

### DIFF
--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -642,9 +642,9 @@ def _extract_ordering_from_query_17(query):
             try:
                 column = col.lstrip("-")
                 field = query.model._meta.get_field_by_name(column)[0]
-                if field.get_internal_type() == u"TextField":
+                if field.get_internal_type()  in (u"TextField", u"BinaryField"):
                     raise NotSupportedError("Ordering on TextField is not supported on the datastore. "
-                        "You might consider using a ComputedCharField which stores the first 500 chars of the "
+                        "You might consider using a ComputedCharField which stores the first MAX_BYTES_LENGTH bytes of the "
                         "TextField and instead ordering on that")
                 column = "__key__" if field.primary_key else field.column
                 final.append("-" + column if col.startswith("-") else column)
@@ -787,9 +787,9 @@ def _extract_ordering_from_query_18(query):
                             column = annotation.col.output_field.column
 
                 field = query.model._meta.get_field_by_name(column)[0]
-                if field.get_internal_type() == u"TextField":
+                if field.get_internal_type() in (u"TextField", u"BinaryField"):
                     raise NotSupportedError("Ordering on TextField is not supported on the datastore. "
-                        "You might consider using a ComputedCharField which stores the first 500 chars of the "
+                        "You might consider using a ComputedCharField which stores the first MAX_BYTES_LENGTH bytes of the "
                         "TextField and instead ordering on that")
                 column = "__key__" if field.primary_key else field.column
                 final.append("-" + column if col.startswith("-") else column)

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -598,11 +598,12 @@ class Query(object):
         return json.dumps(result)
 
 
-INVALID_ORDERING_FIELD_MESSAGE = "" \
-    "Ordering on TextField or BinaryField is not supported on the datastore. " \
-    "You might consider using a ComputedCharField which stores the first " \
-    "_MAX_STRING_LENGTH (from google.appengine.api.datastore_types) bytes of the " \
-    "field and instead order on that"
+INVALID_ORDERING_FIELD_MESSAGE = (
+    "Ordering on TextField or BinaryField is not supported on the datastore. "
+    "You might consider using a ComputedCharField which stores the first "
+    "_MAX_STRING_LENGTH (from google.appengine.api.datastore_types) bytes of the "
+    "field and instead order on that."
+)
 
 def _extract_ordering_from_query_17(query):
     from djangae.db.backends.appengine.commands import log_once

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -642,6 +642,10 @@ def _extract_ordering_from_query_17(query):
             try:
                 column = col.lstrip("-")
                 field = query.model._meta.get_field_by_name(column)[0]
+                if field.get_internal_type() == u"TextField":
+                    raise NotSupportedError("Ordering on TextField is not supported on the datastore. "
+                        "You might consider using a ComputedCharField which stores the first 500 chars of the "
+                        "TextField and instead ordering on that")
                 column = "__key__" if field.primary_key else field.column
                 final.append("-" + column if col.startswith("-") else column)
             except FieldDoesNotExist:
@@ -783,6 +787,10 @@ def _extract_ordering_from_query_18(query):
                             column = annotation.col.output_field.column
 
                 field = query.model._meta.get_field_by_name(column)[0]
+                if field.get_internal_type() == u"TextField":
+                    raise NotSupportedError("Ordering on TextField is not supported on the datastore. "
+                        "You might consider using a ComputedCharField which stores the first 500 chars of the "
+                        "TextField and instead ordering on that")
                 column = "__key__" if field.primary_key else field.column
                 final.append("-" + column if col.startswith("-") else column)
             except FieldDoesNotExist:

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -598,6 +598,12 @@ class Query(object):
         return json.dumps(result)
 
 
+INVALID_ORDERING_FIELD_MESSAGE = "" \
+    "Ordering on TextField or BinaryField is not supported on the datastore. " \
+    "You might consider using a ComputedCharField which stores the first " \
+    "_MAX_STRING_LENGTH (from google.appengine.api.datastore_types) bytes of the " \
+    "field and instead order on that"
+
 def _extract_ordering_from_query_17(query):
     from djangae.db.backends.appengine.commands import log_once
 
@@ -643,9 +649,7 @@ def _extract_ordering_from_query_17(query):
                 column = col.lstrip("-")
                 field = query.model._meta.get_field_by_name(column)[0]
                 if field.get_internal_type()  in (u"TextField", u"BinaryField"):
-                    raise NotSupportedError("Ordering on TextField is not supported on the datastore. "
-                        "You might consider using a ComputedCharField which stores the first MAX_BYTES_LENGTH bytes of the "
-                        "TextField and instead ordering on that")
+                    raise NotSupportedError(INVALID_ORDERING_FIELD_MESSAGE)
                 column = "__key__" if field.primary_key else field.column
                 final.append("-" + column if col.startswith("-") else column)
             except FieldDoesNotExist:
@@ -788,9 +792,7 @@ def _extract_ordering_from_query_18(query):
 
                 field = query.model._meta.get_field_by_name(column)[0]
                 if field.get_internal_type() in (u"TextField", u"BinaryField"):
-                    raise NotSupportedError("Ordering on TextField is not supported on the datastore. "
-                        "You might consider using a ComputedCharField which stores the first MAX_BYTES_LENGTH bytes of the "
-                        "TextField and instead ordering on that")
+                    raise NotSupportedError(INVALID_ORDERING_FIELD_MESSAGE)
                 column = "__key__" if field.primary_key else field.column
                 final.append("-" + column if col.startswith("-") else column)
             except FieldDoesNotExist:

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -110,6 +110,7 @@ class TestFruit(models.Model):
     origin = models.CharField(max_length=32, default="Unknown")
     color = models.CharField(max_length=100)
     is_mouldy = models.BooleanField(default=False)
+    text_field = models.TextField(blank=True, default="")
 
     class Meta:
         ordering = ("color",)
@@ -610,6 +611,9 @@ class BackendTests(TestCase):
         except:
             logging.exception("Error sorting on __scatter__")
             self.fail("Unable to sort on __scatter__ property like we should")
+
+    def test_ordering_on_text_field_not_supported(self):
+        self.assertRaises(NotSupportedError, list, TestFruit.objects.order_by("text_field"))
 
     def test_ordering_on_sparse_field(self):
         """

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -111,6 +111,7 @@ class TestFruit(models.Model):
     color = models.CharField(max_length=100)
     is_mouldy = models.BooleanField(default=False)
     text_field = models.TextField(blank=True, default="")
+    binary_field = models.BinaryField(blank=True)
 
     class Meta:
         ordering = ("color",)
@@ -612,8 +613,9 @@ class BackendTests(TestCase):
             logging.exception("Error sorting on __scatter__")
             self.fail("Unable to sort on __scatter__ property like we should")
 
-    def test_ordering_on_text_field_not_supported(self):
+    def test_ordering_on_non_indexed_fields_not_supported(self):
         self.assertRaises(NotSupportedError, list, TestFruit.objects.order_by("text_field"))
+        self.assertRaises(NotSupportedError, list, TestFruit.objects.order_by("binary_field"))
 
     def test_ordering_on_sparse_field(self):
         """


### PR DESCRIPTION
Text properties aren't indexed on the datastore, and ordering by one will return an empty queryset.

The error suggests a workaround by using a ComputedCharField and storing the first 500 chars which in most
cases will give you the right ordering (obviously it won't if the strings differ at character 501+)