### PR TITLE
Fixes to make Djangae run on Django 1.10 alpha 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: python
 sudo: false
 python:
-- '2.7'
+- 2.7
 env:
-  - "DJANGO_VERSION=1.8"
-  - "DJANGO_VERSION=1.9"
-  - "DJANGO_VERSION=master"
-
+  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION=1.9
+  - DJANGO_VERSION=1.10a1
+  - DJANGO_VERSION=master
+matrix:
+  allow_failures:
+    - env: DJANGO_VERSION=1.10a1
+    - env: DJANGO_VERSION=master
+  fast_finish: true
 before_install:
 - pip install codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 env:
   - "DJANGO_VERSION=1.8"
   - "DJANGO_VERSION=1.9"
+  - "DJANGO_VERSION=master"
 
 before_install:
 - pip install codecov

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -1064,7 +1064,8 @@ def _transform_query_19(connection, kind, query):
 
 _FACTORY = {
     (1, 8): _transform_query_18,
-    (1, 9): _transform_query_19
+    (1, 9): _transform_query_19,
+    (1, 10): _transform_query_19, # Same as 1.9
 }
 
 
@@ -1090,7 +1091,8 @@ def _determine_query_kind_19(query):
 
 _KIND_FACTORY = {
     (1, 8): _determine_query_kind_18,
-    (1, 9): _determine_query_kind_19
+    (1, 9): _determine_query_kind_19,
+    (1, 10): _determine_query_kind_19  # Same as 1.9
 }
 
 
@@ -1102,7 +1104,8 @@ def transform_query(connection, query):
 
 _ORDERING_FACTORY = {
     (1, 8): _extract_ordering_from_query_18,
-    (1, 9): _extract_ordering_from_query_18  # Same as 1.8
+    (1, 9): _extract_ordering_from_query_18,  # Same as 1.8
+    (1, 10): _extract_ordering_from_query_18  # Same as 1.8
 }
 
 

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -1062,6 +1062,13 @@ def _transform_query_19(connection, kind, query):
     return ret
 
 
