### PR TITLE
Change the flow of try/exept in `ContextDecorator`.

### DIFF
--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -72,13 +72,12 @@ class ContextDecorator(object):
         def decorated(*_args, **_kwargs):
             decorator_args = self.decorator_args.copy()
             exception = False
+            self.__class__._do_enter(self._push_state(), decorator_args)
             try:
-                self.__class__._do_enter(self._push_state(), decorator_args)
-                try:
-                    return self.func(*_args, **_kwargs)
-                except:
-                    exception = True
-                    raise
+                return self.func(*_args, **_kwargs)
+            except:
+                exception = True
+                raise
             finally:
                 self.__class__._do_exit(self._pop_state(), decorator_args, exception)
 


### PR DESCRIPTION
Previously, if there was an error in `_do_enter` then `_do_exit` would still be called.  And given that in the `AtomicDecorator`, `_do_exit` relies on things that `_do_enter` does, this means that another error would be raised in `_do_exit`, and the original error from `_do_enter` would never be seen, making debugging extremely difficult.

This change doesn't actually alter the functionality, but it might help us to debug a rare edge case issue that we're seeing where `state.transaction_started` raises an `AttributeError` in `_do_exit`, which is likely being caused by an error in `_do_enter` which we currently can't see.