### PR TITLE
Fix unique constraint violation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug fixes:
 
 - Fixed a regression that prevented precreated users from logging in when `DJANGAE_CREATE_UNKNOWN_USER` is False.
+- Fixed a bug where the IntegrityError for a unique constraint violation could mention the wrong field(s).
 
 ### Documentation:
 

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -93,11 +93,11 @@ def _acquire_identifiers(identifiers, entity_key):
                 created=now
             ))
         elif existing_marker.instance != entity_key and key_exists(existing_marker.instance):
-                fields_and_values = identifier.split("|")
-                table_name = fields_and_values[0]
-                fields_and_values = fields_and_values[1:]
-                fields = [ x.split(":")[0] for x in fields_and_values ]
-                raise IntegrityError("Unique constraint violation for kind {} on fields: {}".format(table_name, ", ".join(fields)))
+            fields_and_values = identifier.split("|")
+            table_name = fields_and_values[0]
+            fields_and_values = fields_and_values[1:]
+            fields = [ x.split(":")[0] for x in fields_and_values ]
+            raise IntegrityError("Unique constraint violation for kind {} on fields: {}".format(table_name, ", ".join(fields)))
         elif existing_marker.instance != entity_key:
             markers_to_create.append(UniqueMarker(
                 key=identifier_key,

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -93,7 +93,7 @@ def _acquire_identifiers(identifiers, entity_key):
                 created=now
             ))
         elif existing_marker.instance != entity_key and key_exists(existing_marker.instance):
-            fields_and_values = identifier.split("|")
+            fields_and_values = identifier_key.name().split("|")
             table_name = fields_and_values[0]
             fields_and_values = fields_and_values[1:]
             fields = [ x.split(":")[0] for x in fields_and_values ]


### PR DESCRIPTION
This fixes a bug where, if your model had more than one unique or unique_together constraint, a violation of one of those constraints could raise an IntegrityError which blamed the violation on the other constraint.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