+def get_factory_for_version(factory, version):
+    try:
+        return factory[version]
+    except KeyError:
+        return factory[max(factory.keys())]
+
+
 _FACTORY = {
     (1, 8): _transform_query_18,
     (1, 9): _transform_query_19,
@@ -1098,8 +1105,8 @@ _KIND_FACTORY = {
 
 def transform_query(connection, query):
     version = django.VERSION[:2]
-    kind = _KIND_FACTORY[version](query)
-    return _FACTORY[version](connection, kind, query)
+    kind = get_factory_for_version(_KIND_FACTORY, version)(query)
+    return get_factory_for_version(_FACTORY, version)(connection, kind, query)
 
 
 _ORDERING_FACTORY = {
@@ -1111,4 +1118,4 @@ _ORDERING_FACTORY = {
 
 def extract_ordering(query):
     version = django.VERSION[:2]
-    return _ORDERING_FACTORY[version](query)
+    return get_factory_for_version(_ORDERING_FACTORY, version)(query)

--- a/djangae/fields/counting.py
+++ b/djangae/fields/counting.py
@@ -155,8 +155,7 @@ class ShardedCounterField(RelatedSetField):
                 "fetching in a single Get operation (%d)" % MAX_ENTITIES_PER_GET
             )
         kwargs.setdefault("related_name", "+")
-        from djangae.models import CounterShard
-        super(ShardedCounterField, self).__init__(CounterShard, **kwargs)
+        super(ShardedCounterField, self).__init__('djangae.CounterShard', **kwargs)
 
     def contribute_to_class(self, cls, name):
         super(ShardedCounterField, self).contribute_to_class(cls, name)

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -442,7 +442,7 @@ class RelatedListField(RelatedIteratorField):
         super(RelatedListField, self).__init__(*args, **kwargs)
 
     def deconstruct(self):
-        name, path, args, kwargs = super(RelatedSetField, self).deconstruct()
+        name, path, args, kwargs = super(RelatedListField, self).deconstruct()
         # We hardcode a number of arguments for RelatedIteratorField, those arguments need to be removed here
         for hardcoded_kwarg in ["default", "null"]:
             del kwargs[hardcoded_kwarg]

--- a/djangae/patches/contenttypes.py
+++ b/djangae/patches/contenttypes.py
@@ -3,6 +3,7 @@ import new
 import logging
 from itertools import chain
 
+import django
 from django.contrib.contenttypes.models import ContentType
 from django.db import DEFAULT_DB_ALIAS, router, connections
 from django.db.models import signals, Manager
@@ -139,6 +140,8 @@ class SimulatedContentTypeManager(Manager):
         if dic["id"] in self._store.constructed_instances:
             return self._store.constructed_instances[dic["id"]]
         else:
+            if django.VERSION[1] > 9:
+                del dic['name']
             result = ContentType(**dic)
             result.save = new.instancemethod(disable_save, ContentType, result)
             self._store.constructed_instances[dic["id"]] = result

--- a/testapp/install_deps.py
+++ b/testapp/install_deps.py
@@ -25,12 +25,14 @@ DEPRECATED_SDK_REPO = "https://storage.googleapis.com/appengine-sdks/deprecated/
 
 DJANGO_VERSION = os.environ.get("DJANGO_VERSION", "1.8")
 
-if DJANGO_VERSION != "master":
+if any([x in DJANGO_VERSION for x in ['master', 'a', 'b', 'rc']]):
+    # For master, beta, alpha or rc versions, get exact versions
+    DJANGO_FOR_PIP = "https://github.com/django/django/archive/{}.tar.gz".format(DJANGO_VERSION)
+    DJANGO_TESTS_URL = "https://github.com/django/django/archive/{}.zip".format(DJANGO_VERSION)
+else:
+    # For normal (eg. 1.8, 1.9) releases, get latest (.x)
     DJANGO_FOR_PIP = "https://github.com/django/django/archive/stable/{}.x.tar.gz".format(DJANGO_VERSION)
     DJANGO_TESTS_URL = "https://github.com/django/django/archive/stable/{}.x.zip".format(DJANGO_VERSION)
-else:
-    DJANGO_FOR_PIP = "https://github.com/django/django/archive/master.tar.gz"
-    DJANGO_TESTS_URL = "https://github.com/django/django/archive/master.zip"
 
 if __name__ == '__main__':
 
@@ -75,5 +77,5 @@ if __name__ == '__main__':
     django_zip = urlopen(DJANGO_TESTS_URL)
     zipfile = ZipFile(StringIO(django_zip.read()))
     for filename in zipfile.namelist():
-        if filename.startswith("django-stable-{}.x/tests/".format(DJANGO_VERSION)) or filename.startswith("django-master/tests/"):
+        if filename.startswith("django-stable-{}.x/tests/".format(DJANGO_VERSION)) or filename.startswith("django-{}/tests/".format(DJANGO_VERSION)):
             zipfile.extract(filename, os.path.join(TARGET_DIR))

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -59,7 +59,9 @@ if "test" in sys.argv:
 
     tests_dir = os.path.join(BASE_DIR, "libs", "django-stable-{}.{}.x/tests".format(*django.VERSION[:2]))
     if not os.path.exists(tests_dir):
-        tests_dir = os.path.join(BASE_DIR, "libs", "django-master/tests")
+        tests_dir = os.path.join(BASE_DIR, "libs", "django-{}/tests".format(django.get_version()))
+        if not os.path.exists(tests_dir):
+            tests_dir = os.path.join(BASE_DIR, "libs", "django-master/tests")
 
     sys.path.insert(0, tests_dir)
 


### PR DESCRIPTION
So these are a couple of fixes that we can merge now to master even though tests don't pass on Django 1.10 alpha 1 and master branches yet. They're marked as allowed to fail in Travis setup though. 

Fixed in this PR:
- Adds 1.10a1 and master to Travis config. Allows them to run and fail. Changes to install_deps and settings to allow for version number 1.10a1
- We were calling `super` on RelatedSetField in RelatedListField
- Model reference in ShardedCounterField needs to be a string, otherwise Django migrations fail on creating testing db
- Added more flexibility so 1.10 or 1.11 doesn't fail because they're not in query factories.