### PR TITLE
Fix incorrect console URL stored in Mapreduce status entity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed an issue where pre-created users may not have been able to log in if the email address associated with their Google account differed in case to the email address saved in their pre-created User object.
 - Made configuration changes to the bundled 'testapp' to allow the `runserver` command to work.
 - Fixed a bug in the `install_deps.py` script in the bundled 'testapp' where it would always re-install the App Engine SDK, even if it already existed.
+- Fixed a bug where the console URL stored in a mapreduce job's status entity was incorrect.
 
 ### Documentation:
 

--- a/djangae/contrib/mappers/pipes.py
+++ b/djangae/contrib/mappers/pipes.py
@@ -38,7 +38,7 @@ class DjangaeMapperPipeline(MapperPipeline):
             )
         self.fill(self.outputs.job_id, mapreduce_id)
         self.set_status(console_url="%s/detail?mapreduce_id=%s" % (
-            (parameters.config.BASE_PATH, mapreduce_id)))
+            (BASE_PATH, mapreduce_id)))
 
     def callback(self):
         """


### PR DESCRIPTION
In the call to `set_status` after kicking off a Mapreduce we use the original
BASE_PATH instead of our own custom one when setting the console URL
for the pipeline. This breaks the pipelines status UI as it uses this
value to link to console URL of child pipelines.