### PR TITLE
Disallow dict list default

### DIFF
--- a/djangae/fields/json.py
+++ b/djangae/fields/json.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 
 from django.db import models
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 from django.core.serializers.json import DjangoJSONEncoder
 
@@ -77,10 +78,11 @@ class JSONField(models.TextField):
 
     def __init__(self, use_ordered_dict=False, *args, **kwargs):
         default = kwargs.get('default', None)
+
         if default is None:
             kwargs['default'] = dict
         elif isinstance(default, (list, dict)):
-            kwargs['default'] = default
+            raise ImproperlyConfigured("You want to specify 'list' or 'dict' as a callable not [] or {}")
 
         # use `collections.OrderedDict` rather than built-in `dict`
         self.use_ordered_dict = use_ordered_dict

--- a/djangae/fields/json.py
+++ b/djangae/fields/json.py
@@ -76,12 +76,11 @@ class JSONField(models.TextField):
     JSON objects seamlessly.  Main thingy must be a dict object."""
 
     def __init__(self, use_ordered_dict=False, *args, **kwargs):
-        default = kwargs.get('default', None)
-
-        if default is None:
+        if 'default' in kwargs:
+            if not callable(kwargs['default']):
+                raise TypeError("'default' must be a callable (e.g. 'dict' or 'list')")
+        else:
             kwargs['default'] = dict
-        elif not callable(default):
-            raise TypeError("default must be None or a callable (e.g. 'dict' or 'list')")
 
         # use `collections.OrderedDict` rather than built-in `dict`
         self.use_ordered_dict = use_ordered_dict

--- a/djangae/fields/json.py
+++ b/djangae/fields/json.py
@@ -81,7 +81,7 @@ class JSONField(models.TextField):
 
         if default is None:
             kwargs['default'] = dict
-        elif isinstance(default, (list, dict)):
+        elif not callable(default):
             raise ImproperlyConfigured("You want to specify 'list' or 'dict' as a callable not [] or {}")
 
         # use `collections.OrderedDict` rather than built-in `dict`

--- a/djangae/fields/json.py
+++ b/djangae/fields/json.py
@@ -82,7 +82,7 @@ class JSONField(models.TextField):
         if default is None:
             kwargs['default'] = dict
         elif not callable(default):
-            raise ImproperlyConfigured("You want to specify 'list' or 'dict' as a callable not [] or {}")
+            raise ImproperlyConfigured("default must be None or a callable (e.g. 'dict' or 'list')")
 
         # use `collections.OrderedDict` rather than built-in `dict`
         self.use_ordered_dict = use_ordered_dict

--- a/djangae/fields/json.py
+++ b/djangae/fields/json.py
@@ -19,7 +19,6 @@ from collections import OrderedDict
 
 from django.db import models
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 from django.core.serializers.json import DjangoJSONEncoder
 
@@ -82,7 +81,7 @@ class JSONField(models.TextField):
         if default is None:
             kwargs['default'] = dict
         elif not callable(default):
-            raise ImproperlyConfigured("default must be None or a callable (e.g. 'dict' or 'list')")
+            raise TypeError("default must be None or a callable (e.g. 'dict' or 'list')")
 
         # use `collections.OrderedDict` rather than built-in `dict`
         self.use_ordered_dict = use_ordered_dict

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -125,7 +125,7 @@ class JSONFieldModel(models.Model):
 
 
 class JSONFieldWithDefaultModel(models.Model):
-    json_field = JSONField(use_ordered_dict=True, default={})
+    json_field = JSONField(use_ordered_dict=True)
 
 
 class ShardedCounterTest(TestCase):


### PR DESCRIPTION
This protects against the easy "default={}" mistake which causes multiple instances to reference the same dictionary.