### PR TITLE
Alias Django's db exceptions to djangae.db.backends.appengine.dbapi.

### DIFF
--- a/djangae/db/backends/appengine/dbapi.py
+++ b/djangae/db/backends/appengine/dbapi.py
@@ -1,34 +1,24 @@
 """ Fake DB API 2.0 for App engine """
+from django.db import utils
 
-class DatabaseError(Exception):
-    pass
 
-class IntegrityError(DatabaseError):
-    pass
+DatabaseError = utils.DatabaseError
+DataError = utils.DataError
+IntegrityError = utils.IntegrityError
+InterfaceError = utils.InterfaceError
+InternalError = utils.InternalError
+NotSupportedError = utils.NotSupportedError
+OperationalError = utils.OperationalError
+ProgrammingError = utils.ProgrammingError
 
-class NotSupportedError(Exception):
-    pass
 
 class CouldBeSupportedError(NotSupportedError):
     pass
 
-class DataError(DatabaseError):
-    pass
-
-class OperationalError(DatabaseError):
-    pass
-
-class InternalError(DatabaseError):
-    pass
-
-class ProgrammingError(DatabaseError):
-    pass
-
-class InterfaceError(DatabaseError):
-    pass
 
 def Binary(val):
     return val
+
 
 Error = DatabaseError
 Warning = DatabaseError


### PR DESCRIPTION
Djangae raises its own IntegrityError in at least one place, which is
not the same as Django's IntegrityError, so this change makes them
the same error class.

This does change the exception hierarchy of some errors. Specifically
NotSupportedError, DatabaseError and InterfaceError now have different
super-classes.