### PR TITLE
Don't rely on db_for_read accepting strings

### DIFF
--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -22,7 +22,7 @@ class DjangaeConfig(AppConfig):
         )
         if 'django.contrib.contenttypes' in settings.INSTALLED_APPS:
             from django.db import router, connections
-            from django.contrib.contentttypes.models import ContentType
+            from django.contrib.contenttypes.models import ContentType
             conn = connections[router.db_for_read(ContentType)]
 
             if conn.settings_dict.get("ENGINE") != 'djangae.db.backends.appengine':

--- a/djangae/apps.py
+++ b/djangae/apps.py
@@ -22,7 +22,8 @@ class DjangaeConfig(AppConfig):
         )
         if 'django.contrib.contenttypes' in settings.INSTALLED_APPS:
             from django.db import router, connections
-            conn = connections[router.db_for_read("contenttypes.ContentType")]
+            from django.contrib.contentttypes.models import ContentType
+            conn = connections[router.db_for_read(ContentType)]
 
             if conn.settings_dict.get("ENGINE") != 'djangae.db.backends.appengine':
                 # Don't enforce djangae.contrib.contenttypes if content types are being


### PR DESCRIPTION
Fixes #[include a number of issue this PR is fixing].

Summary of changes proposed in this Pull Request:
- Use model class rather than string when using db_for_read

PR checklist:
- [X] Updated relevant documentation
- [X] Updated CHANGELOG.md 
- [X] Added tests for my change

Apparently the default Django router does, but it's not documented that custom routers
need to support strings, only model classes.