### PR TITLE
Revert "Use a stack for state in the atomic + non_atomic decorators. Fixes #667"

### DIFF
--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -21,15 +21,6 @@ def in_atomic_block():
     return IsInTransaction()
 
 
-# Because decorators are only instantiated once per function, we need to make sure any state
-# stored on them is both thread-local (to prevent function calls in different threads
-# interacting with each other) and safe to use recursively (by using a stack of state)
-
-class ContextState(object):
-    "Stores state per-call of the ContextDecorator"
-    pass
-
-
 class ContextDecorator(object):
     """
         A thread-safe ContextDecorator. Subclasses should implement classmethods
@@ -55,7 +46,6 @@ class ContextDecorator(object):
         # Add thread local state for variables that change per-call rather than
         # per insantiation of the decorator
         self.state = threading.local()
-        self.state.stack = []
 
     def __get__(self, obj, objtype=None):
         """ Implement descriptor protocol to support instance methods. """
@@ -73,14 +63,14 @@ class ContextDecorator(object):
             decorator_args = self.decorator_args.copy()
             exception = False
             try:
-                self.__class__._do_enter(self._push_state(), decorator_args)
+                self.__class__._do_enter(self.state, decorator_args)
                 try:
                     return self.func(*_args, **_kwargs)
                 except:
                     exception = True
                     raise
             finally:
-                self.__class__._do_exit(self._pop_state(), decorator_args, exception)
+                self.__class__._do_exit(self.state, decorator_args, exception)
 
         if not self.func:
             # We were instantiated with args
@@ -89,19 +79,11 @@ class ContextDecorator(object):
         else:
             return decorated(*args, **kwargs)
 
-    def _push_state(self):
-        "We need a stack for state in case a decorator is called recursively"
-        self.state.stack.append(ContextState())
-        return self.state.stack[-1]
-
-    def _pop_state(self):
-        return self.state.stack.pop()
-
     def __enter__(self):
-        self.__class__._do_enter(self._push_state(), self.decorator_args.copy())
+        self.__class__._do_enter(self.state, self.decorator_args.copy())
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.__class__._do_exit(self._pop_state(), self.decorator_args.copy(), exc_type)
+        self.__class__._do_exit(self.state, self.decorator_args.copy(), exc_type)
 
 
 class TransactionFailedError(Exception):

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -16,18 +16,6 @@ class TransactionTests(TestCase):
         with transaction.atomic(xg=True):
             TestUser.objects.get(pk=pk)
 
-    def test_recursive_atomic(self):
-        l = []
-
-        @transaction.atomic
-        def txn():
-            l.append(True)
-            if len(l) == 3:
-                return
-            else:
-                txn()
-
-        txn()
 
     def test_atomic_decorator(self):
         from .test_connector import TestUser


### PR DESCRIPTION
Reverts potatolondon/djangae#668

That PR seems to cause this problem:

```
Internal Server Error: /_admin/login/
Traceback (most recent call last):
  File "sitepackages/django/core/handlers/base.py", line 223, in get_response
    response = middleware_method(request, response)
  File "sitepackages/django/contrib/sessions/middleware.py", line 50, in process_response
    request.session.save()
  File "sitepackages/django/contrib/sessions/backends/db.py", line 56, in save
    return self.create()
  File "sitepackages/django/contrib/sessions/backends/db.py", line 41, in create
    self.save(must_create=True)
  File "django/contrib/sessions/backends/db.py", line 65, in save
    obj.save(force_insert=must_create, using=using)
  File "django/db/models/base.py", line 734, in save
    force_update=force_update, update_fields=update_fields)
  File "django/db/models/base.py", line 771, in save_base
    update_fields=update_fields, raw=raw, using=using)
  File "django/dispatch/dispatcher.py", line 189, in send
    response = receiver(signal=self, sender=sender, **named)
  File "djangae/db/transaction.py", line 90, in __call__
    return decorated(*args, **kwargs)
  File "djangae/db/transaction.py", line 83, in decorated
    self.__class__._do_exit(self._pop_state(), decorator_args, exception)
  File "djangae/db/transaction.py", line 98, in _pop_state
    return self.state.stack.pop()
AttributeError: 'thread._local' object has no attribute 'stack'
```