### PR TITLE
Fix bug where existing User objects wouldn't validate due to email unique constraint not excluding self.

### DIFF
--- a/djangae/contrib/gauth/common/models.py
+++ b/djangae/contrib/gauth/common/models.py
@@ -135,8 +135,10 @@ class GaeAbstractBaseUser(AbstractBaseUser):
             super_error = None
 
         if self.email and "email" not in exclude:
-            existing = self.__class__.objects.filter(email_lower=self.email.lower()).exists()
-            if existing:
+            existing = self.__class__.objects.filter(email_lower=self.email.lower())
+            if not self._state.adding:
+                existing = existing.exclude(pk=self.pk)
+            if existing.exists():
                 model_name = self._meta.verbose_name
                 field_name = self._meta.get_field("email").verbose_name
                 message = "%s with this %s already exists" % (model_name, field_name)

--- a/djangae/contrib/gauth/tests.py
+++ b/djangae/contrib/gauth/tests.py
@@ -453,7 +453,7 @@ class ModelTests(TestCase):
         """
         no_pass = make_password(None)
         User = get_user_model()
-        User.objects.create_user("111111111111111111111", email="ab@example.com", password=no_pass)
+        user1 = User.objects.create_user("111111111111111111111", email="ab@example.com", password=no_pass)
         user2 = User(username="111111111111111111112", email="AB@example.com", password=no_pass)
         # We expect the second user to have a unique violation on the `email_lower` field, but it
         # should be attached to the (editable) `email` field
@@ -462,3 +462,6 @@ class ModelTests(TestCase):
         except ValidationError as e:
             self.assertTrue("email" in e.error_dict)
             self.assertFalse("email_lower" in e.error_dict)
+        # We should still be able to edit the existing user though
+        user1.email = "AB@example.com"
+        user1.full_clean()


### PR DESCRIPTION
Fixes the second thing that I broke in #722.

Summary of changes proposed in this Pull Request:
- See title.

PR checklist:  
(I'm not adding this to the changelog and am going to pretend that this was all done as part of #722.)

- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [x] Added tests for my change