### PR TITLE
Change `test_ordering_on_sparse_field` to avoid intermittent failure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed the default value of `DJANGAE_CREATE_UNKNOWN_USER` to `True` to match the original behaviour.
 - Fixed a bug where simulate contenttypes was required even on a SQL database
 - Fixed a bug where filtering on an empty PK would result in an inequality filter being used
+- Fixed a test which could intermittently fail (`test_ordering_on_sparse_field`).
 
 ### Documentation:
 

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -646,7 +646,7 @@ class BackendTests(TestCase):
         entity.update(values)
         datastore.Put(entity)
 
-        # Ok, we can get all 3 instances
+        # Ok, we can get all 4 instances
         self.assertEqual(TestFruit.objects.count(), 4)
 
         # Sorted list. No exception should be raised
@@ -654,12 +654,14 @@ class BackendTests(TestCase):
         with sleuth.watch('djangae.db.backends.appengine.commands.utils.django_ordering_comparison') as compare:
             all_names = ['a', 'b', 'c', 'd']
             fruits = list(
-                TestFruit.objects.filter(name__in=all_names).order_by('color')
+                TestFruit.objects.filter(name__in=all_names).order_by('color', 'name')
             )
             # Make sure troubled code got triggered
             # ie. with all() it doesn't
             self.assertTrue(compare.called)
 
+        # Test the ordering of the results.  The ones with a color of None should come back first,
+        # and of the ones with color=None, they should be ordered by name
         # Missing one (None) as first
         expected_fruits = [
             ('c', None), ('d', None), ('a', 'a'), ('b', 'b'),


### PR DESCRIPTION
`test_ordering_on_sparse_field` tests the order in which objects are returned when the field that is being ordered on is missing.  It correctly checks that the objects with a missing value are returned before objects *with* a value, but it also expects the objects with a missing value to come back in a specific order.

This change removes the ambiguity of the ordering of items with a `color` value of `None`.


PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change

