### PR TITLE
Allow user pre creation in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New features & improvements:
 
+- Added the ability to pre-create users in the Django admin who can then log in via Google Accounts.  (Previously you could only pre-create users via the shell.)
 - Added new `assert_login_required` and `assert_login_admin` methods to `djangae.test.TestCase`.
 - Improved ordering of `sys.path` so that libraries in the application folder take precedence over libraries that are bundled with the SDK (with some hard-to-avoid exceptions).
 - Added `djangae.contrib.locking`, for preventing simultaneous executing of functions or blocks of code.

--- a/djangae/contrib/gauth/common/validators.py
+++ b/djangae/contrib/gauth/common/validators.py
@@ -1,0 +1,12 @@
+# STANDARD LIB
+import re
+
+# THIRD PARTY
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
+
+
+def validate_google_user_id(value):
+    """ Validates that the given value is either empty, None, or 21 digits. """
+    if value and not re.match(r'^\d{21}$', value):
+        raise ValidationError(_('Google user ID should be 21 digits.'))

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -19,6 +19,7 @@ from djangae.fields import (
     ShardedCounterField,
     SetField,
     CharField,
+    CharOrNoneField,
 )
 from djangae.fields.counting import DEFAULT_SHARD_COUNT
 from djangae.models import CounterShard
@@ -126,6 +127,16 @@ class JSONFieldModel(models.Model):
 
 class JSONFieldWithDefaultModel(models.Model):
     json_field = JSONField(use_ordered_dict=True)
+
+
+class ModelWithCharField(models.Model):
+    char_field_with_max = CharField(max_length=10, default='', blank=True)
+    char_field_without_max = CharField(default='', blank=True)
+
+
+class ModelWithCharOrNoneField(models.Model):
+
+    char_or_none_field = CharOrNoneField(max_length=100)
 
 
 class ShardedCounterTest(TestCase):
@@ -789,11 +800,6 @@ class JSONFieldModelTests(TestCase):
         self.assertEqual(thing.json_field, {})
 
 
-class ModelWithCharField(models.Model):
-    char_field_with_max = CharField(max_length=10, default='', blank=True)
-    char_field_without_max = CharField(default='', blank=True)
-
-
 class CharFieldModelTests(TestCase):
 
     def test_char_field_with_max_length_set(self):
@@ -837,6 +843,15 @@ class CharFieldModelTests(TestCase):
                 e.message,
                 'CharFields max_length must not be grater than 1500 bytes.',
             )
+
+
+class CharOrNoneFieldTests(TestCase):
+
+    def test_char_or_none_field(self):
+        # Ensure that empty strings are coerced to None on save
+        obj = ModelWithCharOrNoneField.objects.create(char_or_none_field="")
+        obj.refresh_from_db()
+        self.assertIsNone(obj.char_or_none_field)
 
 
 class ISStringReferenceModel(models.Model):


### PR DESCRIPTION
Fixes #97.

Summary of changes proposed in this Pull Request:
- Adds a `CharOrNoneField` (which is required because a normal `CharField` will always set empty value to `""` instead of `None` when saved via a form (even with `blank=True, null=True, default=None`).
- Swapped `GaeAbstractBaseUser.username` to use this new field.
- Job done!