### PR TITLE
Auth backend type error

### DIFF
--- a/djangae/contrib/gauth/backends.py
+++ b/djangae/contrib/gauth/backends.py
@@ -1,6 +1,0 @@
-from djangae.contrib.gauth.datastore.backends import AppEngineUserAPIBackend
-
-
-class AppEngineUserAPI(AppEngineUserAPIBackend):
-    pass
-

--- a/djangae/contrib/gauth/common/backends.py
+++ b/djangae/contrib/gauth/common/backends.py
@@ -93,7 +93,7 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
             else:
                 logging.info(
                     "GAUTH: Creating a new user with an existing email address "
-                    "(User(email=%s, pk=%s))" % (email, existing_user.pk)
+                    "(User(email=%r, pk=%r))", email, existing_user.pk)
                 )
                 with self.atomic(**self.atomic_kwargs):
                     existing_user = User.objects.get(pk=existing_user.pk)

--- a/djangae/contrib/gauth/common/backends.py
+++ b/djangae/contrib/gauth/common/backends.py
@@ -30,7 +30,7 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
     atomic_kwargs = {}
     supports_anonymous_user = True
 
-    def authenticate(self, google_user):
+    def authenticate(self, google_user=None):
         """
         Handles authentication of a user from the given credentials.
         Credentials must be a 'google_user' as returned by the App Engine
@@ -41,7 +41,7 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
 
         if not issubclass(User, GaeAbstractBaseUser):
             raise ImproperlyConfigured(
-                "djangae.contrib.auth.backends.AppEngineUserAPI requires AUTH_USER_MODEL to be a "
+                "AppEngineUserAPIBackend requires AUTH_USER_MODEL to be a "
                 " subclass of djangae.contrib.auth.base.GaeAbstractBaseUser."
             )
 
@@ -94,7 +94,6 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
                 logging.info(
                     "GAUTH: Creating a new user with an existing email address "
                     "(User(email=%r, pk=%r))", email, existing_user.pk)
-                )
                 with self.atomic(**self.atomic_kwargs):
                     existing_user = User.objects.get(pk=existing_user.pk)
                     existing_user.email = None

--- a/djangae/contrib/gauth/common/backends.py
+++ b/djangae/contrib/gauth/common/backends.py
@@ -30,12 +30,11 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
     atomic_kwargs = {}
     supports_anonymous_user = True
 
-    def authenticate(self, **credentials):
+    def authenticate(self, google_user):
         """
         Handles authentication of a user from the given credentials.
