### PR TITLE
Fix transaction decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug fixes:
 
+- Fixed `atomic` and `non_atomic` transaction decorators/context managers so that they can be called recursively.
 - Fix `JSONField` behaviour in forms: it's properly validating JSON string before saving
 it and returns json object, not string when accessed through `cleaned_data`.
 - Fixing `ListFormField.clean` to return `[]` instead of `None` for empty values.

--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -21,6 +21,15 @@ def in_atomic_block():
     return IsInTransaction()
 
 
+# Because decorators are only instantiated once per function, we need to make sure any state
+# stored on them is both thread-local (to prevent function calls in different threads
+# interacting with each other) and safe to use recursively (by using a stack of state)
+
+class ContextState(object):
+    "Stores state per-call of the ContextDecorator"
+    pass
+
+
 class ContextDecorator(object):
     """
         A thread-safe ContextDecorator. Subclasses should implement classmethods
@@ -46,6 +55,7 @@ class ContextDecorator(object):
         # Add thread local state for variables that change per-call rather than
         # per insantiation of the decorator
         self.state = threading.local()
+        self.state.stack = []
 
     def __get__(self, obj, objtype=None):
         """ Implement descriptor protocol to support instance methods. """
@@ -63,14 +73,14 @@ class ContextDecorator(object):
             decorator_args = self.decorator_args.copy()
             exception = False
             try:
-                self.__class__._do_enter(self.state, decorator_args)
+                self.__class__._do_enter(self._push_state(), decorator_args)
                 try:
                     return self.func(*_args, **_kwargs)
                 except:
                     exception = True
                     raise
             finally:
-                self.__class__._do_exit(self.state, decorator_args, exception)
+                self.__class__._do_exit(self._pop_state(), decorator_args, exception)
 
         if not self.func:
             # We were instantiated with args
@@ -79,11 +89,19 @@ class ContextDecorator(object):
         else:
             return decorated(*args, **kwargs)
 
+    def _push_state(self):
+        "We need a stack for state in case a decorator is called recursively"
+        self.state.stack.append(ContextState())
+        return self.state.stack[-1]
+
+    def _pop_state(self):
+        return self.state.stack.pop()
+
     def __enter__(self):
-        self.__class__._do_enter(self.state, self.decorator_args.copy())
+        self.__class__._do_enter(self._push_state(), self.decorator_args.copy())
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.__class__._do_exit(self.state, self.decorator_args.copy(), exc_type)
+        self.__class__._do_exit(self._pop_state(), self.decorator_args.copy(), exc_type)
 
 
 class TransactionFailedError(Exception):

--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -91,6 +91,12 @@ class ContextDecorator(object):
 
     def _push_state(self):
         "We need a stack for state in case a decorator is called recursively"
+        # self.state is a threading.local() object, so if the current thread is not the one in
+        # which ContextDecorator.__init__ was called (e.g. is not the thread in which the function
+        # was decorated), then the 'stack' attribute may not exist
+        if not hasattr(self.state, 'stack'):
+            self.state.stack = []
+
         self.state.stack.append(ContextState())
         return self.state.stack[-1]
 

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -113,7 +113,6 @@ class TransactionTests(TestCase):
         with transaction.atomic():
             double_nested_transactional()
 
-
         @db.transactional()
         def something_containing_atomic():
             with transaction.atomic():
@@ -142,7 +141,6 @@ class TransactionTests(TestCase):
 
         self.assertEqual(0, TestUser.objects.count())
 
-
     def test_non_atomic_context_manager(self):
         from .test_connector import TestUser
         existing = TestUser.objects.create(username="existing", field2="exists")
@@ -158,7 +156,7 @@ class TransactionTests(TestCase):
                 self.assertFalse(transaction.in_atomic_block())
 
                 with sleuth.watch("google.appengine.api.datastore.Get") as datastore_get:
-                    TestUser.objects.get(pk=existing.pk) #Should hit the cache, not the datastore
+                    TestUser.objects.get(pk=existing.pk)  # Should hit the cache, not the datastore
 
                 self.assertFalse(datastore_get.called)
 
@@ -175,14 +173,14 @@ class TransactionTests(TestCase):
                         self.assertRaises(TestUser.DoesNotExist, TestUser.objects.get, pk=user2.pk)
 
                         with sleuth.watch("google.appengine.api.datastore.Get") as datastore_get:
-                            TestUser.objects.get(pk=existing.pk) #Should hit the cache, not the datastore
+                            # Should hit the cache, not the Datastore
+                            TestUser.objects.get(pk=existing.pk)
 
                     self.assertFalse(transaction.in_atomic_block())
                     self.assertRaises(TestUser.DoesNotExist, TestUser.objects.get, pk=user2.pk)
 
                 self.assertTrue(TestUser.objects.filter(pk=user2.pk).exists())
                 self.assertTrue(transaction.in_atomic_block())
-
 
     def test_xg_argument(self):
         from .test_connector import TestUser, TestFruit
@@ -215,10 +213,8 @@ class TransactionTests(TestCase):
             TestUser.objects.create(username=_username)
             txn2(_fruit)
 
-
         with self.assertRaises(ValueError):
             txn1("test", "banana")
-
 
     def test_nested_decorator(self):
         # Nested decorator pattern we discovered can cause a connection_stack

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -16,6 +16,18 @@ class TransactionTests(TestCase):
         with transaction.atomic(xg=True):
             TestUser.objects.get(pk=pk)
 
+    def test_recursive_atomic(self):
+        l = []
+
+        @transaction.atomic
+        def txn():
+            l.append(True)
+            if len(l) == 3:
+                return
+            else:
+                txn()
+
+        txn()
 
     def test_atomic_decorator(self):
         from .test_connector import TestUser

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -29,6 +29,19 @@ class TransactionTests(TestCase):
 
         txn()
 
+    def test_recursive_non_atomic(self):
+        l = []
+
+        @transaction.non_atomic
+        def txn():
+            l.append(True)
+            if len(l) == 3:
+                return
+            else:
+                txn()
+
+        txn()
+
     def test_atomic_decorator(self):
         from .test_connector import TestUser
 

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -1,7 +1,10 @@
-from djangae.test import TestCase
+# STANDARD LIB
+import threading
 
+# DJANGAE
 from djangae.db import transaction
 from djangae.contrib import sleuth
+from djangae.test import TestCase
 
 
 class TransactionTests(TestCase):
@@ -41,6 +44,32 @@ class TransactionTests(TestCase):
                 txn()
 
         txn()
+
+    def test_atomic_in_separate_thread(self):
+        """ Regression test.  See #668. """
+        @transaction.atomic
+        def txn():
+            return
+
+        def target():
+            txn()
+
+        thread = threading.Thread(target=target)
+        thread.start()
+        thread.join()
+
+    def test_non_atomic_in_separate_thread(self):
+        """ Regression test.  See #668. """
+        @transaction.non_atomic
+        def txn():
+            return
+
+        def target():
+            txn()
+
+        thread = threading.Thread(target=target)
+        thread.start()
+        thread.join()
 
     def test_atomic_decorator(self):
         from .test_connector import TestUser


### PR DESCRIPTION
Fixes #667 and the breakage caused by the first attempt to fix that, which was #668.

Summary of changes proposed in this Pull Request:
- `transaction.atomic` and `transaction.non_atomic` decorators can now be used recursively (and in multiple threads) without causing exceptions, explosions or earthquakes. 