### PR TITLE
Fixes #682 - Move ContentType patch to djangae.contrib.contenttypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Extended runserver's file watcher patching to allow ignoring of directories.
 - Add tasks utility functions to djangae.environment.
 - Alias DatastorePaginator -> Paginator, and DatastorePage -> Page to be more like Django
+- Moved `ContentType` patching to `djangae.contrib.contenttypes`. `DJANGAE_SIMULATE_CONTENTTYPES` setting has been deprecated, add `djangae.contrib.contenttypes` to `INSTALLED_APPS` instead. `djangae.contrib.contenttypes` needs to be after `django.contrib.contenttypes` in the `INSTALLED_APPS` order.
 
 ### Bug fixes:
 

--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -15,10 +15,18 @@ class DjangaeConfig(AppConfig):
         request_started.connect(reset_context, dispatch_uid="request_started_context_reset")
 
         from django.conf import settings
-        if 'django.contrib.contenttypes' in settings.INSTALLED_APPS and (
-                not 'djangae.contrib.contenttypes' in settings.INSTALLED_APPS):
-            raise ImproperlyConfigured(
-                "If you're using django.contrib.contenttypes, then you need "
-                "to add djangae.contrib.contenttypes to INSTALLED_APPS after "
-                "django.contrib.contenttypes."
-            )
+        contenttype_configuration_error = ImproperlyConfigured(
+            "If you're using django.contrib.contenttypes, then you need "
+            "to add djangae.contrib.contenttypes to INSTALLED_APPS after "
+            "django.contrib.contenttypes."
+        )
+        if 'django.contrib.contenttypes' in settings.INSTALLED_APPS:
+            if not 'djangae.contrib.contenttypes' in settings.INSTALLED_APPS:
+                # Raise error if User is using Django CT, but not Djangae
+                raise contenttype_configuration_error
+            else:
+                if settings.INSTALLED_APPS.index('django.contrib.contenttypes') > \
+                        settings.INSTALLED_APPS.index('djangae.contrib.contenttypes'):
+                    # Raise error if User is using both Django and Djangae CT, but
+                    # Django CT comes after Djangae CT
+                    raise contenttype_configuration_error

--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
+from django.core.exceptions import ImproperlyConfigured
+
 
 class DjangaeConfig(AppConfig):
     name = 'djangae'
@@ -13,12 +15,10 @@ class DjangaeConfig(AppConfig):
         request_started.connect(reset_context, dispatch_uid="request_started_context_reset")
 
         from django.conf import settings
