### PR TITLE
Fix JSONField behaviour in forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 
 ### Bug fixes:
 
--
+- Fix JSONField behaviour in forms: it's properly validating JSON string before saving
+it and returns json object, not string when accessed through cleaned_data. 
 
 ### Documentation:
 
-- 
+-
 
 ## v0.9.4 (release date: 4th April 2016)
 

--- a/djangae/fields/json.py
+++ b/djangae/fields/json.py
@@ -22,6 +22,8 @@ from django.conf import settings
 from django.utils import six
 from django.core.serializers.json import DjangoJSONEncoder
 
+from djangae.forms.fields import JSONFormField, JSONWidget
+
 __all__ = ( 'JSONField',)
 
 
@@ -134,3 +136,11 @@ class JSONField(models.TextField):
         if self.default == {}:
             del kwargs['default']
         return name, path, args, kwargs
+
+    def formfield(self, **kwargs):
+        defaults = {
+            'form_class': JSONFormField,
+            'widget': JSONWidget,
+        }
+        defaults.update(kwargs)
+        return super(JSONField, self).formfield(**defaults)

--- a/djangae/forms/fields.py
+++ b/djangae/forms/fields.py
@@ -33,7 +33,7 @@ class ListWidget(forms.TextInput):
             of this widget. Returns None if it's not provided.
         """
         value = data.get(name, '')
-        if isinstance(value, (str, unicode)):
+        if isinstance(value, six.string_types):
             value = value.split(',')
         return [v.strip() for v in value if v.strip()]
 

--- a/djangae/forms/fields.py
+++ b/djangae/forms/fields.py
@@ -4,10 +4,14 @@ import base64
 from django import forms
 from django.contrib import admin
 from django.db import models
+from django.utils import six
 from django.utils.safestring import mark_safe
 from django.core.urlresolvers import reverse
 from django.contrib.admin.templatetags.admin_static import static
+
+# DJANGAE
 from djangae.utils import memoized
+
 
 class TrueOrNullFormField(forms.BooleanField):
     def clean(self, value):
@@ -52,6 +56,36 @@ class ListFormField(forms.Field):
         delimiter = self.delimiter  # faster
         for value in values:
             assert delimiter not in value
+
+
+class JSONWidget(forms.Textarea):
+    """ A widget for being able to display a JSONField in a form. """
+
+    def render(self, name, value, attrs=None):
+        """ Dump the python object to JSON if it hasn't been done yet. """
+        from djangae.fields.json import dumps
+        if not isinstance(value, six.string_types):
+            value = dumps(value)
+        return super(JSONWidget, self).render(name, value, attrs)
+
+
+class JSONFormField(forms.CharField):
+    """ A form field for being able to display a JSONField in a form.
+        The JSON is rendered as string in a textarea, but is parsed to python (be)for validation.
+     """
+
+    widget = JSONWidget
+
+    def clean(self, value):
+        """ (Try to) parse JSON string back to python. """
+        if isinstance(value, six.string_types):
+            if value == "":
+                value = None
+            try:
+                value = json.loads(value)
+            except ValueError:
+                raise ValidationError("Could not parse value as JSON")
+        return value
 
 
 #Basic obfuscation, just so that the db_table doesn't

--- a/djangae/tests/test_form_fields.py
+++ b/djangae/tests/test_form_fields.py
@@ -1,4 +1,5 @@
 # LIBRARIES
+from bs4 import BeautifulSoup
 from django import forms
 
 # DJANGAE
@@ -23,3 +24,16 @@ class JSONFieldFormsTest(TestCase):
         assert form.is_valid()  # Sanity, and to trigger cleaned_data
         expected_data = {"cats": "awesome", "dogs": 46234}
         self.assertEqual(form.cleaned_data['json_field'], expected_data)
+
+    def test_json_data_is_rendered_as_json_in_html_form(self):
+        """ When the form renders the <textarea> with the JSON in it, it should have been through
+            json.dumps, and should not just be repr(python_thing).
+        """
+        instance = JSONFieldModel(json_field={u'name': 'Lucy', 123: 456})
+        form = JSONModelForm(instance=instance)
+        html = form.as_p()
+        soup = BeautifulSoup(html, "html.parser")
+        # Now we want to check that our value was rendered as JSON.
+        # So the key 123 should have been converted to a string key of "123"
+        textarea = soup.find("textarea").text
+        self.assertTrue('"123"' in textarea)

--- a/djangae/tests/test_form_fields.py
+++ b/djangae/tests/test_form_fields.py
@@ -1,0 +1,25 @@
+# LIBRARIES
+from django import forms
+
+# DJANGAE
+from djangae.test import TestCase
+from djangae.tests.test_db_fields import JSONFieldModel
+
+
+class JSONModelForm(forms.ModelForm):
+    class Meta:
+        model = JSONFieldModel
+        fields = ['json_field']
+
+
+class JSONFieldFormsTest(TestCase):
+
+    def test_json_data_is_python_after_cleaning(self):
+        """ In the forms' `cleaned_data`, the json_field data should be python, rather than still
+            a string.
+        """
+        data = dict(json_field="""{"cats": "awesome", "dogs": 46234}""")
+        form = JSONModelForm(data)
+        assert form.is_valid()  # Sanity, and to trigger cleaned_data
+        expected_data = {"cats": "awesome", "dogs": 46234}
+        self.assertEqual(form.cleaned_data['json_field'], expected_data)


### PR DESCRIPTION
Previously, if we had a JSONField on a model, and we edited that in a form, then we would take the raw string from the POST and essentially pass it straight through to the field in the DB.  If you then reloaded the object from the DB then it would parse the JSON back into python, but there were 2 problems:

1. We didn't do any validation on the JSON string before saving it (i.e. didn't attempt to parse it).
1. If you overrode your form's `clean` method and accessed `self.cleaned_data['my_json_field']` then you would have a string, not the proper object (which is contrary to how things like BooleanFields work, where `cleaned_data` gives `True` or `False`, not `"1"` or `""`.

This pull request fixes that.