-        Credentials must be a combination of 'request' and 'google_user'.
-        If any other combination of credentials are given then we raise a TypeError, see
-        authenticate() in django.contrib.auth.__init__.py.
+        Credentials must be a 'google_user' as returned by the App Engine
+        Users API.
         """
 
         User = get_user_model()
@@ -46,63 +45,58 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
                 " subclass of djangae.contrib.auth.base.GaeAbstractBaseUser."
             )
 
-        if len(credentials) != 1:
-            # Django expects a TypeError if this backend cannot handle the given credentials
-            raise TypeError()
+        if google_user is None:
+            # users.get_current_user() can return None.
+            return None
 
-        google_user = credentials.get('google_user', None)
-
-        if google_user:
-            user_id = google_user.user_id()
-            email = BaseUserManager.normalize_email(google_user.email())
+        user_id = google_user.user_id()
+        email = BaseUserManager.normalize_email(google_user.email())
+        try:
+            return User.objects.get(username=user_id)
+        except User.DoesNotExist:
             try:
-                return User.objects.get(username=user_id)
+                existing_user = User.objects.get(email=BaseUserManager.normalize_email(email))
             except User.DoesNotExist:
-                try:
-                    existing_user = User.objects.get(email=BaseUserManager.normalize_email(email))
-                except User.DoesNotExist:
-                    force_pre_creation = getattr(settings, 'DJANGAE_FORCE_USER_PRE_CREATION', False)
-                    user_is_admin = users.is_current_user_admin()
-                    if force_pre_creation and not user_is_admin:
-                        # Indicate to Django that this user is not allowed
-                        return
+                force_pre_creation = getattr(settings, 'DJANGAE_FORCE_USER_PRE_CREATION', False)
+                user_is_admin = users.is_current_user_admin()
+                if force_pre_creation and not user_is_admin:
+                    # Indicate to Django that this user is not allowed
+                    return
+                return User.objects.create_user(user_id, email)
+
+            # If the existing user was precreated, update and reuse it
+            if existing_user.username is None:
+                if (
+                    getattr(settings, 'DJANGAE_ALLOW_USER_PRE_CREATION', False) or
+                    # Backwards compatibility, remove before 1.0
+                    getattr(settings, 'ALLOW_USER_PRE_CREATION', False)
+                ):
+                    # Convert the pre-created User object so that the user can now login via
+                    # Google Accounts, and ONLY via Google Accounts.
+                    existing_user.username = user_id
+                    existing_user.last_login = timezone.now()
+                    existing_user.save()
+                    return existing_user
+
+                # There's a precreated user but user precreation is disabled
+                # This will fail with an integrity error
+                from django.db import IntegrityError
+                raise IntegrityError(
+                    "GAUTH: Found existing User with email=%s and username=None, "
+                    "but user precreation is disabled." % email
+                )
+
+            # There is an existing user with this email address, but it is tied to a different
+            # Google user id.  As we treat the user id as the primary identifier, not the email
+            # address, we leave the existing user in place and blank its email address (as the
+            # email field is unique), then create a new user with the new user id.
+            else:
+                logging.info(
+                    "GAUTH: Creating a new user with an existing email address "
+                    "(User(email=%s, pk=%s))" % (email, existing_user.pk)
+                )
+                with self.atomic(**self.atomic_kwargs):
+                    existing_user = User.objects.get(pk=existing_user.pk)
+                    existing_user.email = None
+                    existing_user.save()
                     return User.objects.create_user(user_id, email)
-
-                # If the existing user was precreated, update and reuse it
-                if existing_user.username is None:
-                    if (
-                        getattr(settings, 'DJANGAE_ALLOW_USER_PRE_CREATION', False) or
-                        # Backwards compatibility, remove before 1.0
-                        getattr(settings, 'ALLOW_USER_PRE_CREATION', False)
-                    ):
-                        # Convert the pre-created User object so that the user can now login via
-                        # Google Accounts, and ONLY via Google Accounts.
-                        existing_user.username = user_id
-                        existing_user.last_login = timezone.now()
-                        existing_user.save()
-                        return existing_user
-
-                    # There's a precreated user but user precreation is disabled
-                    # This will fail with an integrity error
-                    from django.db import IntegrityError
-                    raise IntegrityError(
-                        "GAUTH: Found existing User with email=%s and username=None, "
-                        "but user precreation is disabled." % email
-                    )
-
-                # There is an existing user with this email address, but it is tied to a different
-                # Google user id.  As we treat the user id as the primary identifier, not the email
-                # address, we leave the existing user in place and blank its email address (as the
-                # email field is unique), then create a new user with the new user id.
-                else:
-                    logging.info(
-                        "GAUTH: Creating a new user with an existing email address "
-                        "(User(email=%s, pk=%s))" % (email, existing_user.pk)
-                    )
-                    with self.atomic(**self.atomic_kwargs):
-                        existing_user = User.objects.get(pk=existing_user.pk)
-                        existing_user.email = None
-                        existing_user.save()
-                        return User.objects.create_user(user_id, email)
-        else:
-            raise TypeError()  # Django expects to be able to pass in whatever credentials it has, and for you to raise a TypeError if they mean nothing to you

--- a/djangae/contrib/gauth/settings.py
+++ b/djangae/contrib/gauth/settings.py
@@ -1,6 +1,6 @@
 
 AUTHENTICATION_BACKENDS = (
-    'djangae.contrib.gauth.backends.AppEngineUserAPI',
+    'djangae.contrib.gauth.datastore.backends.AppEngineUserAPIBackend',
 )
 
 AUTH_USER_MODEL = 'djangae.GaeDatastoreUser'

--- a/djangae/contrib/gauth/tests.py
+++ b/djangae/contrib/gauth/tests.py
@@ -13,7 +13,7 @@ from google.appengine.api import users
 
 # DJANGAE
 from djangae.contrib.gauth.datastore.models import GaeDatastoreUser, Group, get_permission_choices
-from djangae.contrib.gauth.backends import AppEngineUserAPI
+from djangae.contrib.gauth.datastore.backends import AppEngineUserAPIBackend
 from djangae.contrib.gauth.middleware import AuthenticationMiddleware
 from djangae.contrib.gauth.settings import AUTHENTICATION_BACKENDS
 from djangae.contrib.gauth.utils import get_switch_accounts_url
@@ -21,13 +21,13 @@ from djangae.contrib import sleuth
 
 
 class BackendTests(TestCase):
-    """ Tests for the AppEngineUserAPI auth backend. """
+    """ Tests for the AppEngineUserAPIBackend auth backend. """
 
     def test_invalid_credentials_cause_typeerror(self):
         """ If the `authenticate` method is passed credentials which it doesn't understand then
             Django expects it to raise a TypeError.
         """
-        backend = AppEngineUserAPI()
+        backend = AppEngineUserAPIBackend()
         credentials = {'username': 'ted', 'password': 'secret'}
         self.assertRaises(TypeError, backend.authenticate, **credentials)
 
@@ -38,7 +38,7 @@ class BackendTests(TestCase):
         self.assertEqual(User.objects.count(), 0)
         email = 'UpperCasedAddress@example.com'
         google_user = users.User(email, _user_id='111111111100000000001')
-        backend = AppEngineUserAPI()
+        backend = AppEngineUserAPIBackend()
         user = backend.authenticate(google_user=google_user,)
         self.assertEqual(user.email, email.lower())
         self.assertEqual(User.objects.count(), 1)
@@ -52,7 +52,7 @@ class BackendTests(TestCase):
             then matched by email address when they log in.
         """
         User = get_user_model()
