### PR TITLE
Fix iexact index with underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New features & improvements:
 
+- Fixed bug with `__iexact` indexer where values containing underscores would not be correctly indexed.  (Existing objects will need to be re-saved to be correctly indexed.)
 - Improved ordering of `sys.path` so that libraries in the application folder take precedence over libraries that are bundled with the SDK (with some hard-to-avoid exceptions).
 - Added `djangae.contrib.locking`, for preventing simultaneous executing of functions or blocks of code.
 - Moved and renamed several functions from `djangae.utils` to `djangae.environment`.

--- a/djangae/db/backends/appengine/indexing.py
+++ b/djangae/db/backends/appengine/indexing.py
@@ -138,6 +138,7 @@ class IExactIndexer(Indexer):
         return value.lower()
 
     def prep_value_for_query(self, value):
+        value = self.unescape(value)
         return value.lower()
 
     def indexed_column_name(self, field_column, value, index):

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1535,6 +1535,12 @@ class EdgeCaseTests(TestCase):
         user = TestUser.objects.get(id__iexact=str(self.u1.id))
         self.assertEqual("A", user.username)
 
+    def test_iexact_containing_underscores(self):
+        add_special_index(TestUser, "username", "iexact")
+        user = TestUser.objects.create(username="A_B", email="test@example.com")
+        results = TestUser.objects.filter(username__iexact=user.username.lower())
+        self.assertEqual(list(results), [user])
+
     def test_year(self):
         user = TestUser.objects.create(username="Z", email="z@example.com")
         user.last_login = datetime.datetime(2000,1,1,0,0,0)


### PR DESCRIPTION
Fixes issue described on mailing list: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/djangae-users/erIUL3LZ9GA/ZWo0OAl1AQAJ

`__iexact` queries now work correctly when the indexed value contains an underscore.
