### PR TITLE
Fix user email case sensitivity once and for all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed a bug where making a projection query on time or datetime fields will return truncated values without microseconds
 - Fixed a test which could intermittently fail (`test_ordering_on_sparse_field`).
 - Fixed a bug where an empty upload_to argument to FileField would result in a broken "./" folder in Cloud Storage.
+- Fixed an issue where pre-created users may not have been able to log in if the email address associated with their Google account differed in case to the email address saved in their pre-created User object.
 
 ### Documentation:
 

--- a/djangae/contrib/gauth/common/models.py
+++ b/djangae/contrib/gauth/common/models.py
@@ -28,18 +28,13 @@ class GaeUserManager(UserManager):
         values.update(**extra_fields)
         values.update(
             # things which cannot be overridden
-            email=self.normalize_email(email),
+            email=self.normalize_email(email),  # lowercase the domain only
             username=None,
             password=make_password(None),  # unusable password
             # Stupidly, last_login is not nullable, so we can't set it to None.
         )
         return self.create(**values)
 
-    @classmethod
-    def normalize_email(cls, email):
-        """ Lowercase given email address """
-        email = email or ''
-        return email.lower()
 
 def _get_email_lower(user):
     """ Computer function for the computed lowercase email field. """

--- a/djangae/contrib/gauth/common/models.py
+++ b/djangae/contrib/gauth/common/models.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import (
     python_2_unicode_compatible,
     UserManager,
 )
+from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.utils.http import urlquote
 from django.db import models
@@ -12,7 +13,7 @@ from django.utils import timezone, six
 from django.utils.translation import ugettext_lazy as _
 
 # DJANGAE
-from djangae.fields import CharOrNoneField
+from djangae.fields import CharOrNoneField, ComputedCharField
 from .validators import validate_google_user_id
 
 
@@ -40,6 +41,12 @@ class GaeUserManager(UserManager):
         email = email or ''
         return email.lower()
 
+def _get_email_lower(user):
+    """ Computer function for the computed lowercase email field. """
+    # Note that the `email` field is not nullable, but the `email_lower` one is nullable and must
+    # not contain empty strings because it is unique
+    return user.email and user.email.lower() or None
+
 
 @python_2_unicode_compatible
 class GaeAbstractBaseUser(AbstractBaseUser):
@@ -54,8 +61,16 @@ class GaeAbstractBaseUser(AbstractBaseUser):
     )
     first_name = models.CharField(_('first name'), max_length=30, blank=True)
     last_name = models.CharField(_('last name'), max_length=30, blank=True)
