### PR TITLE
Change the default for ALLOWED_HOSTS to '*'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### New features & improvements:
 
--
+- ALLOWED_HOSTS is now set to ("*",) by default as App Engine deals with routing and this prevents
+  users being confused when their deployed app returns 400 responses.
 
 ### Bug fixes:
 

--- a/djangae/settings_base.py
+++ b/djangae/settings_base.py
@@ -48,10 +48,9 @@ LOGGING = {
 
 EMAIL_BACKEND = 'djangae.mail.AsyncEmailBackend'
 
-# Setting to *.appspot.com is OK, because GAE takes care of domain routing
-# it needs to be like this because of the syntax of addressing non-default versions
-# (e.g. -dot-)
-ALLOWED_HOSTS = (".appspot.com", )
+# Setting to * is OK, because GAE takes care of domain routing - setting it to anything
+# else just causes unnecessary pain when something isn't accessible under a custom domain
+ALLOWED_HOSTS = ("*",)
 
 DJANGAE_RUNSERVER_IGNORED_FILES_REGEXES = ['^.+$(?<!\.py)(?<!\.yaml)(?<!\.html)']
 # Note that these should match a directory name, not directory path:


### PR DESCRIPTION
Fixes #421 

Summary of changes proposed in this Pull Request:
- Change the ALLOWED_HOSTS default

PR checklist:
- [X] Updated relevant documentation
- [X] Updated CHANGELOG.md 
- [ ] Added tests for my change

Google takes care of defending against host header attacks and having this fixed at
any other value has caused confusion when deployed apps return 400 responses