### PR TITLE
Fix contenttypes warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a regression that prevented precreated users from logging in when `DJANGAE_CREATE_UNKNOWN_USER` is False.
 - Fixed a bug where the IntegrityError for a unique constraint violation could mention the wrong field(s).
 - Changed the default value of `DJANGAE_CREATE_UNKNOWN_USER` to `True` to match the original behaviour.
+- Fixed a bug where simulate contenttypes was required even on a SQL database
 
 ### Documentation:
 

--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -21,6 +21,14 @@ class DjangaeConfig(AppConfig):
             "django.contrib.contenttypes."
         )
         if 'django.contrib.contenttypes' in settings.INSTALLED_APPS:
+            from django.db import router, connections
+            conn = connections[router.db_for_read("contenttypes.ContentType")]
+
+            if conn.settings_dict.get("ENGINE") != 'djangae.db.backends.appengine':
+                # Don't enforce djangae.contrib.contenttypes if content types are being
+                # saved to a different database backend
+                return
+
             if not 'djangae.contrib.contenttypes' in settings.INSTALLED_APPS:
                 # Raise error if User is using Django CT, but not Djangae
                 raise contenttype_configuration_error


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Prevents the contenttypes warning unless we're running on the appengine backend

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change (n/a)
