### PR TITLE
Don't use gettempdir to get the list of possible default tmp

### DIFF
--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -374,7 +374,6 @@ def activate(sandbox_name, add_sdk_to_path=False, new_env_vars=None, **overrides
 
 @contextlib.contextmanager
 def allow_mode_write():
-    import tempfile
     from google.appengine.tools.devappserver2.python import stubs
 
     original_modes = stubs.FakeFile.ALLOWED_MODES
@@ -385,14 +384,13 @@ def allow_mode_write():
     original_dirs = stubs.FakeFile._allowed_dirs
     new_dirs = set(stubs.FakeFile._allowed_dirs)
 
-    try:
-        # If tempfile is available, then allow writing to the tempdir
-        # which is a useful thing to be able to do from the the shell
-        # etc. e.g. this won't work on dev_appserver but will from tests
-        temp_dir = tempfile.gettempdir()
-        new_dirs.add(temp_dir)
-    except NotImplementedError:
-        pass
+    # for some reason when we call gettempdir in some scenarios
+    # (we experience that in ajax call when we tried to render template
+    # with assets) we might end up with thread.error when Python tries
+    # to release the lock. Since we mess with the tempfile in allow_modules
+    # we could - instead of calling gettempdir - simply add default temp
+    # directories.
+    new_dirs.update(['/tmp', '/var/tmp', '/usr/tmp'])
 
     stubs.FakeFile.ALLOWED_MODES = frozenset(new_modes)
     stubs.FakeFile._allowed_dirs = frozenset(new_dirs)


### PR DESCRIPTION
directories.

* for some reason calling gettempdir might end up with thread.error
(somehow we the lock is released too fast). We don't really know why
this is the case, but we suspect changing tempfile module in
`allow_modules` might contribute to that.
* we decided to remove gettempdir completely and provide the list of
default tmp directories directly in `allow_mode_write`.