### PR TITLE
Add custom test assertions to check if login:admin or login:required protect a handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features & improvements:
 
--
+- Added new `assert_login_required` and `assert_login_admin` methods to `djangae.test.TestCase`.
 
 ### Bug fixes:
 
@@ -10,7 +10,7 @@
 
 ### Documentation:
 
-- 
+-
 
 ## v0.9.4 (release date: 4th April 2016)
 

--- a/djangae/test.py
+++ b/djangae/test.py
@@ -1,11 +1,18 @@
 import contextlib
 import logging
+import os
 
 from django import test
 from django.test import Client
 
-from google.appengine.api import apiproxy_stub_map
+from djangae.utils import find_project_root
+
+from google.appengine.api import apiproxy_stub_map, appinfo
 from google.appengine.datastore import datastore_stub_util
+from google.appengine.tools.devappserver2 import url_handler
+from google.appengine.tools.devappserver2.application_configuration import ModuleConfiguration
+from google.appengine.tools.devappserver2.python import request_handler
+from google.appengine.tools.devappserver2.module import Module, _ScriptHandler
 
 
 @contextlib.contextmanager
@@ -105,9 +112,65 @@ class TestCaseMixin(object):
         process_task_queues(queue_name)
 
 
-class TestCase(TestCaseMixin, test.TestCase):
+class HandlerAssertionsMixin(object):
+    """
+    Custom assert methods which verifies a range of handler configuration
+    setting specified in app.yaml.
+    """
+
+    msg_prefix = 'Handler configuration for {url} is not protected by {perm}.'
+
+    def assert_login_admin(self, url):
+        """
+        Test that the handler defined in app.yaml which matches the url provided
+        has `login: admin` in the configuration.
+        """
+        handler = self._match_handler(url)
+        self.assertEqual(
+            handler.url_map.login, appinfo.LOGIN_ADMIN, self.msg_prefix.format(
+                url=url, perm='`login: admin`'
+            )
+        )
+
+    def assert_login_required(self, url):
+        """
+        Test that the handler defined in app.yaml which matches the url provided
+        has `login: required` or `login: admin` in the configruation.
+        """
+        handler = self._match_handler(url)
+        login_admin = handler.url_map.login == appinfo.LOGIN_ADMIN
+        login_required = handler.url_map.login == appinfo.LOGIN_REQUIRED or login_admin
+
+        self.assertTrue(login_required, self.msg_prefix.format(
+                url=url, perm='`login: admin` or `login: required`'
+            )
+        )
+
+    def _match_handler(self, url):
+        """
+        Load script handler configurations from app.yaml and try to match
+        the provided url path to a url_maps regex.
+        """
+        app_yaml_path = os.path.join(find_project_root(), "app.yaml")
+        config = ModuleConfiguration(app_yaml_path)
+
+        url_maps = config.handlers
+        script_handlers = [
+            _ScriptHandler(maps) for
+            maps in url_maps if
+            maps.GetHandlerType() == appinfo.HANDLER_SCRIPT
+        ]
+
+        for handler in script_handlers:
+            if handler.match(url):
+                return handler
+
+        raise AssertionError('No handler found for {url}'.format(url=url))
+
+
+class TestCase(HandlerAssertionsMixin, TestCaseMixin, test.TestCase):
     pass
 
 
-class TransactionTestCase(TestCaseMixin, test.TransactionTestCase):
+class TransactionTestCase(HandlerAssertionsMixin, TestCaseMixin, test.TransactionTestCase):
     pass

--- a/djangae/test.py
+++ b/djangae/test.py
@@ -9,10 +9,8 @@ from djangae.utils import find_project_root
 
 from google.appengine.api import apiproxy_stub_map, appinfo
 from google.appengine.datastore import datastore_stub_util
-from google.appengine.tools.devappserver2 import url_handler
 from google.appengine.tools.devappserver2.application_configuration import ModuleConfiguration
-from google.appengine.tools.devappserver2.python import request_handler
-from google.appengine.tools.devappserver2.module import Module, _ScriptHandler
+from google.appengine.tools.devappserver2.module import _ScriptHandler
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
When writing tests for an app it would be useful to have some built in assertion methods to verify that handlers defined in app.yaml have the correct login configuration.

This would reduce the likelihood of that line being removed and the change not being noticed (it could have profound security implications after all).

It would also make it more explicit that requests processed by a handler require users to login in the tests. Currently this can be quite transparent.

Obviously these assertions don't need to test that the configuration is correctly processed by appengine (those tests already exist in the SDK), but only assert that presence of the correct configuration for a defined handler.