### PR TITLE
Use positional arguments to logging calls instead of formatting.

### DIFF
--- a/djangae/contrib/mappers/readers.py
+++ b/djangae/contrib/mappers/readers.py
@@ -54,7 +54,7 @@ class DjangoInputReader(input_readers.InputReader):
 
         # Grab the input parameters for the split
         params = input_readers._get_params(mapper_spec)
-        logging.info("Params: %s" % params)
+        logging.info("Params: %r", params)
 
         db = params['db']
         # Unpickle the query
@@ -75,7 +75,7 @@ class DjangoInputReader(input_readers.InputReader):
 
         pk_range = last_id - first_id
 
-        logging.info("Query range: %s - %s = %s" % (first_id, last_id, pk_range))
+        logging.info("Query range: %s - %s = %s", first_id, last_id, pk_range)
 
         if pk_range < shard_count or shard_count == 1:
             return [DjangoInputReader(first_id-1, last_id, params['model'], db=db)]
@@ -98,7 +98,7 @@ class DjangoInputReader(input_readers.InputReader):
             if shard_end_id > last_id:
                 shard_end_id = last_id
 
-            logging.info("Creating shard: %s - %s" % (shard_start_id, shard_end_id))
+            logging.info("Creating shard: %s - %s", shard_start_id, shard_end_id)
             reader = DjangoInputReader(shard_start_id, shard_end_id, params['model'], db=db)
             reader.shard_id = shard_id
             readers.append(reader)

--- a/djangae/contrib/security/middleware.py
+++ b/djangae/contrib/security/middleware.py
@@ -79,7 +79,7 @@ def _HttpUrlLoggingWrapper(func):
             arg_value = get_default_argument(func, 'url')
 
         if arg_value and not arg_value.startswith('https://'):
-            logging.warn('SECURITY : fetching non-HTTPS url %s' % (arg_value))
+            logging.warn('SECURITY : fetching non-HTTPS url %r', arg_value)
         return func(*args, **kwargs)
     return _CheckAndLog
 

--- a/djangae/contrib/uniquetool/models.py
+++ b/djangae/contrib/uniquetool/models.py
@@ -239,7 +239,7 @@ class CleanMapper(RawMapperMixin, MapReduceTask):
             try:
                 instance = model.objects.using(alias).get(pk=instance_id)
             except model.DoesNotExist:
-                logging.info("Deleting unique marker {} because the associated instance no longer exists".format(entity.key().id_or_name()))
+                logging.info("Deleting unique marker %s because the associated instance no longer exists", entity.key().id_or_name())
                 datastore.Delete(entity)
                 return
 
@@ -248,5 +248,5 @@ class CleanMapper(RawMapperMixin, MapReduceTask):
             identifiers = unique_identifiers_from_entity(model, instance_entity, ignore_pk=True)
             identifier_keys = [datastore.Key.from_path(UniqueMarker.kind(), i, namespace=entity["instance"].namespace()) for i in identifiers]
             if entity.key() not in identifier_keys:
-                logging.info("Deleting unique marker {} because the it no longer represents the associated instance state".format(entity.key().id_or_name()))
+                logging.info("Deleting unique marker %s because the it no longer represents the associated instance state", entity.key().id_or_name())
                 datastore.Delete(entity)

--- a/djangae/db/backends/appengine/indexing.py
+++ b/djangae/db/backends/appengine/indexing.py
@@ -46,7 +46,7 @@ def load_special_indexes():
     _special_indexes = data
     _last_loaded_time = mtime
 
-    logging.debug("Loaded special indexes for {0} models".format(len(_special_indexes)))
+    logging.debug("Loaded special indexes for %d models", len(_special_indexes))
 
 
 def special_index_exists(model_class, field_name, index_type):

--- a/djangae/test.py
+++ b/djangae/test.py
@@ -84,7 +84,7 @@ def process_task_queues(queue_name=None):
             response = client.get(task['url'], **headers)
 
         if response.status_code != 200:
-            logging.info("Unexpected status ({}) while simulating task with url: {}".format(response.status_code, task['url']))
+            logging.info("Unexpected status (%r) while simulating task with url: %r", response.status_code, task['url'])
 
         if not tasks:
             #The map reduce may have added more tasks, so refresh the list


### PR DESCRIPTION
Hi,

This change just tidies up some logging calls that were using string formatting for arguments, instead of letting the logging module handle the formatting itself.

And for the security middleware, display non-https urls with %r formatting because that makes it easier to see exactly what the value was when there is whitespace at the beginning of the string.

David B.