### PR TITLE
Fix edgecase in SimulatedContentTypeManager

### DIFF
--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -43,6 +43,9 @@ class SimulatedContentTypeManager(models.Manager):
                 if model not in self._store.queried_models:
                     conn.queries.append("select * from {}".format(ContentType._meta.db_table))
                     break
+        
+        if not hasattr(self._store, "queried_models"):
+            self._store.queried_models = set()
 
         self._store.queried_models |= set(models or [])
 


### PR DESCRIPTION
I'm not sure exactly when this edge case happens, but it showed up when I tried to run Wagtail on Datastore ;) 

Wagtail is trying to do this: 
`ContentType.objects.get_for_models(*form_models).values()`, where `form_models == []`

Djangae blows up on this line: `self._store.queried_models |= set(models or [])` in `_update_queries` because `queried_models` doesn't exist on `self._store`: 

```
AttributeError at /admin/
'thread._local' object has no attribute 'queried_models'
```