### PR TITLE
Improvements to CharField (issue #333)

### DIFF
--- a/djangae/core/validators.py
+++ b/djangae/core/validators.py
@@ -1,0 +1,12 @@
+from django.core.validators import BaseValidator
+from django.utils.translation import ungettext_lazy
+
+
+class MaxBytesValidator(BaseValidator):
+    compare = lambda self, a, b: a > b
+    clean = lambda self, x: len(x.encode('utf-8'))
+    message = ungettext_lazy(
+        'Ensure this value has at most %(limit_value)d byte (it has %(show_value)d).',
+        'Ensure this value has at most %(limit_value)d bytes (it has %(show_value)d).',
+        'limit_value')
+    code = 'max_length'

--- a/djangae/fields/__init__.py
+++ b/djangae/fields/__init__.py
@@ -1,5 +1,7 @@
 from djangae.forms.fields import TrueOrNullFormField
+from djangae.core import validators
 from django.utils.translation import ugettext_lazy as _
+from google.appengine.api.datastore_types import _MAX_STRING_LENGTH
 
 from .iterable import *
 from .related import *
@@ -46,3 +48,13 @@ class TrueOrNullField(models.NullBooleanField):
         }
         defaults.update(kwargs)
         return super(TrueOrNullField, self).formfield(**defaults)
+
+
+class CharField(models.CharField):
+
+    def __init__(self, max_length=_MAX_STRING_LENGTH, *args, **kwargs):
+        assert max_length <= _MAX_STRING_LENGTH, \
+            "%ss max_length must not be grater than %d bytes." % (self.__class__.__name__, _MAX_STRING_LENGTH)
+
+        super(CharField, self).__init__(max_length=max_length, *args, **kwargs)
+        self.validators = [validators.MaxBytesValidator(limit_value=max_length)]


### PR DESCRIPTION
- add MaxBytesValidator class
- add custom djangae CharField with max_lenght set to 1500 bytes (current GAE
  limit) by default and MaxBytesValidator added to its validators
- add tests for the new field