### PR TITLE
Make various fixes to `runtests.sh` and `testapp/install_deps.py`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - ALLOWED_HOSTS is now set to ("*",) by default as App Engine deals with routing and this prevents
   users being confused when their deployed app returns 400 responses.
-- Added version string to `__init__`
+- Added version string to `__init__`.
+- Added an `--install_deps` flag to the `runtests.sh` script to allow triggering of dependency installation without having to delete the SDK folder.
+- Added an `--install_sdk` flag to both the `runtests.sh` script and to the `install_deps.py` script in the bundled 'testapp'.
 
 ### Bug fixes:
 
@@ -18,6 +20,7 @@
 - Fixed a bug where an empty upload_to argument to FileField would result in a broken "./" folder in Cloud Storage.
 - Fixed an issue where pre-created users may not have been able to log in if the email address associated with their Google account differed in case to the email address saved in their pre-created User object.
 - Made configuration changes to the bundled 'testapp' to allow the `runserver` command to work.
+- Fixed a bug in the `install_deps.py` script in the bundled 'testapp' where it would always re-install the App Engine SDK, even if it already existed.
 
 ### Documentation:
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,19 @@ For running the tests, you just need to run:
 
     $ ./runtests.sh
 
-On the first run this will download the App Engine SDK, pip install a bunch of stuff locally (into a folder, no virtualenv needed), download the Django tests and run them.  Subsequent runs will just run the tests. If you want to run the tests on a specific Django version, simply do:
+On the first run this will download the App Engine SDK, pip install a bunch of stuff locally (into a folder, no virtualenv needed), download the Django tests and run them.  Subsequent runs will just run the tests. If you want to run the tests on a specific Django version, you can switch the installed version by doing:
 
-    $ DJANGO_VERSION=1.8 ./runtests.sh
+    $ DJANGO_VERSION=1.8 ./runtests.sh --install_deps
 
 Currently the default is 1.8. TravisCI runs on 1.8 and 1.9 currently.
+
+If you want to run the tests on a specific App Engine SDK version, then you can switch the installed version by doing:
+
+    $ SDK_VERSION=1.9.35 ./runtests.sh --install_sdk
+
+Note that this also re-installs the dependencies, so will reset the Django version to the default of 1.8.
+
+
 
 You can run specific tests in the usual way by doing:
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -2,14 +2,36 @@
 
 cd testapp;
 
+# Check for the --install_deps and --install_sdk args, and pass the other args down to manage.py test
+ARGS=()
+for var in "$@"; do
+    if [ "$var" = '--install_deps' ]; then
+        INSTALL_DEPS=true
+    elif [ "$var" = '--install_sdk' ]; then
+        INSTALL_DEPS=true
+        INSTALL_SDK=true
+    else
+        ARGS[${#ARGS[@]}]="$var"
+    fi
+done
+
+# If the SDK doesn't exist then we want to run install_deps anyway.  We don't need to pass
+# install_sdk to it because it will detect that the SDK doesn't exist anyway.
 if [ ! -d "libs/google_appengine" ]; then
-    echo "SDK directory not found, installing SDK and dependencies..."
-    python install_deps.py
-else
-    echo "SDK directory already exists, not installing dependencies."
-    echo "Run python testapp/install_deps.py manually to install/upgrade dependencies."
+    INSTALL_DEPS=true
 fi
 
-python manage.py test "$@"
+if [ -n "$INSTALL_DEPS" ]; then
+    echo "Running install_deps..."
+    if [ -n "$INSTALL_SDK" ]; then
+        python install_deps.py --install_sdk
+    else
+        python install_deps.py
+    fi
+else
+    echo "Not running install_deps.  Pass --install_deps if you want to install dependencies."
+fi
+
+python manage.py test "${ARGS[@]}"
 
 cd ..;

--- a/testapp/install_deps.py
+++ b/testapp/install_deps.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 import os
 import stat
-import subprocess
 import shutil
+import subprocess
+import sys
 
 import tarfile
 from StringIO import StringIO
@@ -16,8 +17,10 @@ TARGET_DIR = os.path.join(PROJECT_DIR, "libs")
 
 APPENGINE_TARGET_DIR = os.path.join(TARGET_DIR, "google_appengine")
 
-APPENGINE_SDK_VERSION = "1.9.37"
+DJANGO_VERSION = os.environ.get("DJANGO_VERSION", "1.8")
+APPENGINE_SDK_VERSION = os.environ.get("SDK_VERSION", "1.9.40")
 APPENGINE_SDK_FILENAME = "google_appengine_%s.zip" % APPENGINE_SDK_VERSION
+INSTALL_APPENGINE_SDK = "--install_sdk" in sys.argv
 
 # Google move versions from 'featured' to 'deprecated' when they bring
 # out new releases
@@ -25,6 +28,7 @@ FEATURED_SDK_REPO = "https://storage.googleapis.com/appengine-sdks/featured/"
 DEPRECATED_SDK_REPO = "https://storage.googleapis.com/appengine-sdks/deprecated/%s/" % APPENGINE_SDK_VERSION.replace('.', '')
 
 DJANGO_VERSION = os.environ.get("DJANGO_VERSION", "1.8")
+
 
 if any([x in DJANGO_VERSION for x in ['master', 'a', 'b', 'rc']]):
     # For master, beta, alpha or rc versions, get exact versions
@@ -35,10 +39,12 @@ else:
 
 if __name__ == '__main__':
 
-    if os.path.exists(TARGET_DIR):
-        shutil.rmtree(TARGET_DIR)
+    if INSTALL_APPENGINE_SDK or not os.path.exists(APPENGINE_TARGET_DIR):
 
-    if not os.path.exists(APPENGINE_TARGET_DIR):
+        # If we're going to install the App Engine SDK then we can just wipe the entire TARGET_DIR
+        if os.path.exists(TARGET_DIR):
+            shutil.rmtree(TARGET_DIR)
+
         print('Downloading the AppEngine SDK...')
 
         #First try and get it from the 'featured' folder
@@ -60,7 +66,13 @@ if __name__ == '__main__':
             st = os.stat(app)
             os.chmod(app, st.st_mode | stat.S_IEXEC)
     else:
-        print('Not updating SDK as it exists. Remove {} and re-run to get the latest SDK'.format(APPENGINE_TARGET_DIR))
+        print('Not updating SDK as it exists. Pass --install_sdk to install it.')
+        # In this sencario we need to wipe everything except the SDK from the TARGET_DIR
+        for name in os.listdir(TARGET_DIR):
+            path = os.path.join(TARGET_DIR, name)
+            if path == APPENGINE_TARGET_DIR:
+                continue
+            shutil.rmtree(path)
 
     print("Running pip...")
     args = ["pip", "install", "--no-deps", "-r", REQUIREMENTS_FILE, "-t", TARGET_DIR, "-I"]


### PR DESCRIPTION
Fixes #727.

Summary of changes proposed in this Pull Request:
* install_deps.py no longer installs the SDK every time, even when it exists.  It now only installs it if it doesn't exist or if you pass `--install_sdk`.
* install_deps.py now looks for an `SDK_VERSION` environment variable to allow easy installation of a different SDK version.
* runtests.sh now accepts an `--install_deps` flag so that you don't have to delete the App Engine SDK in order to get `install_deps` to be run, thus allowing the `DJANGO_VERSION=1.8` thing to work.
* Updated README to give correct instructions.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change - it's hard to write tests for, but I've tested it!

