### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The best way to run Django on Google App Engine.
 Djangae (djan-gee) is a Django app that allows you to run Django applications on Google App Engine, including (if you
 want to) using Django's models with the App Engine Datastore as the underlying database.
 
-Documentation: https://djangae.readthedocs.org/
+Documentation: https://djangae.readthedocs.io/
 
 Google Group: https://groups.google.com/forum/#!forum/djangae-users
 
@@ -36,7 +36,7 @@ GitHub: https://github.com/potatolondon/djangae
 
 ## Documentation
 
-https://djangae.readthedocs.org/
+https://djangae.readthedocs.io/
 
 ## Supported Django Versions
 
@@ -45,7 +45,7 @@ Django 1.8 and 1.9 are supported.
 
 # Installation
 
-See https://djangae.readthedocs.org/en/latest/installation/
+See https://djangae.readthedocs.io/en/latest/installation/
 
 
 # Contributing to Djangae


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.