### PR TITLE
Fixed weird regression issue with JSONField.

### DIFF
--- a/djangae/fields/json.py
+++ b/djangae/fields/json.py
@@ -78,7 +78,7 @@ class JSONField(models.TextField):
     def __init__(self, use_ordered_dict=False, *args, **kwargs):
         default = kwargs.get('default', None)
         if default is None:
-            kwargs['default'] = '{}'
+            kwargs['default'] = {}
         elif isinstance(default, (list, dict)):
             kwargs['default'] = dumps(default)
 
@@ -125,6 +125,6 @@ class JSONField(models.TextField):
 
     def deconstruct(self):
         name, path, args, kwargs = super(JSONField, self).deconstruct()
-        if self.default == '{}':
+        if self.default == {}:
             del kwargs['default']
         return name, path, args, kwargs

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -766,6 +766,15 @@ class JSONFieldModelTests(TestCase):
         test_instance = JSONFieldModel.objects.get()
         self.assertEqual(test_instance.json_field['test'], 0.1)
 
+    def test_defaults_are_handled_as_pythonic_data_structures(self):
+        """ Tests that default values are handled as python data structures and
+            not as strings. This seems to be a regression after changes were
+            made to remove Subfield from the JSONField and simply use TextField
+            instead.
+        """
+        thing = JSONFieldModel()
+        self.assertEqual(thing.json_field, {})
+
 
 class ModelWithCharField(models.Model):
     char_field_with_max = CharField(max_length=10, default='', blank=True)


### PR DESCRIPTION
Fixed weird regression issue with JSONField that meant that defaults were being returned as strings '{}' instead of python data structs as they were before the move away from the Subfield meta class inheritance. Not entirely sure if this is the correct fix, but thought I would give it a whirl and at least give the issue better visibility with some sample code and tests. With this fix in place and my test, all tests are passing minus the one that was failing before I made any changes. :)