### PR TITLE
Clean up of the deconstruct methods on Related fields

### DIFF
--- a/djangae/fields/counting.py
+++ b/djangae/fields/counting.py
@@ -134,7 +134,7 @@ class ReverseRelatedShardsDescriptor(ReverseRelatedObjectsDescriptor):
 
 class ShardedCounterField(RelatedSetField):
 
-    def __init__(self, shard_count=DEFAULT_SHARD_COUNT, *args, **kwargs):
+    def __init__(self, shard_count=DEFAULT_SHARD_COUNT, **kwargs):
         # Note that by removing the related_name by default we avoid reverse name clashes caused by
         # having multiple ShardedCounterFields on the same model.
 
@@ -145,6 +145,9 @@ class ShardedCounterField(RelatedSetField):
                 "on a ShardedCounterField, use increment() after creation instead"
             )
 
+        if "to" in kwargs:
+            del kwargs["to"]
+
         self.shard_count = shard_count
         if shard_count > MAX_ENTITIES_PER_GET:
             raise ImproperlyConfigured(
@@ -153,7 +156,7 @@ class ShardedCounterField(RelatedSetField):
             )
         kwargs.setdefault("related_name", "+")
         from djangae.models import CounterShard
-        super(ShardedCounterField, self).__init__(CounterShard, *args, **kwargs)
+        super(ShardedCounterField, self).__init__(CounterShard, **kwargs)
 
     def contribute_to_class(self, cls, name):
         super(ShardedCounterField, self).contribute_to_class(cls, name)
@@ -162,10 +165,7 @@ class ShardedCounterField(RelatedSetField):
     def deconstruct(self):
         name, path, args, kwargs = super(ShardedCounterField, self).deconstruct()
 
-        args = tuple() # We don't take any non-kwargs (we override "model" in __ini__)
-
-        if "to" in kwargs:
-            del kwargs["to"]
+        del kwargs["to"]
 
         # Add the shard count if necessary
         if self.shard_count != DEFAULT_SHARD_COUNT:

--- a/djangae/fields/counting.py
+++ b/djangae/fields/counting.py
@@ -164,6 +164,9 @@ class ShardedCounterField(RelatedSetField):
 
         args = tuple() # We don't take any non-kwargs (we override "model" in __ini__)
 
+        if "to" in kwargs:
+            del kwargs["to"]
+
         # Add the shard count if necessary
         if self.shard_count != DEFAULT_SHARD_COUNT:
             kwargs["shard_count"] = self.shard_count
@@ -173,4 +176,3 @@ class ShardedCounterField(RelatedSetField):
             del kwargs["default"]
 
         return name, path, args, kwargs
-

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -261,7 +261,7 @@ class RelatedIteratorField(ForeignObject):
     generate_reverse_relation = True
     empty_strings_allowed = False
 
-    def __init__(self, model, limit_choices_to=None, related_name=None, on_delete=models.DO_NOTHING, **kwargs):
+    def __init__(self, to, limit_choices_to=None, related_name=None, on_delete=models.DO_NOTHING, **kwargs):
         # Make sure that we do nothing on cascade by default
         if on_delete == models.CASCADE:
             raise ImproperlyConfigured(
@@ -274,33 +274,28 @@ class RelatedIteratorField(ForeignObject):
                              " (e.g. wipeout the entire list) if you really want to do that "
                              "then use models.SET instead and return an empty list/set")
 
-
         kwargs["rel"] = RelatedIteratorRel(
             self,
-            model,
+            to,
             related_name=related_name,
             limit_choices_to=limit_choices_to,
             on_delete=on_delete
         )
 
-        kwargs.update({
-            'to': model,
-            'from_fields': ['self'],
-            'to_fields': [None],
-        })
         if django.VERSION[1] >= 9:  # Django 1.8 doesn't have on_delete as attribute
             kwargs.update({
                 'on_delete': models.DO_NOTHING,
             })
 
-        super(RelatedIteratorField, self).__init__(**kwargs)
+        from_fields = ['self']
+        to_fields = [None]
+
+        super(RelatedIteratorField, self).__init__(to, from_fields=from_fields, to_fields=to_fields, **kwargs)
 
     def deconstruct(self):
         name, path, args, kwargs = super(RelatedIteratorField, self).deconstruct()
-        args = (self.rel.to,)
-
         # We hardcode a number of arguments for RelatedIteratorField, those arguments need to be removed here
-        for hardcoded_kwarg in ["null", "default", "to_fields", "from_fields", "to", "on_delete"]:
+        for hardcoded_kwarg in ["to_fields", "from_fields", "on_delete"]:
             del kwargs[hardcoded_kwarg]
 
         return name, path, args, kwargs
@@ -392,6 +387,14 @@ class RelatedSetField(RelatedIteratorField):
 
         super(RelatedSetField, self).__init__(*args, **kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(RelatedSetField, self).deconstruct()
+        # We hardcode a number of arguments for RelatedIteratorField, those arguments need to be removed here
+        for hardcoded_kwarg in ["default", "null"]:
+            del kwargs[hardcoded_kwarg]
+
+        return name, path, args, kwargs
+
     def to_python(self, value):
         if value is None:
             return set()
@@ -437,6 +440,14 @@ class RelatedListField(RelatedIteratorField):
         kwargs["null"] = True
 
         super(RelatedListField, self).__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(RelatedSetField, self).deconstruct()
+        # We hardcode a number of arguments for RelatedIteratorField, those arguments need to be removed here
+        for hardcoded_kwarg in ["default", "null"]:
+            del kwargs[hardcoded_kwarg]
+
+        return name, path, args, kwargs
 
     def to_python(self, value):
         if value is None:


### PR DESCRIPTION
This renames the first positional argument of related fields from "model" to "to" which is more consistent with Django's ForeignKey etc.