### PR TITLE
Don't run concrete to_python implementation when the computed field i…

### DIFF
--- a/djangae/fields/computed.py
+++ b/djangae/fields/computed.py
@@ -21,6 +21,8 @@ class ComputedFieldMixin(object):
         return name, path, args, kwargs
 
     def from_db_value(self, value, expression, connection, context):
+        if value is None:
+            return value
         return self.to_python(value)
 
 


### PR DESCRIPTION
…s missing (read in the first time)

Regular django fields seem to return None when there's None in the db so I think this makes sense.