### PR TITLE
Fixing ListFormField.clean to return [] instead of None for empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Bug fixes:
 
 - Fix JSONField behaviour in forms: it's properly validating JSON string before saving
-it and returns json object, not string when accessed through cleaned_data. 
+it and returns json object, not string when accessed through cleaned_data.
+- Fixing ListFormField.clean to return [] instead of None for empty values.
 
 ### Documentation:
 

--- a/djangae/forms/fields.py
+++ b/djangae/forms/fields.py
@@ -50,7 +50,7 @@ class ListFormField(forms.Field):
                 self._check_values_against_delimiter(value)
                 return value
             return [v.strip() for v in value.split(',') if v.strip()]
-        return None
+        return []
 
     def _check_values_against_delimiter(self, values):
         delimiter = self.delimiter  # faster

--- a/djangae/tests/test_form_fields.py
+++ b/djangae/tests/test_form_fields.py
@@ -1,8 +1,10 @@
 # LIBRARIES
 from bs4 import BeautifulSoup
 from django import forms
+from django.db import models
 
 # DJANGAE
+from djangae.fields import ListField
 from djangae.test import TestCase
 from djangae.tests.test_db_fields import JSONFieldModel
 
@@ -11,6 +13,16 @@ class JSONModelForm(forms.ModelForm):
     class Meta:
         model = JSONFieldModel
         fields = ['json_field']
+
+
+class BlankableListFieldModel(models.Model):
+    list_field = ListField(models.CharField(max_length=1), blank=True)
+
+
+class ListFieldForm(forms.ModelForm):
+    class Meta:
+        model = BlankableListFieldModel
+        fields = ['list_field']
 
 
 class JSONFieldFormsTest(TestCase):
@@ -37,3 +49,14 @@ class JSONFieldFormsTest(TestCase):
         # So the key 123 should have been converted to a string key of "123"
         textarea = soup.find("textarea").text
         self.assertTrue('"123"' in textarea)
+
+
+class ListFieldFormsTest(TestCase):
+
+    def test_save_empty_value_from_form(self):
+        """ Submitting an empty value in the form should save an empty list. """
+        data = dict(list_field="")
+        form = ListFieldForm(data)
+        self.assertTrue(form.is_valid())
+        obj = form.save()
+        self.assertEqual(obj.list_field, [])


### PR DESCRIPTION
This was causing an error whereby if you submitted a form with an empty value for a ListField then it would die with `"You cannot set a ListField to None, did you mean []?"`.

Note that this PR is branched from #652 and should not be merged until that is merged.