### PR TITLE
Adds ability to override the application to run remote commands against.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### New features & improvements:
 
-- Cleaned up and refactored internal implementation of SimulatedContentTypeManager. Now also allows patching ContentType manager in migrations. 
--
+- Cleaned up and refactored internal implementation of SimulatedContentTypeManager. Now also allows patching ContentType manager in migrations.
+- Add ability to specify GAE target instance for remote command with `--app_id` flag
 
 ### Bug fixes:
 

--- a/djangae/core/management/__init__.py
+++ b/djangae/core/management/__init__.py
@@ -56,8 +56,12 @@ def execute_from_command_line(argv=None, **sandbox_overrides):
     parser = argparse.ArgumentParser(prog='manage.py')
     parser.add_argument(
         '--sandbox', default=sandbox.LOCAL, choices=sandbox.SANDBOXES.keys())
+    parser.add_argument('--application', default=None, help='APPLICATION ID')
     parser.add_argument('args', nargs=argparse.REMAINDER)
     namespace = parser.parse_args(argv[1:])
+
+    # if namespace.application:
+    sandbox_overrides['app_id'] = namespace.application
 
     overrides = DJANGO_DEFAULTS
     overrides.update(sandbox_overrides)

--- a/djangae/core/management/__init__.py
+++ b/djangae/core/management/__init__.py
@@ -56,12 +56,12 @@ def execute_from_command_line(argv=None, **sandbox_overrides):
     parser = argparse.ArgumentParser(prog='manage.py')
     parser.add_argument(
         '--sandbox', default=sandbox.LOCAL, choices=sandbox.SANDBOXES.keys())
-    parser.add_argument('--application', default=None, help='APPLICATION ID')
+    parser.add_argument('--app_id', default=None, help='GAE APPLICATION ID')
     parser.add_argument('args', nargs=argparse.REMAINDER)
     namespace = parser.parse_args(argv[1:])
 
     # if namespace.application:
-    sandbox_overrides['app_id'] = namespace.application
+    sandbox_overrides['app_id'] = namespace.app_id
 
     overrides = DJANGO_DEFAULTS
     overrides.update(sandbox_overrides)

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -255,7 +255,7 @@ _OPTIONS = None
 _CONFIG = None
 
 @contextlib.contextmanager
-def activate(sandbox_name, add_sdk_to_path=False, new_env_vars=None, **overrides):
+def activate(sandbox_name, add_sdk_to_path=False, new_env_vars=None, app_id=None, **overrides):
     """Context manager for command-line scripts started outside of dev_appserver.
 
     :param sandbox_name: str, one of 'local', 'remote' or 'test'
@@ -363,7 +363,10 @@ def activate(sandbox_name, add_sdk_to_path=False, new_env_vars=None, **overrides
 
         setattr(options, option, overrides[option])
 
-    configuration = application_configuration.ApplicationConfiguration(options.config_paths)
+    if app_id:
+        configuration = application_configuration.ApplicationConfiguration(options.config_paths, app_id=app_id)
+    else:
+        configuration = application_configuration.ApplicationConfiguration(options.config_paths)
 
     # Enable built-in libraries from app.yaml without enabling the full sandbox.
     module = configuration.modules[0]

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -25,8 +25,12 @@ Then run your management command specifying the `remote` sandbox.  Note that the
 
     ./manage.py --sandbox=remote shell
 
-
 This will use your **local** Python code, but all database operations will be performed on the remote Datastore.
+
+Additionally, you can specify the application to run commands against by providing an `--app_id`. Eg
+
+  ./manage.py --sandbox=remote --app_id=myapp shell  # Starts a remote shell with the "myapp" instance
+
 
 ### Deferring Tasks Remotely
 
@@ -36,6 +40,3 @@ App Engine tasks are stored in the Datastore, so when you are in the remote shel
     >>> from my_code import my_function
     >>> from google.appengine.ext.deferred import defer
     >>> defer(my_function, arg1, arg2, _queue="queue_name")
-
-
-


### PR DESCRIPTION
Additional arg `--application` to override the application used in app.yaml, or where app.yaml does not specify an application. 