### PR TITLE
723 on change sharded counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Alias DatastorePaginator -> Paginator, and DatastorePage -> Page to be more like Django
 - Moved `ContentType` patching to `djangae.contrib.contenttypes`. `DJANGAE_SIMULATE_CONTENTTYPES` setting has been removed, add `djangae.contrib.contenttypes` to `INSTALLED_APPS` instead. `djangae.contrib.contenttypes` needs to be after `django.contrib.contenttypes` in the `INSTALLED_APPS` order.
 - Allow customization of which user data is synced in gauth `AuthenticationMiddleware`.
+- Allow passing `on_change` callback run when ShardedCounter is changed.
 
 ### Bug fixes:
 

--- a/djangae/fields/counting.py
+++ b/djangae/fields/counting.py
@@ -109,7 +109,7 @@ class RelatedShardManager(RelatedIteratorManagerBase, models.Manager):
                 shard.save()
 
         # if the ShardedCounter has on_change callback, run it now
-        if hasattr(self.field, 'on_change'):
+        if self.field.on_change:
             self.field.on_change(self.instance, step, is_reset=is_reset)
 
     def _create_shard(self, count):
@@ -157,8 +157,7 @@ class ShardedCounterField(RelatedSetField):
                 "fetching in a single Get operation (%d)" % MAX_ENTITIES_PER_GET
             )
 
-        if "on_change" in kwargs:
-            self.on_change = kwargs.pop("on_change")
+        self.on_change = kwargs.pop("on_change", None)
 
         kwargs.setdefault("related_name", "+")
         super(ShardedCounterField, self).__init__('djangae.CounterShard', **kwargs)

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -64,6 +64,19 @@ class ModelWithManyCounters(models.Model):
         app_label = "djangae"
 
 
+def update_denormalized_counter(instance, step):
+    instance.denormalized_counter += step
+    instance.save()
+
+
+class ModelWithCountersWithCallback(models.Model):
+    counter = ShardedCounterField(on_change=update_denormalized_counter)
+    denormalized_counter = models.IntegerField(default=0)
+
+    class Meta:
+        app_label = "djangae"
+
+
 class ModelWithCounterWithManyShards(models.Model):
     # The DEFAULT_SHARD_COUNT is based on the max allowed in a Datastore transaction
     counter = ShardedCounterField(shard_count=DEFAULT_SHARD_COUNT+5)
@@ -177,7 +190,6 @@ class ShardedCounterTest(TestCase):
         instance.counter.increment(2)
         self.assertEqual(instance.counter.value(), 5)
 
-
     def test_decrement_step(self):
         """ Test the behvaviour of decrementing in steps of more than 1. """
         instance = ModelWithCounter.objects.create()
@@ -237,7 +249,6 @@ class ShardedCounterTest(TestCase):
         instance = ModelWithCounter.objects.get()
         self.assertEqual(instance.counter.all().count(), DEFAULT_SHARD_COUNT)
 
-
     def test_label_reference_is_saved(self):
         """ Test that each CounterShard which the field creates is saved with the label of the
             model and field to which it belongs.
@@ -264,6 +275,28 @@ class ShardedCounterTest(TestCase):
         instance.counter1.reset()
         self.assertEqual(instance.counter1.value(), 0)
         self.assertEqual(instance.counter2.value(), 1)
+
+    def test_on_change_callback_called(self):
+        """ Test that if ShardedCounter has on_change callback specified, it
+            will be called after any change to the counter.
+        """
+        instance = ModelWithCountersWithCallback.objects.create()
+        self.assertEquals(instance.denormalized_counter, 0)
+
+        # callback called after increment
+        instance.counter.increment(5)
+        instance.refresh_from_db()
+        self.assertEquals(instance.denormalized_counter, 5)
+
+        # after decrement
+        instance.counter.decrement(1)
+        instance.refresh_from_db()
+        self.assertEquals(instance.denormalized_counter, 4)
+
+        # and reset
+        instance.counter.reset()
+        instance.refresh_from_db()
+        self.assertEquals(instance.denormalized_counter, 0)
 
 
 class IterableFieldTests(TestCase):

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -101,10 +101,10 @@ If you want to perform some actions after a sharded counter was changed you can 
 
 ```your_field = ShardedCounterField(on_change=your_callback_function)```
 
-The callback function takes two arguments: `instance` and `step`, where instance is the instance of the object with the `ShardedCounterField` and `step` informs us how much the counter was changed.
+The callback function takes two arguments: `instance`, `step` and optional `is_reset`, where instance is the instance of the object with the `ShardedCounterField`, `step` informs us how much the counter was changed and `is_reset` lets us know if the counter was reset.
 
 ```python
-def your_callback_function(instance, step):
+def your_callback_function(instance, step, is_reset=False):
     ...
 ```
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -95,6 +95,21 @@ When you access the attribute of your sharded counter field on your model, you g
 * `.reset()`: Resets the counter to 0.
     - This is done by changing the value of the shards, not by deleting them.  So you can continue to use your counter afterwards without having to call `populate()` again first.
 
+### Callback function
+
+If you want to perform some actions after a sharded counter was changed you can provide `on_change` argument with a function to call.
+
+```your_field = ShardedCounterField(on_change=your_callback_function)```
+
+The callback function takes two arguments: `instance` and `step`, where instance is the instance of the object with the `ShardedCounterField` and `step` informs us how much the counter was changed.
+
+```python
+def your_callback_function(instance, step):
+    ...
+```
+
+The function will be called every time you run `increment`, `decrement` and `reset`.
+
 
 ### Additional notes:
 


### PR DESCRIPTION
Fixes #723.

Summary of changes proposed in this Pull Request:
- allow passing `on_change` callback function to `ShardedCounterField`
- call callback function when counter was changed (on `increment`, `decrement` and `reset`)

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
