### PR TITLE
Simplify auth backend

### DIFF
--- a/djangae/contrib/gauth/common/backends.py
+++ b/djangae/contrib/gauth/common/backends.py
@@ -1,4 +1,5 @@
-import logging
+import warnings
+
 from django.db import transaction
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -15,20 +16,35 @@ from djangae.contrib.gauth.common.models import GaeAbstractBaseUser
 # Backwards compatibility, remove before 1.0
 # This is here so that we only log once on import, not on each authentication
 if hasattr(settings, "ALLOW_USER_PRE_CREATION"):
-    logging.warning(
+    warnings.warn(
         "settings.ALLOW_USER_PRE_CREATION is deprecated, "
-        "please use DJANGAE_ALLOW_USER_PRE_CREATION instead"
+        "please use DJANGAE_CREATE_UNKNOWN_USER instead"
+    )
+
+if hasattr(settings, 'DJANGAE_FORCE_USER_PRE_CREATION'):
+    warnings.warn(
+        'settings.DJANGAE_FORCE_USER_PRE_CREATION is deprecated, please use'
+        ' DJANGAE_CREATE_UNKNOWN_USER instead'
+    )
+
+if hasattr(settings, 'DJANGAE_ALLOW_USER_PRE_CREATION'):
+    warnings.warn(
+        'settings.DJANGAE_ALLOW_USER_PRE_CREATION is deprecated, please use'
+        ' DJANGAE_CREATE_UNKNOWN_USER instead'
     )
 
 
 def should_create_unknown_user():
-    """Returns True if we should create a Django user for unknown users."""
+    """Returns True if we should create a Django user for unknown users.
+
+    Default is False.
+    """
     if hasattr(settings, 'DJANGAE_CREATE_UNKNOWN_USER'):
         return settings.DJANGAE_CREATE_UNKNOWN_USER
 
     if hasattr(settings, 'DJANGAE_FORCE_USER_PRE_CREATION'):
-        # N.B. This setting meant that there had to be an existing user, it
-        # would not create a new user (unless it was an admin).
+        # This setting meant that there _had_ to be an existing user, it would
+        # refuse to create a new user (except for admins).
         return not settings.DJANGAE_FORCE_USER_PRE_CREATION
 
     if hasattr(settings, 'DJANGAE_ALLOW_USER_PRE_CREATION'):

--- a/djangae/contrib/gauth/middleware.py
+++ b/djangae/contrib/gauth/middleware.py
@@ -21,7 +21,7 @@ class AuthenticationMiddleware(DjangoMiddleware):
 
         if django_user.is_anonymous() and google_user:
             # If there is a google user, but we are anonymous, log in!
-            # Note that if DJANGAE_FORCE_USER_PRE_CREATION is True then this may not authenticate
+            # Note that if DJANGAE_CREATE_UNKNOWN_USER=False then this may not authenticate
             django_user = authenticate(google_user=google_user) or AnonymousUser()
             if django_user.is_authenticated():
                 login(request, django_user)

--- a/djangae/contrib/gauth/settings.py
+++ b/djangae/contrib/gauth/settings.py
@@ -6,6 +6,6 @@ AUTHENTICATION_BACKENDS = (
 AUTH_USER_MODEL = 'djangae.GaeDatastoreUser'
 LOGIN_URL = 'djangae_login_redirect'
 
-# This allows you to create User objects for Google-Accounts-based users before they have logged in.
-# When pre-creating a Google user, you must set the `username` to None.  Matching is done by email.
-DJANGAE_ALLOW_USER_PRE_CREATION = False
+# Set this to True to allow unknown Google users to sign in. Matching is done
+# by email. Defaults to False.
+# DJANGAE_CREATE_UNKNOWN_USER = False

--- a/djangae/contrib/gauth/tests.py
+++ b/djangae/contrib/gauth/tests.py
@@ -31,6 +31,7 @@ class BackendTests(TestCase):
         credentials = {'username': 'ted', 'password': 'secret'}
         self.assertRaises(TypeError, backend.authenticate, **credentials)
 
+    @override_settings(DJANGAE_CREATE_UNKNOWN_USER=True)
     def test_authenticate_creates_user_object(self):
         """ If `authenticate` is called with valid credentials then a User object should be created
         """
@@ -46,7 +47,7 @@ class BackendTests(TestCase):
         user2 = backend.authenticate(google_user=google_user)
         self.assertEqual(user.pk, user2.pk)
 
-    @override_settings(ALLOW_USER_PRE_CREATION=True)
+    @override_settings(DJANGAE_CREATE_UNKNOWN_USER=True)
     def test_user_pre_creation(self):
         """ User objects for Google-Accounts-based users should be able to be pre-created in DB and
             then matched by email address when they log in.
@@ -64,7 +65,7 @@ class BackendTests(TestCase):
         self.assertIsNotNone(user.last_login)
         self.assertFalse(user.has_usable_password())
 
-    @override_settings(ALLOW_USER_PRE_CREATION=True)
+    @override_settings(DJANGAE_CREATE_UNKNOWN_USER=True)
     def test_user_id_switch(self):
         """ Users sometimes login with the same email, but a different google user id. We handle those cases by
             blanking out the email on the old user object and creating a new one with the new user id.
@@ -112,6 +113,7 @@ class BackendTests(TestCase):
 class MiddlewareTests(TestCase):
     """ Tests for the AuthenticationMiddleware. """
 
+    @override_settings(DJANGAE_CREATE_UNKNOWN_USER=True)
     def test_login(self):
 
         def _get_current_user():
@@ -144,6 +146,7 @@ class MiddlewareTests(TestCase):
         self.assertEqual(user.email, '1@example.com')
         self.assertEqual(user.username, '111111111100000000001')
 
+    @override_settings(DJANGAE_CREATE_UNKNOWN_USER=True)
     def test_account_switch(self):
         user1 = users.User('1@example.com', _user_id='111111111100000000001')
         user2 = users.User('2@example.com', _user_id='222222222200000000002')
@@ -163,6 +166,7 @@ class MiddlewareTests(TestCase):
 
         self.assertEqual(user2.user_id(), request.user.username)
 
+    @override_settings(DJANGAE_CREATE_UNKNOWN_USER=True)
     def test_user_id_switch(self):
         """ Users sometimes login with the same email, but a different google user id. We handle those cases by
             blanking out the email on the old user object and creating a new one with the new user id.
@@ -210,6 +214,7 @@ class MiddlewareTests(TestCase):
         # and so with pre-creation required, authentication should have failed
         self.assertTrue(isinstance(request.user, AnonymousUser))
 
+    @override_settings(DJANGAE_CREATE_UNKNOWN_USER=True)
     def test_middleware_resaves_email(self):
         # Create user with uppercased email
         email = 'User@example.com'
@@ -349,6 +354,7 @@ class CustomPermissionsUserModelBackendTest(TestCase):
 class SwitchAccountsTests(TestCase):
     """ Tests for the switch accounts functionality. """
 
+    @override_settings(DJANGAE_CREATE_UNKNOWN_USER=True)
     def test_switch_accounts(self):
         gcu = 'djangae.contrib.gauth.middleware.users.get_current_user'
         final_destination = '/death/' # there's no escaping it

--- a/docs/gauth.md
+++ b/docs/gauth.md
@@ -55,7 +55,7 @@ AUTHENTICATION_BACKENDS = (
 If you want to write your own permissions system, but you still want to take advantage of the authentication provided by the Google Users API, then you may want to subclass `djangae.contrib.gauth.common.models.GaeAbstractBaseUser`.
 
 
-## Authentication for Unknown Users
+## Authentication for unknown users
 
 By default Djangae will deny access for unknown users (unless the user is an administrator for the App Engine application).
 

--- a/docs/gauth.md
+++ b/docs/gauth.md
@@ -55,18 +55,16 @@ AUTHENTICATION_BACKENDS = (
 If you want to write your own permissions system, but you still want to take advantage of the authentication provided by the Google Users API, then you may want to subclass `djangae.contrib.gauth.common.models.GaeAbstractBaseUser`.
 
 
+## Authentication for Unknown Users
 
-## User Pre-Creation
+By default Djangae will deny access for unknown users (unless the user is an administrator for the App Engine application).
 
-When using Google Accounts-based authentication, the `username` field of the user model is populated with the `user_id` which is provided by Google Accounts.  This is populated when the user object is created on the user's first log in, and is then used as the authentication check for subsequent log ins.  It is impossible to know what this ID is going to be before the user logs in, which creates an issue if you want to create users and assign permissions to them before they have authenticated.
+Add `DJANGAE_CREATE_UNKNOWN_USER=True` to your settings and Djangae will always grant access (for authenticated Google Accounts users), creating a Django user if one does not exist.
 
-Djangae allows you to pre-create users by specifying their email address.  First, you need to set `DJANGAE_ALLOW_USER_PRE_CREATION` to `True` in settings, and then you can create user objects which have an email address and a `username` of `None`.  Djangae then recognises these as pre-created users, and will populate the `username` with their Google `user_id` when they first log in.
+If there is a Django user with a matching email address and username set to `None` then Djangae will update the Django user, setting the username to the Google user ID. If there is a user with a matching email address and username set to another user ID then Djangae will set the existing user's email address to `None` and create a new Django user.
 
-## Force user Pre-Creation
+App Engine administrators are always granted access, and a Django user will be created if one does not exist.
 
-If you want to prevent creating users for every single Google Account visiting your website, you can allow only pre-created users to be allowed to log in. To enable that you need to set `DJANGAE_FORCE_USER_PRE_CREATION` to `True` in your settings file.
-
-Note: you don't need to pre-create User for GAE user admins.
 
 ## Username/password authentication
 


### PR DESCRIPTION
Hello,

These changes replace the 2 settings for the Google Accounts authentication backend with a new setting `DJANGAE_CREATE_UNKNOWN_USER`, as described in #595 .

One difference is that the new logic will not raise `IntegrityError` when `DJANGAE_CREATE_UNKNOWN_USER=False` and there is an existing user with a matching email address.

The setting is named to be consistent with Django's RemoteUser backend, which has a `create_unknown_user` attribute that controls a similar feature to do with auto-creating user accounts.

David B.