-    # The null-able-ness of the email is only to deal with when an email address moves between Google Accounts
-    email = models.EmailField(_('email address'), unique=True, null=True)
+
+    # Email addresses are case sensitive, but many email systems and many people treat them as if
+    # they're not.  We must store the case-preserved email address to ensure that sending emails
+    # always works, but we must be able to query for them case insensitively and therefore we must
+    # enforce uniqueness on a case insensitive basis, hence these 2 fields
+    email = models.EmailField(_('email address'))
+    # The null-able-ness of the email_lower is only to deal with when an email address moves between
+    # Google Accounts and therefore we need to wipe it without breaking the unique constraint.
+    email_lower = ComputedCharField(_get_email_lower, unique=True, null=True)
+
     is_staff = models.BooleanField(
         _('staff status'), default=False,
         help_text=_('Designates whether the user can log into this admin site.')
@@ -106,3 +121,33 @@ class GaeAbstractBaseUser(AbstractBaseUser):
         if username:
             return "{} ({})".format(six.text_type(self.email), six.text_type(username))
         return six.text_type(self.email)
+
+    def validate_unique(self, exclude=None):
+        """ Check that the email address does not already exist by querying on email_lower. """
+        exclude = exclude or []
+        if "email_lower" not in exclude:
+            # We do our own check using the email_lower field, so we don't need Django to query
+            # on it as well
+            exclude.append("email_lower")
+
+        try:
+            super(GaeAbstractBaseUser, self).validate_unique(exclude=exclude)
+        except ValidationError as super_error:
+            pass
+        else:
+            super_error = None
+
+        if self.email and "email" not in exclude:
+            existing = self.__class__.objects.filter(email_lower=self.email.lower()).exists()
+            if existing:
+                model_name = self._meta.verbose_name
+                field_name = self._meta.get_field("email").verbose_name
+                message = "%s with this %s already exists" % (model_name, field_name)
+                error_dict = {"email": [message]}
+                if super_error:
+                    super_error.update_error_dict(error_dict)
+                    raise super_error
+                else:
+                    raise ValidationError(error_dict)
+        elif super_error:
+            raise

--- a/djangae/contrib/gauth/middleware.py
+++ b/djangae/contrib/gauth/middleware.py
@@ -48,18 +48,7 @@ class AuthenticationMiddleware(DjangoMiddleware):
     def sync_user_data(self, django_user, google_user):
         # Now make sure we update is_superuser and is_staff appropriately
         is_superuser = users.is_current_user_admin()
-        resave = False
 
         if is_superuser != django_user.is_superuser:
             django_user.is_superuser = django_user.is_staff = is_superuser
-            resave = True
-
-        # for users which already exist, we want to verify that their email is still correct
-        # users are already authenticated with their user_id, so we can save their real email
-        # not the lowercased version
-        if django_user.email != google_user.email():
-            django_user.email = google_user.email()
-            resave = True
-
-        if resave:
-            django_user.save()
+            django_user.save(update_fields=['is_superuser', 'is_staff'])

--- a/djangae/contrib/gauth/tests.py
+++ b/djangae/contrib/gauth/tests.py
@@ -282,27 +282,6 @@ class MiddlewareTests(TestCase):
         # and so with pre-creation required, authentication should have failed
         self.assertTrue(isinstance(request.user, AnonymousUser))
 
-    @override_settings(DJANGAE_CREATE_UNKNOWN_USER=True)
-    def test_middleware_resaves_email(self):
-        # Create user with uppercased email
-        email = 'User@example.com'
-        google_user = users.User(email, _user_id='111111111100000000001')
-        backend = AppEngineUserAPIBackend()
-        user = backend.authenticate(google_user=google_user,)
-        # Normalize_email should save a user with lowercase email
-        self.assertEqual(user.email, email.lower())
-
-        # Run AuthenticationMiddleware, if email are mismatched
-        with sleuth.switch('djangae.contrib.gauth.middleware.users.get_current_user', lambda: google_user):
-            request = HttpRequest()
-            SessionMiddleware().process_request(request)  # Make the damn sessions work
-            middleware = AuthenticationMiddleware()
-            middleware.process_request(request)
-
-        # Middleware should resave to uppercased email, keeping user the same
-        self.assertEqual(request.user.email, email)
-        self.assertEqual(request.user.pk, user.pk)
-
 
 @override_settings(
     AUTH_USER_MODEL='djangae.GaeDatastoreUser',

--- a/docs/gauth.md
+++ b/docs/gauth.md
@@ -3,7 +3,6 @@
 Djangae includes two applications to aid authentication and user management with
 App Engine. Each provides both an abstract class, to extend if you're defining your own custom User model, or a concrete version to use in place of `'django.contrib.auth.models.User'`.  Also provided are custom authentication backends which delegate to the App Engine users API and a middleware to handle the link between the Django's user object and App Engine's (amongst other things).
 
-The only minor difference between Djangae Gauth and Django Auth is that Djangae overrides `normalize_email` to lowercase whole email, not just the domain part like Django does. See rationale behind this decision in [issue #481 on Github](https://github.com/potatolondon/djangae/issues/481).
 
 ## Using the Datastore
 
@@ -86,7 +85,7 @@ and replace `'djangae.contrib.gauth.middleware.AuthenticationMiddleware'` with y
 
 You can add users to the database before they have logged in.  If you've set `DJANGAE_CREATE_UNKNOWN_USER` to `False` then **only** users who already exist in the database can log in.
 
-Users are keyed by their Google User ID, which is stored in the `username` field.  However, it is impossible to know what a user's Google User ID will be until they have logged in.  Therefore, pre-created users who have not yet logged in are keyed by their email address.  To create a user who has not yet logged in you can either:
+Users are keyed by their Google User ID, which is stored in the `username` field.  However, it is impossible to know what a user's Google User ID will be until they have logged in.  Therefore, pre-created users who have not yet logged in are keyed by their email address (case insensitively).  To create a user who has not yet logged in you can either:
 
 * Create the user via the Django admin, leaving the `username` field (labelled _"User ID"_) blank.  Or...
 * Create the user via the remote shell with `get_user_model().objects.pre_create_google_user("user@example.com")`.


### PR DESCRIPTION
Fixes #everything.  This will definitely not come back and bite me again.

Hopefully this removes all issues around the uppercase vs. lowercase differences in email addresses in Gauth.  So now:

* Neither the case of the email address of pre-created `User` object nor the case of the email address of the Google that a pre-created user logs in with make any difference.
* Email addresses are stored case sensitively, so that sending emails to people always works.
* Email addresses are forced to be unique on a case-insensitive basis, so:
  - You cannot create _a@example.com_ and _A@example.com.
  - In the rare case where the email address on a Google account changes and the original email address moves to a different Google account, it can change case when it moves and we will still handle it.
* All is good in the world.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
