### PR TITLE
Improve unique constraints

### DIFF
--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -908,7 +908,7 @@ class InsertCommand(object):
             @db.transactional(xg=len(entities) > 1)
             def txn():
                 results = []
-                for key, ent in zip(keys, entities):
+                for key in keys:
                     if check_existence and key is not None:
                         if utils.key_exists(key):
                             raise IntegrityError("Tried to INSERT with existing key")

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -885,7 +885,7 @@ class InsertCommand(object):
     def execute(self):
         check_existence = self.has_pk and not has_concrete_parents(self.model)
 
-        if not constraints.constraint_checks_enabled(self.model) and not check_existence:
+        if not constraints.has_active_unique_constraints(self.model) and not check_existence:
             # Fast path, no constraint checks and no keys mean we can just do a normal datastore.Put
             results = datastore.Put(self.entities)
             caching.add_entities_to_cache(
@@ -1000,7 +1000,7 @@ class DeleteCommand(object):
 
         self.select.execute()
 
-        constraints_enabled = constraints.constraint_checks_enabled(self.model)
+        constraints_enabled = constraints.has_active_unique_constraints(self.model)
         keys = [ x.key() for x in self.select.results ]
 
         def wipe_polymodel_from_entity(entity, db_table):
@@ -1141,7 +1141,7 @@ class UpdateCommand(object):
         if POLYMODEL_CLASS_ATTRIBUTE in result:
             result[POLYMODEL_CLASS_ATTRIBUTE] = list(set(result[POLYMODEL_CLASS_ATTRIBUTE]))
 
-        if not constraints.constraint_checks_enabled(self.model):
+        if not constraints.has_active_unique_constraints(self.model):
             # The fast path, no constraint checking
             datastore.Put(result)
             caching.add_entities_to_cache(

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -156,11 +156,14 @@ def acquire(model, entity):
 
 
 def release_markers(markers):
-    @db.transactional(propagation=TransactionOptions.INDEPENDENT)
-    def delete(marker):
-        Delete(marker.key())
+    @db.transactional(propagation=TransactionOptions.INDEPENDENT, xg=True)
+    def delete_markers(markers):
+        Delete([marker.key() for marker in markers])
 
-    [delete(x) for x in markers]
+    to_delete = markers[:]
+    while to_delete:
+        delete_markers(to_delete[:25])
+        to_delete = to_delete[25:]
 
 
 def release_identifiers(identifiers, namespace):

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -100,7 +100,7 @@ def _acquire_identifiers(identifiers, entity_key):
                 raise IntegrityError("Unique constraint violation for kind {} on fields: {}".format(table_name, ", ".join(fields)))
         else:
             # The marker is ours anyway
-            markers.append(marker)
+            markers.append(existing_marker)
 
     db.put(markers_to_create)
     return markers + markers_to_create

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -137,19 +137,6 @@ def update_instance_on_markers(entity, markers):
     update_all()
 
 
-def acquire_bulk(model, entities):
-    markers = []
-    try:
-        for entity in entities:
-            markers.append(acquire(model, entity))
-
-    except:
-        for m in markers:
-            release_markers(m)
-        raise
-    return markers
-
-
 def acquire(model, entity):
     """
         Given a model and entity, this tries to acquire unique marker locks for the instance. If the locks already exist

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -18,7 +18,8 @@ DJANGAE_LOG = logging.getLogger("djangae")
 
 def has_active_unique_constraints(model_or_instance):
     """
-        Returns true if constraint checking is enabled on the model
+        Returns true if the model/instance has unique fields or unique_together fields and unique
+        constraint checking is enabled on the model
     """
 
     django_opts = getattr(model_or_instance, "_meta", None)
@@ -168,6 +169,9 @@ def release_markers(markers):
     while to_delete:
         delete_markers(to_delete[:25])
         to_delete = to_delete[25:]
+    """ Delete the given UniqueMarker objects. """
+    # Note that these should all be from the same Django model instance, and therefore there should
+    # be a maximum of 25 of them (because everything blows up if you have more than that - limitation)
 
 
 def release_identifiers(identifiers, namespace):
@@ -182,6 +186,7 @@ def release_identifiers(identifiers, namespace):
 
 
 def release(model, entity):
+    """ Delete the UniqueMarker objects for the given entity. """
     identifiers = unique_identifiers_from_entity(model, entity, ignore_pk=True)
     # Key.from_path expects None for an empty namespace, but Key.namespace() returns ''
     namespace = entity.key().namespace() or None

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -60,6 +60,10 @@ class UniqueMarker(db.Model):
         return "_djangae_unique_marker"
 
 
+# If a marker doesn't have an instance for longer than this time period then
+# it is ignored by uniqueness checks
+UNOWNED_MARKER_TIMEOUT_IN_SECONDS = 5
+
 def acquire_identifiers(identifiers, entity_key):
     def acquire_marker(identifier):
         # Key.from_path expects None for an empty namespace, but Key.namespace() returns ''
@@ -70,7 +74,7 @@ def acquire_identifiers(identifiers, entity_key):
         if marker:
             # If the marker instance is None, and the marker is older then 5 seconds then we wipe it out
             # and assume that it's stale.
-            if not marker.instance and (datetime.datetime.utcnow() - marker.created).seconds > 5:
+            if not marker.instance and (datetime.datetime.utcnow() - marker.created).seconds > UNOWNED_MARKER_TIMEOUT_IN_SECONDS:
                 marker.delete()
             elif marker.instance and marker.instance != entity_key and key_exists(marker.instance):
                 fields_and_values = identifier.split("|")

--- a/djangae/tests/test_caching.py
+++ b/djangae/tests/test_caching.py
@@ -442,8 +442,9 @@ class MemcacheCachingTests(TestCase):
                 CachingTestModel(field1="Banana", comb1=2, comb2="Cherry"),
                 CachingTestModel(field1="Orange", comb1=3, comb2="Cherry"),
             ])
-        self.assertEqual(set_many_2.call_count, 1)
-        self.assertEqual(len(set_many_2.calls[0].args[1]), 3*2)
+        self.assertEqual(set_many_2.call_count, 2)
+        self.assertEqual(len(set_many_2.calls[0].args[1]), 3)
+        self.assertEqual(len(set_many_2.calls[1].args[1]), 3)
 
         pks = list(CachingTestModel.objects.values_list('pk', flat=True))
         with sleuth.watch("djangae.db.backends.appengine.caching.KeyPrefixedClient.set_multi_async") as set_many_3:

--- a/djangae/tests/test_caching.py
+++ b/djangae/tests/test_caching.py
@@ -141,6 +141,7 @@ class MemcacheCachingTests(TestCase):
         )
 
         instance = CachingTestModel.objects.create(id=222, **entity_data)
+        instance.refresh_from_db() # Adds to memcache (consistent Get)
 
         for identifier in identifiers:
             self.assertEqual(entity_data, cache.get(identifier))
@@ -176,6 +177,7 @@ class MemcacheCachingTests(TestCase):
             self.assertIsNone(cache.get(identifier))
 
         instance = CachingTestModel.objects.create(id=222, **entity_data)
+        instance.refresh_from_db()
 
         for identifier in identifiers:
             self.assertEqual(entity_data, cache.get(identifier))
@@ -208,6 +210,7 @@ class MemcacheCachingTests(TestCase):
             self.assertIsNone(cache.get(identifier))
 
         instance = CachingTestModel.objects.create(id=222, **entity_data)
+        instance.refresh_from_db() # Add to memcache (consistent Get)
 
         for identifier in identifiers:
             self.assertEqual(entity_data, cache.get(identifier))
@@ -235,6 +238,7 @@ class MemcacheCachingTests(TestCase):
             self.assertIsNone(cache.get(identifier))
 
         instance = CachingTestModel.objects.create(id=222, **entity_data)
+        instance.refresh_from_db() # Add to memcache (consistent Get)
 
         for identifier in identifiers:
             self.assertEqual("old", cache.get(identifier)["field1"])
@@ -268,7 +272,8 @@ class MemcacheCachingTests(TestCase):
         for identifier in identifiers:
             self.assertIsNone(cache.get(identifier))
 
-        CachingTestModel.objects.create(id=222, **entity_data)
+        instance = CachingTestModel.objects.create(id=222, **entity_data)
+        instance.refresh_from_db() # Add to memcache (consistent Get)
 
         for identifier in identifiers:
             self.assertEqual(entity_data, cache.get(identifier))
@@ -299,7 +304,8 @@ class MemcacheCachingTests(TestCase):
         for identifier in identifiers:
             self.assertIsNone(cache.get(identifier))
 
-        CachingTestModel.objects.create(id=222, **entity_data)
+        instance = CachingTestModel.objects.create(id=222, **entity_data)
+        instance.refresh_from_db() # Add to memcache (consistent Get)
 
         for identifier in identifiers:
             self.assertEqual(entity_data, cache.get(identifier))
@@ -323,6 +329,7 @@ class MemcacheCachingTests(TestCase):
         }
 
         original = CachingTestModel.objects.create(**entity_data)
+        original.refresh_from_db()
 
         with sleuth.watch("google.appengine.api.datastore.Query.Run") as datastore_query:
             instance = CachingTestModel.objects.filter(field1="Apple").all()[0]
@@ -368,7 +375,7 @@ class MemcacheCachingTests(TestCase):
         }
 
         original = CachingTestModel.objects.create(**entity_data)
-
+        original.refresh_from_db() # Add to memcache (consistent Get)
 
         with sleuth.watch("google.appengine.api.datastore.Get") as datastore_get:
             instance = CachingTestModel.objects.get(pk=original.pk)
@@ -402,6 +409,7 @@ class MemcacheCachingTests(TestCase):
         }
 
         original = CachingTestModel.objects.create(**entity_data)
+        original.refresh_from_db()
 
         with sleuth.watch("google.appengine.api.datastore.Get") as datastore_get:
             instance = CachingTestModel.objects.get(field1="Apple")
@@ -432,19 +440,17 @@ class MemcacheCachingTests(TestCase):
     @disable_cache(memcache=False, context=True)
     def test_bulk_cache(self):
         with sleuth.watch("djangae.db.backends.appengine.caching.KeyPrefixedClient.set_multi_async") as set_many_1:
-            CachingTestModel.objects.create(field1="Apple", comb1=1, comb2="Cherry")
+            instance = CachingTestModel.objects.create(field1="Apple", comb1=1, comb2="Cherry")
+            instance.refresh_from_db()
 
         self.assertEqual(set_many_1.call_count, 1)
         self.assertEqual(len(set_many_1.calls[0].args[1]), 3)
 
-        with sleuth.watch("djangae.db.backends.appengine.caching.KeyPrefixedClient.set_multi_async") as set_many_2:
-            CachingTestModel.objects.bulk_create([
-                CachingTestModel(field1="Banana", comb1=2, comb2="Cherry"),
-                CachingTestModel(field1="Orange", comb1=3, comb2="Cherry"),
-            ])
-        self.assertEqual(set_many_2.call_count, 2)
-        self.assertEqual(len(set_many_2.calls[0].args[1]), 3)
-        self.assertEqual(len(set_many_2.calls[1].args[1]), 3)
+        CachingTestModel.objects.bulk_create([
+            CachingTestModel(field1="Banana", comb1=2, comb2="Cherry"),
+            CachingTestModel(field1="Orange", comb1=3, comb2="Cherry"),
+        ])
+
 
         pks = list(CachingTestModel.objects.values_list('pk', flat=True))
         with sleuth.watch("djangae.db.backends.appengine.caching.KeyPrefixedClient.set_multi_async") as set_many_3:

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -762,7 +762,9 @@ class CacheTests(TestCase):
 
 
 def compare_markers(list1, list2):
-    return sorted([x.key() for x in list1]) == sorted([x.key() for x in list2])
+    return (
+        sorted([(x.key(), x.instance) for x in list1]) == sorted([(x.key(), x.instance) for x in list2])
+    )
 
 
 class ConstraintTests(TestCase):

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -50,6 +50,7 @@ Here is a brief list of hard limitations you may encounter when using the Djanga
  - Transactions.  The Datastore has transactions, but they are not "normal" transactions in the SQL sense. [Transactions
   should be done using djangae.db.transactional.atomic](db_backend.md#transactions).
 - If unique constraints are enabled, then you are limited to a maximum of 25 unique or unique_together constraints per model (see [Unique Constraint Checking](#unique-constraint-checking)).
+- You are also restricted to altering 12 unique field values on an instance in a single save
 
 There are probably more but the list changes regularly as we improve the datastore backend. If you find another limitation not
 mentioned above please consider sending a documentation PR.

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -29,20 +29,29 @@ Here's the full list of magic:
 
 Due to the limitations of the App Engine Datastore (it being a non-relational database for a start), there are some
 things which you still can't do with the Django ORM when using the djangae backend.  The easiest way to find these out
-is to just build your app and look out for the `NotSupportedError` exceptions.  But if you don't like surprises, here's
-a quick list:
+is to just build your app and look out for the `NotSupportedError` exceptions.
 
-* `ManyToManyField` - a non-relational database simply can't do these (or not efficiently).  However, you can probably
-  solve these kind of problems using djangae's `ListField`.  We may even create a many-to-many replacement based on
-  that in the future.
-* Use `F` objects when filtering, e.g. `qs.filter(this=F('that'))`. This is a limitation of the Datastore. Additionally,
-  you cannot use `F` objects when updating a model - but this will change soon.
-* `__in` queries with more than 30 values.  This is a limitation of the Datastore.  You can filter for up to 500 values
-  on the primary key field though.
-* More than one inequality filter, i.e. you can't do `.exclude(a=1, b=2)`.  This is a limitation of the Datastore.
-* Transactions.  The Datastore has transactions, but they are not "normal" transactions in the SQL sense. [Transactions
+### Notable Limitations
+
+Here is a brief list of hard limitations you may encounter when using the Djangae datastore backend:
+
+ - `bulk_create()` is limited to 25 instances if the model has active unique constraints, or the instances being inserted have
+   the primary key specified. In other cases the limit is 1000.
+ - `filter(field__in=[...])` queries are limited to 30 entries in the list if `field` is not the primary key
+ - `filter(pk__in=[...])` queries are limited to 1000 entries
+ - You are limited to a single inequality filter per query, although excluding by primary key is not included in this count
+ - Queries without primary key equality filters are not allowed within an `atomic` block
+ - Queries with an inequality filter on a field must be ordered first by that field
+ - Only 25 individual instances can be retrieved or saved within an `atomic` block, although you can get/save the same entity
+   multiple times without increasing the allowed count
+ - Primary key values of zero are not allowed
+ - Primary key string values must not start with a leading double underscore (`__`)
+ - `ManyToManyField` will not work reliably/efficiently - use `RelatedSetField` or `RelatedListField` instead
+ - Transactions.  The Datastore has transactions, but they are not "normal" transactions in the SQL sense. [Transactions
   should be done using djangae.db.transactional.atomic](db_backend.md#transactions).
 
+There are probably more but the list changes regularly as we improve the datastore backend. If you find another limitation not
+mentioned above please consider sending a documentation PR.
 
 ## Other Considerations
 

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -49,6 +49,7 @@ Here is a brief list of hard limitations you may encounter when using the Djanga
  - `ManyToManyField` will not work reliably/efficiently - use `RelatedSetField` or `RelatedListField` instead
  - Transactions.  The Datastore has transactions, but they are not "normal" transactions in the SQL sense. [Transactions
   should be done using djangae.db.transactional.atomic](db_backend.md#transactions).
+- If unique constraints are enabled, then you are limited to a maximum of 25 unique or unique_together constraints per model (see [Unique Constraint Checking](#unique-constraint-checking)).
 
 There are probably more but the list changes regularly as we improve the datastore backend. If you find another limitation not
 mentioned above please consider sending a documentation PR.
@@ -199,9 +200,10 @@ Unique constraint checks have the following caveats...
  - Unique constraints drastically increase your datastore writes. Djangae needs to create a marker for each unique constraint on each model, for each instance. This means if you have
    one unique field on your model, and you save() Djangae must do two datastore writes (one for the entity, one for the marker)
  - Unique constraints increase your datastore reads. Each time you save an object, Djangae needs to check for the existence of unique markers.
- - Unique constraints slow down your saves(). See above, each time you write a bunch of stuff needs to happen.
+ - Unique constraints slow down your saves(). See above, each time you save, a bunch of stuff needs to happen.
  - Updating instances via the datastore API (NDB, DB, or datastore.Put and friends) will break your unique constraints. Don't do that!
- - Updating instances via the datastore admin will do the same thing, you'll be bypassing the unique marker creation
+ - Updating instances via the datastore admin will do the same thing, you'll be bypassing the unique marker creation.
+ - There is a limit of 25 unique or unique_together constraints per model.
 
 However, unique markers are very powerful when you need to enforce uniqueness. **They are enabled by default** simply because that's the behaviour that Django expects. If you don't want to
 use this functionality, you have the following options:


### PR DESCRIPTION
This PR does the following:

 - Improves performance of inserts by performing fewer RPC calls
 - Improves the performance of constraints by updating markers in xg transactions, which could potentially also fix race conditions
 - Limits bulk inserts to the max-entity-groups per transaction value if there are unique constraints or pre-defined primary keys. This is necessary for reliable behaviour on failure (to prevent some entities being committed and others not). If you need to bulk_create more then either don't specify keys, disable unique constraints, or bulk create in a loop and handle any errors appropriately.
 - Doesn't cache in memcache on insert, only in the context cache - this is to prevent potential inconsistencies between what's in the datastore vs what's in memcache
 - Fixes a bug where the instance on a constraint marker wasn't appropriately set on insert