### PR TITLE
Make sure to call super() in TestCase setUp and tearDown methods.

### DIFF
--- a/djangae/contrib/consistency/tests.py
+++ b/djangae/contrib/consistency/tests.py
@@ -20,6 +20,7 @@ class TestModel(models.Model):
 class ConsistencyTests(TestCase):
 
     def setUp(self):
+        super(ConsistencyTests, self).setUp()
         # Having post-delete signals registered changes the way that django does its delete queries
         # so to avoid causing django tests to fail (which are run as part of the 'testapp' tests in
         # djangae) we only register the consistency signals during our tests
@@ -27,8 +28,7 @@ class ConsistencyTests(TestCase):
 
     def tearDown(self):
         disconnect_signals()
-
-
+        super(ConsistencyTests, self).tearDown()
 
     def test_newly_created_objects_returned(self):
         existing = TestModel.objects.create(name='existing')

--- a/djangae/contrib/gauth/tests.py
+++ b/djangae/contrib/gauth/tests.py
@@ -249,6 +249,8 @@ class CustomPermissionsUserModelBackendTest(TestCase):
         # Fix Django so that we can use our custom user model.
         # TODO: Submit a fix to Django to allow override_settings(AUTH_USER_MODEL='something') to
         # work, even if the project has already set AUTH_USER_MODEL to a custom user
+        super(CustomPermissionsUserModelBackendTest, self).setUp()
+
         GaeDatastoreUser.objects = GaeDatastoreUser._default_manager
         GaeDatastoreUser._base_manager = GaeDatastoreUser._default_manager
         self.user = GaeDatastoreUser.objects.create(

--- a/djangae/contrib/uniquetool/tests.py
+++ b/djangae/contrib/uniquetool/tests.py
@@ -36,6 +36,8 @@ class MapperTests(TestCase):
         if self.i4:
             self.i4.delete()
 
+        super(MapperTests, self).tearDown()
+
     def test_check_ok(self):
         # A check should produce no errors.
         UniqueAction.objects.create(action_type="check", model=encode_model(TestModel))


### PR DESCRIPTION
Hi,

This tidies up a few test cases which weren't calling super() in their setUp or tearDown methods.

Fixes #598.

Dave