### PR TITLE
Make import of `patches` explicitly relative.

### DIFF
--- a/djangae/__init__.py
+++ b/djangae/__init__.py
@@ -7,5 +7,5 @@ if extra_library_path not in sys.path:
 
 default_app_config = 'djangae.apps.DjangaeConfig'
 
-from patches import json
+from .patches import json
 json.patch()


### PR DESCRIPTION
Avoids potential conflict if you add a global package called `patches`, and will avoid breakage if this moves to Python 3.