### PR TITLE
Allow precreated users to login when DJANGAE_CREATE_UNKNOWN_USER is False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ filenames properly.
 - Fix for `RelatedIterator` that fails when related iterated fields model is set as string.
 - Ensure `MapReduceTask `uses the db returned by the application router(s) unless explicitly passed.
 - Fixed bug with `__iexact` indexer where values containing underscores would not be correctly indexed.  (Existing objects will need to be re-saved to be correctly indexed.)
+- Fixed a regression that prevented precreated users from logging in when `DJANGAE_CREATE_UNKNOWN_USER` is False
 
 ### Documentation:
 

--- a/djangae/contrib/gauth/common/backends.py
+++ b/djangae/contrib/gauth/common/backends.py
@@ -90,9 +90,14 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
         auto_create = should_create_unknown_user()
         user_is_admin = users.is_current_user_admin()
 
-        if not (auto_create or user_is_admin):
-            # User doesn't exist and we aren't going to create one.
-            return None
+        try:
+            existing_user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            if not (auto_create or user_is_admin):
+                # User doesn't exist and we aren't going to create one.
+                return None
+
+            existing_user = None
 
         # OK. We will grant access. We may need to update an existing user, or
         # create a new one, or both.
@@ -106,10 +111,6 @@ class BaseAppEngineUserAPIBackend(ModelBackend):
         # Google account. This is possible but very unlikely.
         # 3. There is no User object realting to this user whatsoever.
 
-        try:
-            existing_user = User.objects.get(email=email)
-        except User.DoesNotExist:
-            existing_user = None
 
         if existing_user:
             if existing_user.username is None:


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Added a test for pre-created users when DJANGAE_CREATE_UNKNOWN_USER is False
- Moved auto_create/admin check to allow pre-created users to be fetched as they would have been pre-0.9.4

PR checklist:
- ~~Updated relevant documentation~~ N/A
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
