### PR TITLE
Change `lower()` methods of DB commands to return unicode instead of str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ### New features & improvements:
 
-- 
+-
 -
 
 ### Bug fixes:
 
-- 
+- Fixed an issue where Django Debug Toolbar would get a `UnicodeDecodeError` if a query contained a non-ascii character.
 -
 
 ### Documentation:
 
 -
-- 
+-
 
 
 ## v0.9.7 (release date: 11th August 2016)

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -756,7 +756,7 @@ class SelectCommand(object):
         """
             This exists solely for django-debug-toolbar compatibility.
         """
-        return str(self).lower()
+        return unicode(self).lower()
 
 
 class FlushCommand(object):
@@ -928,7 +928,7 @@ class InsertCommand(object):
         """
             This exists solely for django-debug-toolbar compatibility.
         """
-        return str(self).lower()
+        return unicode(self).lower()
 
     def __unicode__(self):
         try:
@@ -1059,7 +1059,7 @@ class DeleteCommand(object):
         """
             This exists solely for django-debug-toolbar compatibility.
         """
-        return str(self).lower()
+        return unicode(self).lower()
 
 
 class UpdateCommand(object):
@@ -1074,7 +1074,7 @@ class UpdateCommand(object):
         """
             This exists solely for django-debug-toolbar compatibility.
         """
-        return str(self).lower()
+        return unicode(self).lower()
 
     def _update_entity(self, key):
         markers_to_acquire = []


### PR DESCRIPTION
Fixes #740.

Summary of changes proposed in this Pull Request:
- This avoids Django Debug Toolbar (which is the only thing these methods exist for) getting a UnicodeDecodeError when a query contains a non-ascii character.


PR checklist:
- N/A Updated relevant documentation
- [x] Updated CHANGELOG.md 
- N/A Added tests for my change
