### PR TITLE
Fix a bug when using an empty upload_to on a filefield on GCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed a bug where filtering on an empty PK would result in an inequality filter being used
 - Fixed a bug where making a projection query on time or datetime fields will return truncated values without microseconds
 - Fixed a test which could intermittently fail (`test_ordering_on_sparse_field`).
+- Fixed a bug where an empty upload_to argument to FileField would result in a broken "./" folder in Cloud Storage.
 
 ### Documentation:
 

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -303,6 +303,13 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
         fp = cloudstorage.open(self._add_bucket(name), mode=mode)
         return File(fp)
 
+    def get_valid_name(self, name):
+        # App Engine doesn't properly deal with "./" and a blank upload_to argument
+        # on a filefield results in ./filename so we must remove it if it's there.
+        if name.startswith("./"):
+            name = name.replace("./", "", 1)
+        return name
+
     def _add_bucket(self, name):
         safe_name = urllib.quote(name.encode('utf-8'))
         return '/{0}/{1}'.format(self.bucket, safe_name)
@@ -312,6 +319,8 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
         return mimetypes.guess_type(name)[0] or DEFAULT_CONTENT_TYPE
 
     def _save(self, name, content):
+        name = self.get_valid_name(name) #Make sure the name is valid
+
         kwargs = {
             'content_type': self._content_type_for_name(name),
             'options': self.write_options,

--- a/djangae/tests/test_storage.py
+++ b/djangae/tests/test_storage.py
@@ -50,6 +50,14 @@ class CloudStorageTests(TestCase):
         self.assertFalse(storage.exists(filename))
 
     @override_settings(CLOUD_STORAGE_BUCKET='test_bucket')
+    def test_dotslash_prefix(self):
+        storage = CloudStorage()
+        name = './my_file'
+        f = ContentFile('content')
+        filename = storage.save(name, f)
+        self.assertEqual(filename, name.lstrip("./"))
+
+    @override_settings(CLOUD_STORAGE_BUCKET='test_bucket')
     def test_supports_nameless_files(self):
         storage = CloudStorage()
         f2 = ContentFile('nameless-content')


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Generate a correct filename when using an empty upload_to on GCS

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change

