### PR TITLE
Move changelog entry for #684 from 0.9.5 to 0.9.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug fixes:
 
--
+- Fixed a regression that prevented precreated users from logging in when `DJANGAE_CREATE_UNKNOWN_USER` is False.
 
 ### Documentation:
 
@@ -40,7 +40,6 @@ filenames properly.
 - Fix for `RelatedIterator` that fails when related iterated fields model is set as string.
 - Ensure `MapReduceTask `uses the db returned by the application router(s) unless explicitly passed.
 - Fixed bug with `__iexact` indexer where values containing underscores would not be correctly indexed.  (Existing objects will need to be re-saved to be correctly indexed.)
-- Fixed a regression that prevented precreated users from logging in when `DJANGAE_CREATE_UNKNOWN_USER` is False
 
 ### Documentation:
 


### PR DESCRIPTION
#684 was committed before the 0.9.5 release but was not merged until afterwards, and hence the CHANGELOG entry ended up in the wrong section.  This fixes that.