### PR TITLE
JSONField fix after removing SubfieldBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Renamed `AppEngineUserAPI` to `AppEngineUserAPIBackend`
 
 ### Bug fixes:
+- JSONField fixes after removing SubfieldBase dependency - to_python added and default value not converted to string anymore
 - Special indexing now works on fields that are primary keys too
 - Fixed a bug with special indexing of datetime fields, that now allows for `__year` or `__month` lookups
 - Allow serializing queries containing non-ascii characters

--- a/djangae/fields/json.py
+++ b/djangae/fields/json.py
@@ -80,14 +80,14 @@ class JSONField(models.TextField):
         if default is None:
             kwargs['default'] = {}
         elif isinstance(default, (list, dict)):
-            kwargs['default'] = dumps(default)
+            kwargs['default'] = default
 
         # use `collections.OrderedDict` rather than built-in `dict`
         self.use_ordered_dict = use_ordered_dict
 
         models.TextField.__init__(self, *args, **kwargs)
 
-    def from_db_value(self, value, expression, connection, context):
+    def parse_json(self, value):
         """Convert our string value to JSON after we load it from the DB"""
         if value is None or value == '':
             return {}
@@ -107,6 +107,12 @@ class JSONField(models.TextField):
             return res
         else:
             return value
+
+    def to_python(self, value):
+        return self.parse_json(value)
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.parse_json(value)
 
     def get_db_prep_save(self, value, connection, **kwargs):
         """Convert our JSON object to a string before we save"""

--- a/djangae/fields/json.py
+++ b/djangae/fields/json.py
@@ -78,7 +78,7 @@ class JSONField(models.TextField):
     def __init__(self, use_ordered_dict=False, *args, **kwargs):
         default = kwargs.get('default', None)
         if default is None:
-            kwargs['default'] = '{}'
+            kwargs['default'] = {}
         elif isinstance(default, (list, dict)):
             kwargs['default'] = dumps(default)
 
@@ -125,6 +125,6 @@ class JSONField(models.TextField):
 
     def deconstruct(self):
         name, path, args, kwargs = super(JSONField, self).deconstruct()
-        if self.default == '{}':
+        if self.default == {}:
             del kwargs['default']
         return name, path, args, kwargs

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -766,6 +766,15 @@ class JSONFieldModelTests(TestCase):
         test_instance = JSONFieldModel.objects.get()
         self.assertEqual(test_instance.json_field['test'], 0.1)
 
+    def test_defaults_are_handled_as_pythonic_data_structures(self):
+        """ Tests that default values are handled as python data structures and
+            not as strings. This seems to be a regression after changes were
+            made to remove Subfield from the JSONField and simply use TextField
+            instead.
+        """
+        thing = JSONFieldModel()
+        self.assertEqual(thing.json_field, {})
+
 
 class ModelWithCharField(models.Model):
     char_field_with_max = CharField(max_length=10, default='', blank=True)

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -124,6 +124,10 @@ class JSONFieldModel(models.Model):
     json_field = JSONField(use_ordered_dict=True)
 
 
+class JSONFieldWithDefaultModel(models.Model):
+    json_field = JSONField(use_ordered_dict=True, default={})
+
+
 class ShardedCounterTest(TestCase):
     def test_basic_usage(self):
         instance = ModelWithCounter.objects.create()
@@ -773,6 +777,15 @@ class JSONFieldModelTests(TestCase):
             instead.
         """
         thing = JSONFieldModel()
+        self.assertEqual(thing.json_field, {})
+
+    def test_default_value_correctly_handled_as_data_structure(self):
+        """ Test that default value - if provided is not transformed into
+            string anymore. Previously we needed string, since we used
+            SubfieldBase in JSONField. Since it is now deprecated we need
+            to change handling of default value.
+        """
+        thing = JSONFieldWithDefaultModel()
         self.assertEqual(thing.json_field, {})
 
 


### PR DESCRIPTION
After commit ad9de1c4ab7495c4dfa5fb2b3f110cb28446c256 and removing any references to deprecated `SubfieldBase` in `JSONField` we ended up with the problem of incorrect default value. We cannot provide it as a string anymore, so we removed dumping the value and made sure that we provide `{}` if the default value is not provided. 

We also implement `to_python` method, since Django documentation states it is necessary for more complicated custom fields anyway.