-        backend = AppEngineUserAPI()
+        backend = AppEngineUserAPIBackend()
         email = '1@example.com'
         # Pre-create our user
         User.objects.pre_create_google_user(email)
@@ -73,7 +73,7 @@ class BackendTests(TestCase):
         old_user = users.User(email=email, _user_id='111111111100000000001')
         new_user = users.User(email=email, _user_id='111111111100000000002')
         User = get_user_model()
-        backend = AppEngineUserAPI()
+        backend = AppEngineUserAPIBackend()
         # Authenticate 1st time, creating the user
         user1 = backend.authenticate(google_user=old_user)
         self.assertEqual(user1.email, email)
@@ -95,7 +95,7 @@ class BackendTests(TestCase):
         User = get_user_model()
         self.assertEqual(User.objects.count(), 0)
         google_user = users.User('1@example.com', _user_id='111111111100000000001')
-        backend = AppEngineUserAPI()
+        backend = AppEngineUserAPIBackend()
 
         self.assertIsNone(backend.authenticate(google_user=google_user,))
         self.assertEqual(User.objects.count(), 0)
@@ -119,7 +119,7 @@ class MiddlewareTests(TestCase):
 
         request = HttpRequest()
         SessionMiddleware().process_request(request) # Make the damn sessions work
-        request.session[BACKEND_SESSION_KEY] = 'djangae.contrib.gauth.backends.AppEngineUserAPI'
+        request.session[BACKEND_SESSION_KEY] = 'djangae.contrib.gauth.datastore.backends.AppEngineUserAPIBackend'
         middleware = AuthenticationMiddleware()
         # Check that we're not logged in already
         user = get_user(request)
@@ -150,7 +150,7 @@ class MiddlewareTests(TestCase):
 
         request = HttpRequest()
         SessionMiddleware().process_request(request)  # Make the damn sessions work
-        request.session[BACKEND_SESSION_KEY] = 'djangae.contrib.gauth.backends.AppEngineUserAPI'
+        request.session[BACKEND_SESSION_KEY] = 'djangae.contrib.gauth.datastore.backends.AppEngineUserAPIBackend'
         middleware = AuthenticationMiddleware()
 
         with sleuth.switch('djangae.contrib.gauth.middleware.users.get_current_user', lambda: user1):
