### PR TITLE
Gauth supuser sync mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features & improvements:
 
--
+- Added a `DJANGAE_SUPERUSER_SYNC_MODE` setting to allow control of whether and how the gauth middleware updates users' `is_superuser` based on whether or not they are an admin of the App Engine application.
 
 ### Bug fixes:
 

--- a/djangae/contrib/gauth/middleware.py
+++ b/djangae/contrib/gauth/middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth import authenticate, login, logout, get_user, BACKEND_SESSION_KEY, load_backend
 from django.contrib.auth.middleware import AuthenticationMiddleware as DjangoMiddleware
 from django.contrib.auth.models import BaseUserManager, AnonymousUser
@@ -42,12 +43,9 @@ class AuthenticationMiddleware(DjangoMiddleware):
         # Note that the logic above may have logged us out, hence new `if` statement
         if django_user.is_authenticated():
             # Now make sure we update is_superuser and is_staff appropriately
-            is_superuser = users.is_current_user_admin()
             resave = False
 
-            if is_superuser != django_user.is_superuser:
-                django_user.is_superuser = django_user.is_staff = is_superuser
-                resave = True
+            resave = sync_superuser(django_user)
 
             # for users which already exist, we want to verify that their email is still correct
             # users are already authenticated with their user_id, so we can save their real email
@@ -60,3 +58,28 @@ class AuthenticationMiddleware(DjangoMiddleware):
                 django_user.save()
 
         request.user = django_user
+
+
+def sync_superuser(user):
+    """ Syncs the is_superuser and is_staff flags on the given user with the result of
+        is_current_user_admin() according to the DJANGAE_SUPERUSER_SYNC_MODE.
+        Returns True if the user needs re-saving.
+    """
+    mode = getattr(settings, 'DJANGAE_SUPERUSER_SYNC_MODE', 1)
+    if mode == 0:
+        # Mode 0 is do nothing
+        return False
+    elif mode == 1:
+        # Mode 1 is to make GAE admins superusers, but not require superusers to be GAE admins
+        if not (user.is_superuser and user.is_staff) and users.is_current_user_admin():
+            user.is_staff, user.is_superuser = True, True
+            return True
+    elif mode == 2:
+        # Mode 2 is to enforce that all superusers are GAE admins and vice versa
+        is_gae_admin = users.is_current_user_admin()
+        if user.is_superuser != is_gae_admin:
+            # You could argue that we shouldn't set is_staff to False if it's currently True, but
+            # setting it to False is the safer option
+            user.is_superuser = user.is_staff = is_gae_admin
+            return True
+    return False

--- a/djangae/contrib/gauth/settings.py
+++ b/djangae/contrib/gauth/settings.py
@@ -9,3 +9,11 @@ LOGIN_URL = 'djangae_login_redirect'
 # Set this to True to allow unknown Google users to sign in. Matching is done
 # by email. Defaults to False.
 # DJANGAE_CREATE_UNKNOWN_USER = False
+
+# This determines whether/how the gauth middleware updates the `is_superuser` and `is_staff` fields
+# based on whether the current user is an admin of the App Engine application
+# 0: Do not update the is_superuser or is_staff fields at all.
+# 1: Set all App Engine admins to be superusers, but also allow other superusers to exist.
+# 2: Set all App Engine admins to be superusers and all non-App Engine admins to not be superusers.
+# Default:
+# DJANGAE_SUPERUSER_SYNC_MODE = 1

--- a/docs/gauth.md
+++ b/docs/gauth.md
@@ -90,7 +90,7 @@ The URL for the user to be sent to afterwards should be provided in `request.GET
 
 Learn more about [Google multiple sign-in on App Engine here](https://p.ota.to/blog/2014/2/google-multiple-sign-in-on-app-engine/).
 
-### Example usage:
+### Example switch accounts usage:
 
 Include GAuth urls in your main urls.py file.
 
@@ -103,3 +103,11 @@ Use this URL to add "Switch account" functionality for user:
 ```html
 <a href="{% url 'djangae_switch_accounts' %}">Switch account</a>
 ```
+
+## Making App Engine Admins into Superusers
+
+Gauth provides a setting to allow you to control whether and/or how gauth updates users' `is_superuser` and `is_staff` fields based on whether or not they are admins of the App Engine application.  The setting is `DJANGAE_SUPERUSER_SYNC_MODE` and it has 3 possible values.
+
+* `0`: Do not update the `is_superuser` or `is_staff` fields at all.
+* `1` (default): Any user who is authenticated as an admin of the App Engine application will have `is_staff` and `is_superuser` set to `True`, but there can also be other superusers who are not admins of the App Engine application and these will not be altered.
+* `2`: All users will have `is_staff` and `is_superuser` set to `True` or `False` based on whether or not they are admins of the App Engine application.


### PR DESCRIPTION
Currently, the gauth middleware sets `is_staff` and `is_superuser` on all users based on whether or not they are admins of the App Engine application.  This is generally useful but sometimes annoying, as it means that (1) you can't have any superusers which are not GAE admins (because gauth sets their superuser flag back to `False)`, and (2) it forcefully makes all GAE admins into superusers, which is not necessarily what you want, especially if you have some which only have the "viewer" role.

This pull request replaces that forceful, one-size-fits-all approach with a setting to allow you to choose whether or how the users' superuser status is sync'd with their GAE admin status.  So you can now choose to have

* Enforced syncing (like the current behaviour).
* Semi-syncing (GAE admins are set to superuser, but you can set other users to be superusers too, and they don't get altered).
* No syncing at all.

The mode is controlled via the new `DJANGAE_SUPERUSER_SYNC_MODE` setting.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
