### PR TITLE
Fix truncating microseconds on time and datetime fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed the default value of `DJANGAE_CREATE_UNKNOWN_USER` to `True` to match the original behaviour.
 - Fixed a bug where simulate contenttypes was required even on a SQL database
 - Fixed a bug where filtering on an empty PK would result in an inequality filter being used
+- Fixed a bug where making a projection query on time or datetime fields will return truncated values without microseconds
 
 ### Documentation:
 

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -26,7 +26,8 @@ from djangae.db.utils import (
     django_instance_to_entity,
     MockInstance,
     has_concrete_parents,
-    get_field_from_column
+    get_field_from_column,
+    ensure_datetime,
 )
 
 from djangae.db.backends.appengine import POLYMODEL_CLASS_ATTRIBUTE
@@ -106,15 +107,6 @@ def field_conv_day_only(value):
     value = ensure_datetime(value)
     return datetime(value.year, value.month, value.day, 0, 0)
 
-
-def ensure_datetime(value):
-    """
-        Painfully, sometimes the Datastore returns dates as datetime objects, and sometimes
-        it returns them as unix timestamps in microseconds!!
-    """
-    if isinstance(value, long):
-        return datetime.fromtimestamp(value / 1000000)
-    return value
 
 def coerce_unicode(value):
     if isinstance(value, str):

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -40,7 +40,8 @@ from djangae.db.backends.appengine import POLYMODEL_CLASS_ATTRIBUTE
 from djangae.db.utils import (
     get_top_concrete_parent,
     has_concrete_parents,
-    get_field_from_column
+    get_field_from_column,
+    ensure_datetime,
 )
 
 from google.appengine.api import datastore
@@ -302,7 +303,6 @@ class Query(object):
             raise NotSupportedError("Unsupported annotation %s" % name)
 
         def process_date(value, lookup_type):
-            from djangae.db.backends.appengine.commands import ensure_datetime #FIXME move func to utils
             value = ensure_datetime(value)
             ret = datetime.datetime.fromtimestamp(0)
 

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -409,3 +409,13 @@ def entity_matches_query(entity, query):
             return True
 
     return False
+
+
+def ensure_datetime(value):
+    """
+        Painfully, sometimes the Datastore returns dates as datetime objects, and sometimes
+        it returns them as unix timestamps in microseconds!!
+    """
+    if isinstance(value, long):
+        return datetime.fromtimestamp(value / 1000000)
+    return value

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -417,5 +417,5 @@ def ensure_datetime(value):
         it returns them as unix timestamps in microseconds!!
     """
     if isinstance(value, long):
-        return datetime.fromtimestamp(value / 1000000)
+        return datetime.fromtimestamp(value / 1e6)
     return value

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -722,6 +722,18 @@ class BackendTests(TestCase):
         entity = datastore.Get(key)
         self.assertTrue(isinstance(entity['duration_field'], (int, long)))
 
+    def test_datetime_and_time_fields_precision_for_projection_queries(self):
+        """
+        The returned datetime and time values should include microseconds.
+        See issue #707.
+        """
+        t = datetime.time(22, 13, 50, 541022)
+        dt = datetime.datetime(2016, 5, 27, 18, 40, 12, 927371)
+        NullDate.objects.create(time=t, datetime=dt)
+        result = NullDate.objects.all().values_list('time', 'datetime')
+        expected = [(t, dt)]
+        self.assertItemsEqual(result, expected)
+
 
 class ModelFormsetTest(TestCase):
     def test_reproduce_index_error(self):


### PR DESCRIPTION
Fixes #707.

Summary of changes proposed in this Pull Request:
- Fix a random test
- Fix the issue and bit of cleanup 

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