@@ -174,7 +174,7 @@ class MiddlewareTests(TestCase):
         User = get_user_model()
         request = HttpRequest()
         SessionMiddleware().process_request(request)  # Make the damn sessions work
-        request.session[BACKEND_SESSION_KEY] = 'djangae.contrib.gauth.backends.AppEngineUserAPI'
+        request.session[BACKEND_SESSION_KEY] = 'djangae.contrib.gauth.datastore.backends.AppEngineUserAPIBackend'
         middleware = AuthenticationMiddleware()
 
         with sleuth.switch('djangae.contrib.gauth.middleware.users.get_current_user', lambda: user1):
@@ -214,7 +214,7 @@ class MiddlewareTests(TestCase):
         # Create user with uppercased email
         email = 'User@example.com'
         google_user = users.User(email, _user_id='111111111100000000001')
-        backend = AppEngineUserAPI()
+        backend = AppEngineUserAPIBackend()
         user = backend.authenticate(google_user=google_user,)
         # Normalize_email should save a user with lowercase email
         self.assertEqual(user.email, email.lower())
@@ -233,7 +233,7 @@ class MiddlewareTests(TestCase):
 
 @override_settings(
     AUTH_USER_MODEL='djangae.GaeDatastoreUser',
-    AUTHENTICATION_BACKENDS=('djangae.contrib.gauth.backends.AppEngineUserAPI',)
+    AUTHENTICATION_BACKENDS=('djangae.contrib.gauth.datastore.backends.AppEngineUserAPIBackend',)
 )
 class CustomPermissionsUserModelBackendTest(TestCase):
     """
@@ -342,7 +342,7 @@ class CustomPermissionsUserModelBackendTest(TestCase):
 
 @override_settings(
     AUTH_USER_MODEL='djangae.GaeDatastoreUser',
-    AUTHENTICATION_BACKENDS=('djangae.contrib.gauth.backends.AppEngineUserAPI',)
+    AUTHENTICATION_BACKENDS=('djangae.contrib.gauth.datastore.backends.AppEngineUserAPIBackend',)
 )
 class SwitchAccountsTests(TestCase):
     """ Tests for the switch accounts functionality. """

--- a/docs/gauth.md
+++ b/docs/gauth.md
@@ -3,7 +3,7 @@
 Djangae includes two applications to aid authentication and user management with
 App Engine. Each provides both an abstract class, to extend if you're defining your own custom User model, or a concrete version to use in place of `'django.contrib.auth.models.User'`.  Also provided are custom authentication backends which delegate to the App Engine users API and a middleware to handle the link between the Django's user object and App Engine's (amongst other things).
 
-The only minor difference between Djangae Gauth and Django Auth is that Djangae overrides `normalize_email` to lowercase whole email, not just the domain part like Django does. See rationale behind this decision in [issue #481 on Github](https://github.com/potatolondon/djangae/issues/481). 
+The only minor difference between Djangae Gauth and Django Auth is that Djangae overrides `normalize_email` to lowercase whole email, not just the domain part like Django does. See rationale behind this decision in [issue #481 on Github](https://github.com/potatolondon/djangae/issues/481).
 
 ## Using the Datastore
 
@@ -74,7 +74,7 @@ As well as using Djangae's Google Accounts-based authentication, you can also us
 
 ```python
 AUTHENTICATION_BACKENDS = (
-    'djangae.contrib.gauth.datastore.backends.AppEngineUserAPI',
+    'djangae.contrib.gauth.datastore.backends.AppEngineUserAPIBackend',
     'django.contrib.auth.backends.ModelBackend',
 )
 


### PR DESCRIPTION
Hi,

This fixes #592 by changing the base App Engine auth backend to return None if it is not passed a valid App Engine user. Previously it would raise  TypeError.

Also, quite importantly, this change removes the legacy djangae.contrib.gauth.backends module.

**This is a breaking change for projects which still specify the old backend name in their `AUTHENTICATION_BACKENDS` settings.** Those projects can update their settings to specify `djangae.contrib.gauth.datastore.AppEngineUserAPIBackend `.

Hope this helps,

Dave