-        if getattr(settings, 'DJANGAE_SIMULATE_CONTENTTYPES', False):
-            import warnings
-            warnings.warn(
-                "settings.DJANGAE_SIMULATE_CONTENTTYPES is deprecated, please "
-                "add djangae.contrib.contenttypes to INSTALLED_APPS instead. "
-                "It needs to be after django.contrib.contenttypes in the list."
+        if 'django.contrib.contenttypes' in settings.INSTALLED_APPS and (
+                not 'djangae.contrib.contenttypes' in settings.INSTALLED_APPS):
+            raise ImproperlyConfigured(
+                "If you're using django.contrib.contenttypes, then you need "
+                "to add djangae.contrib.contenttypes to INSTALLED_APPS after "
+                "django.contrib.contenttypes."
             )
-            from djangae.contrib.contenttypes import apps
-            apps.patch_contenttypes()

--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -6,9 +6,6 @@ class DjangaeConfig(AppConfig):
     verbose_name = _("Djangae")
 
     def ready(self):
-        from .patches.contenttypes import patch
-        patch(sender=self)
-
         from djangae.db.backends.appengine.caching import reset_context
         from django.core.signals import request_finished, request_started
 

--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -11,3 +11,14 @@ class DjangaeConfig(AppConfig):
 
         request_finished.connect(reset_context, dispatch_uid="request_finished_context_reset")
         request_started.connect(reset_context, dispatch_uid="request_started_context_reset")
+
+        from django.conf import settings
+        if getattr(settings, 'DJANGAE_SIMULATE_CONTENTTYPES', False):
+            import warnings
+            warnings.warn(
+                "settings.DJANGAE_SIMULATE_CONTENTTYPES is deprecated, please "
+                "add djangae.contrib.contenttypes to INSTALLED_APPS instead. "
+                "It needs to be after django.contrib.contenttypes in the list."
+            )
+            from djangae.contrib.contenttypes import apps
+            apps.patch_contenttypes()

--- a/djangae/contrib/contenttypes/__init__.py
+++ b/djangae/contrib/contenttypes/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'djangae.contrib.contenttypes.apps.ContentTypesConfig'

--- a/djangae/contrib/contenttypes/apps.py
+++ b/djangae/contrib/contenttypes/apps.py
@@ -1,0 +1,20 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+from django.contrib.contenttypes.management import update_contenttypes as django_update_contenttypes
+from django.db.models.signals import post_migrate
+
+from .management import update_contenttypes
+from .models import SimulatedContentTypeManager
+
+
+class ContentTypesConfig(AppConfig):
+    name = 'djangae.contrib.contenttypes'
+    verbose_name = _("Djangae Content Types")
+    label = "djangae_contenttypes"
+
+    def ready(self):
+        if django_update_contenttypes != update_contenttypes:
+            post_migrate.disconnect(django_update_contenttypes)
+            from django.contrib.contenttypes import models as django_models
+            if not isinstance(django_models.ContentType.objects, SimulatedContentTypeManager):
+                django_models.ContentType.objects = SimulatedContentTypeManager()

--- a/djangae/contrib/contenttypes/apps.py
+++ b/djangae/contrib/contenttypes/apps.py
@@ -7,17 +7,14 @@ from .management import update_contenttypes
 from .models import SimulatedContentTypeManager
 
 
-def patch_contenttypes():
-    if django_update_contenttypes != update_contenttypes:
-        post_migrate.disconnect(django_update_contenttypes)
-        from django.contrib.contenttypes import models as django_models
-        if not isinstance(django_models.ContentType.objects, SimulatedContentTypeManager):
-            django_models.ContentType.objects = SimulatedContentTypeManager()
-
 class ContentTypesConfig(AppConfig):
     name = 'djangae.contrib.contenttypes'
     verbose_name = _("Djangae Content Types")
     label = "djangae_contenttypes"
 
     def ready(self):
-        patch_contenttypes()
+        if django_update_contenttypes != update_contenttypes:
+            post_migrate.disconnect(django_update_contenttypes)
+            from django.contrib.contenttypes import models as django_models
+            if not isinstance(django_models.ContentType.objects, SimulatedContentTypeManager):
+                django_models.ContentType.objects = SimulatedContentTypeManager()

--- a/djangae/contrib/contenttypes/apps.py
+++ b/djangae/contrib/contenttypes/apps.py
@@ -7,14 +7,17 @@ from .management import update_contenttypes
 from .models import SimulatedContentTypeManager
 
 
+def patch_contenttypes():
+    if django_update_contenttypes != update_contenttypes:
+        post_migrate.disconnect(django_update_contenttypes)
+        from django.contrib.contenttypes import models as django_models
+        if not isinstance(django_models.ContentType.objects, SimulatedContentTypeManager):
+            django_models.ContentType.objects = SimulatedContentTypeManager()
+
 class ContentTypesConfig(AppConfig):
     name = 'djangae.contrib.contenttypes'
     verbose_name = _("Djangae Content Types")
     label = "djangae_contenttypes"
 
     def ready(self):
-        if django_update_contenttypes != update_contenttypes:
-            post_migrate.disconnect(django_update_contenttypes)
-            from django.contrib.contenttypes import models as django_models
-            if not isinstance(django_models.ContentType.objects, SimulatedContentTypeManager):
-                django_models.ContentType.objects = SimulatedContentTypeManager()
+        patch_contenttypes()

--- a/djangae/contrib/contenttypes/management.py
+++ b/djangae/contrib/contenttypes/management.py
@@ -1,0 +1,106 @@
+import django
+from django.db import DEFAULT_DB_ALIAS, router
+from django.apps import apps
+from django.utils.encoding import smart_text
+from django.utils import six
+from django.utils.six.moves import input
+
+
+def update_contenttypes(sender, verbosity=2, db=DEFAULT_DB_ALIAS, **kwargs):
+    """
+        Django's default update_contenttypes relies on many inconsistent queries which causes problems
+        with syncdb. This monkeypatch replaces it with a version that does look ups on unique constraints
+        which are slightly better protected from eventual consistency issues by the context cache.
+    """
+    from django.contrib.contenttypes.models import ContentType
+    
+    if verbosity >= 2:
+        print("Running Djangae version of update_contenttypes on {}".format(sender))
+
+    try:
+        apps.get_model('contenttypes', 'ContentType')
+    except LookupError:
+        return
+
+    if hasattr(router, "allow_migrate_model"):
+        if not router.allow_migrate_model(db, ContentType):
+            return
+
+    ContentType.objects.clear_cache()
+    app_models = sender.get_models()
+    if not app_models:
+        return
+    # They all have the same app_label, get the first one.
+    app_label = sender.label
+    app_models = dict(
+        (model._meta.model_name, model)
+        for model in app_models
+    )
+
+    created_or_existing_pks = []
+    created_or_existing_by_unique = {}
+
+    for (model_name, model) in six.iteritems(app_models):
+        # Go through get_or_create any models that we want to keep
+        defaults = {}
+        if django.VERSION < (1, 9):
+            defaults['name'] = smart_text(model._meta.verbose_name_raw)
+
+        ct, created = ContentType.objects.get_or_create(
+            app_label=app_label,
+            model=model_name,
+            defaults=defaults,
+        )
+
+        if verbosity >= 2 and created:
+            print("Adding content type '%s | %s'" % (ct.app_label, ct.model))
+
+        created_or_existing_pks.append(ct.pk)
+        created_or_existing_by_unique[(app_label, model_name)] = ct.pk
+
+    # Now lets see if we should remove any
+
+    to_remove = [x for x in ContentType.objects.filter(app_label=app_label) if x.pk not in created_or_existing_pks]
+
+    # Now it's possible that our get_or_create failed because of consistency issues and we create a duplicate.
+    # Then the original appears in the to_remove and we remove the original. This is bad. So here we go through the
+    # to_remove list, and if we created the content type just now, we delete that one, and restore the original in the
+    # cache
+    for ct in to_remove:
+        unique = (ct.app_label, ct.model)
+        if unique in created_or_existing_by_unique:
+            # We accidentally created a duplicate above due to HRD issues, delete the one we created
+            ContentType.objects.get(pk=created_or_existing_by_unique[unique]).delete()
+            created_or_existing_by_unique[unique] = ct.pk
+            ct.save()  # Recache this one in the context cache
+
+    to_remove = [ x for x in to_remove if (x.app_label, x.model) not in created_or_existing_by_unique ]
+
+    # Now, anything left should actually be a stale thing. It's still possible we missed some but they'll get picked up
+    # next time. Confirm that the content type is stale before deletion.
+    if to_remove:
+        if kwargs.get('interactive', False):
+            content_type_display = '\n'.join([
+                '    %s | %s' % (x.app_label, x.model)
+                for x in to_remove
+            ])
+            ok_to_delete = input("""The following content types are stale and need to be deleted:
+
+%s
+
+Any objects related to these content types by a foreign key will also
+be deleted. Are you sure you want to delete these content types?
+If you're unsure, answer 'no'.
+
+    Type 'yes' to continue, or 'no' to cancel: """ % content_type_display)
+        else:
+            ok_to_delete = False
+
+        if ok_to_delete == 'yes':
+            for ct in to_remove:
+                if verbosity >= 2:
+                    print("Deleting stale content type '%s | %s'" % (ct.app_label, ct.model))
+                ct.delete()
+        else:
+            if verbosity >= 2:
+                print("Stale content types remain.")

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -1,20 +1,16 @@
 import threading
 import new
 import logging
-from itertools import chain
 
 import django
-from django.contrib.contenttypes.models import ContentType
-from django.db import DEFAULT_DB_ALIAS, router, connections
-from django.db.models import signals, Manager
+from django.db import router, connections, models
 from django.apps import apps
 from django.utils.encoding import smart_text
 from django.utils import six
-from django.utils.six.moves import input
 from djangae.crc64 import CRC64
 
 
-class SimulatedContentTypeManager(Manager):
+class SimulatedContentTypeManager(models.Manager):
     """
         Simulates content types without actually hitting the datastore.
     """
@@ -39,6 +35,7 @@ class SimulatedContentTypeManager(Manager):
             This is just to satisfy the contenttypes tests which check that queries are executed at certain
             times. It's a bit hacky but it works for that purpose.
         """
+        from django.contrib.contenttypes.models import ContentType
         conn = connections[router.db_for_write(ContentType)]
 
         if getattr(conn, "use_debug_cursor", getattr(conn, "force_debug_cursor", False)):
@@ -108,9 +105,11 @@ class SimulatedContentTypeManager(Manager):
         try:
             return self._store.content_types[id]
         except KeyError:
+            from django.contrib.contenttypes.models import ContentType
             raise ContentType.DoesNotExist()
 
     def get(self, **kwargs):
+        from django.contrib.contenttypes.models import ContentType
         self._repopulate_if_necessary()
 
         if "pk" in kwargs:
@@ -141,12 +140,14 @@ class SimulatedContentTypeManager(Manager):
         if dic["id"] in self._store.constructed_instances:
             return self._store.constructed_instances[dic["id"]]
         else:
+            from django.contrib.contenttypes.models import ContentType
             result = ContentType(**dic)
             result.save = new.instancemethod(disable_save, ContentType, result)
             self._store.constructed_instances[dic["id"]] = result
             return result
 
     def create(self, **kwargs):
+        from django.contrib.contenttypes.models import ContentType
         try:
             return self.get(**kwargs)
         except ContentType.DoesNotExist:
@@ -187,123 +188,3 @@ class SimulatedContentTypeManager(Manager):
 
     def bulk_create(self, *args, **kwargs):
         pass
-
-
-def update_contenttypes(sender, verbosity=2, db=DEFAULT_DB_ALIAS, **kwargs):
-    """
-        Django's default update_contenttypes relies on many inconsistent queries which causes problems
-        with syncdb. This monkeypatch replaces it with a version that does look ups on unique constraints
-        which are slightly better protected from eventual consistency issues by the context cache.
-    """
-    if verbosity >= 2:
-        print("Running Djangae version of update_contenttypes on {}".format(sender))
-
-    try:
-        apps.get_model('contenttypes', 'ContentType')
-    except LookupError:
-        return
-
-    if hasattr(router, "allow_migrate_model"):  # Django >= 1.8
-        if not router.allow_migrate_model(db, ContentType):
-            return
-    else:
-        if not router.allow_migrate(db, ContentType):  # Django == 1.7
-            return
-
-
-    ContentType.objects.clear_cache()
-    app_models = sender.get_models()
-    if not app_models:
-        return
-    # They all have the same app_label, get the first one.
-    app_label = sender.label
-    app_models = dict(
-        (model._meta.model_name, model)
-        for model in app_models
-    )
-
-    created_or_existing_pks = []
-    created_or_existing_by_unique = {}
-
-    for (model_name, model) in six.iteritems(app_models):
-        # Go through get_or_create any models that we want to keep
-        defaults = {}
-        if django.VERSION < (1, 9):
-            defaults['name'] = smart_text(model._meta.verbose_name_raw)
-
-        ct, created = ContentType.objects.get_or_create(
-            app_label=app_label,
-            model=model_name,
-            defaults=defaults,
-        )
-
-        if verbosity >= 2 and created:
-            print("Adding content type '%s | %s'" % (ct.app_label, ct.model))
-
-        created_or_existing_pks.append(ct.pk)
-        created_or_existing_by_unique[(app_label, model_name)] = ct.pk
-
-    # Now lets see if we should remove any
-
-    to_remove = [x for x in ContentType.objects.filter(app_label=app_label) if x.pk not in created_or_existing_pks]
-
-    # Now it's possible that our get_or_create failed because of consistency issues and we create a duplicate.
-    # Then the original appears in the to_remove and we remove the original. This is bad. So here we go through the
-    # to_remove list, and if we created the content type just now, we delete that one, and restore the original in the
-    # cache
-    for ct in to_remove:
-        unique = (ct.app_label, ct.model)
-        if unique in created_or_existing_by_unique:
-            # We accidentally created a duplicate above due to HRD issues, delete the one we created
-            ContentType.objects.get(pk=created_or_existing_by_unique[unique]).delete()
-            created_or_existing_by_unique[unique] = ct.pk
-            ct.save()  # Recache this one in the context cache
-
-    to_remove = [ x for x in to_remove if (x.app_label, x.model) not in created_or_existing_by_unique ]
-
-    # Now, anything left should actually be a stale thing. It's still possible we missed some but they'll get picked up
-    # next time. Confirm that the content type is stale before deletion.
-    if to_remove:
-        if kwargs.get('interactive', False):
-            content_type_display = '\n'.join([
-                '    %s | %s' % (x.app_label, x.model)
-                for x in to_remove
-            ])
-            ok_to_delete = input("""The following content types are stale and need to be deleted:
-
-%s
-
-Any objects related to these content types by a foreign key will also
-be deleted. Are you sure you want to delete these content types?
-If you're unsure, answer 'no'.
-
-    Type 'yes' to continue, or 'no' to cancel: """ % content_type_display)
-        else:
-            ok_to_delete = False
-
-        if ok_to_delete == 'yes':
-            for ct in to_remove:
-                if verbosity >= 2:
-                    print("Deleting stale content type '%s | %s'" % (ct.app_label, ct.model))
-                ct.delete()
-        else:
-            if verbosity >= 2:
-                print("Stale content types remain.")
-
-
-def patch(sender):
-    from django.contrib.contenttypes.management import update_contenttypes as original
-
-    if original == update_contenttypes:
-        return
-
-    signals.post_migrate.disconnect(original)
-
-    from django.conf import settings
-    if getattr(settings, "DJANGAE_SIMULATE_CONTENTTYPES", False):
-        from django.contrib.contenttypes import models
-
-        if not isinstance(models.ContentType.objects, SimulatedContentTypeManager):
-            models.ContentType.objects = SimulatedContentTypeManager()
-    else:
-        signals.post_migrate.connect(update_contenttypes, sender=sender)

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'djangae.contrib.security',
     'djangae.contrib.consistency',
     'django.contrib.contenttypes',
+    'djangae.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.messages',
@@ -159,7 +160,6 @@ AUTH_USER_MODEL = 'djangae.GaeDatastoreUser'
 GENERATE_SPECIAL_INDEXES_DURING_TESTING = True
 COMPLETE_FLUSH_WHILE_TESTING = True
 DJANGAE_SEQUENTIAL_IDS_IN_TESTS = True
-DJANGAE_SIMULATE_CONTENTTYPES = True
 
 TEST_RUNNER = 'djangae.test_runner.SkipUnsupportedRunner'
 DJANGAE_ADDITIONAL_TEST_APPS = ["djangae"] + TO_TEST


### PR DESCRIPTION
Fixes #682 

Summary of changes proposed in this Pull Request:
- Moves ContentType patch to djangae.contrib.contenttypes
- If django.contrib.contenttypes is in INSTALLED_APPS, but not djangae.contrib.contenttypes, raises an ImproperlyConfigured error
