### PR TITLE
Fixes #630 - Add Django master to Travis builds we run, but allow it to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: python
 sudo: false
 python:
-- '2.7'
+- 2.7
 env:
-  - "DJANGO_VERSION=1.8"
-  - "DJANGO_VERSION=1.9"
-
+  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION=1.9
+  - DJANGO_VERSION=master
+matrix:
+  allow_failures:
+    - env: DJANGO_VERSION=master
+  fast_finish: true
 before_install:
 - pip install codecov
-
 install:
 - cd testapp
 - python install_deps.py


### PR DESCRIPTION
I think this is gonna satisfy our requirements of having all of our tests be run on Django master, but without interrupting current development flow. This config runs of Django 1.8, 1.9 and master, but allows tests run on master to fail while still being marked as green. 

Nightly builds are already configured and happening. 