### PR TITLE
Flip the default for create_unknown_user so that it matches old behav…

### DIFF
--- a/djangae/contrib/gauth/common/backends.py
+++ b/djangae/contrib/gauth/common/backends.py
@@ -37,7 +37,9 @@ if hasattr(settings, 'DJANGAE_ALLOW_USER_PRE_CREATION'):
 def should_create_unknown_user():
     """Returns True if we should create a Django user for unknown users.
 
-    Default is False.
+    Default is True unless DJANGAE_CREATE_UNKNOWN_USER is set to False
+
+    Other settings listed here are for backwards compatibility.
     """
     if hasattr(settings, 'DJANGAE_CREATE_UNKNOWN_USER'):
         return settings.DJANGAE_CREATE_UNKNOWN_USER
@@ -53,7 +55,7 @@ def should_create_unknown_user():
     if hasattr(settings, 'ALLOW_USER_PRE_CREATION'):
         return settings.ALLOW_USER_PRE_CREATION
 
-    return False
+    return True
 
 
 class BaseAppEngineUserAPIBackend(ModelBackend):


### PR DESCRIPTION
…iour

It seems that we flipped over the default by accident. The logic for making creating unknown users the default is that you would have already sent the user around the Google auth loop at this point and if you've done that you'll probably want a user at the end of it.