### PR TITLE
Fix `ValidationError` import error in JSON field.

### DIFF
--- a/djangae/forms/fields.py
+++ b/djangae/forms/fields.py
@@ -84,7 +84,7 @@ class JSONFormField(forms.CharField):
             try:
                 value = json.loads(value)
             except ValueError:
-                raise ValidationError("Could not parse value as JSON")
+                raise forms.ValidationError("Could not parse value as JSON")
         return value
 
 


### PR DESCRIPTION
The `ValidationError` exception is not imported in the file, it can be reached from `forms`.

Summary of changes proposed in this Pull Request:
- Fixes import error.