### PR TITLE
Stop _get_queued_tasks flushing task queues other than the one specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Bug fixes:
 
 - Fixed an issue where Django Debug Toolbar would get a `UnicodeDecodeError` if a query contained a non-ascii character.
-- Fixed an issue where getting and flushing a specific TaskQueue using the test stub would flush all task queues.
+- Fixed an issue where getting and flushing a specific TaskQueue using the test stub (including when using `djangae.test.TestCase.process_task_queues`) would flush all task queues.
 -
 
 ### Documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug fixes:
 
 - Fixed an issue where Django Debug Toolbar would get a `UnicodeDecodeError` if a query contained a non-ascii character.
+- Fixed an issue where getting and flushing a specific TaskQueue using the test stub would flush all task queues.
 -
 
 ### Documentation:

--- a/djangae/test.py
+++ b/djangae/test.py
@@ -42,11 +42,14 @@ def inconsistent_db(probability=0, connection='default'):
 
 def _get_queued_tasks(stub, queue_name=None, flush=True):
     tasks = []
+    queues = stub.GetQueues()
 
-    for queue in stub.GetQueues():
+    if queue_name is not None:
+        queues = filter(lambda q: queue_name == q['name'], queues)
+
+    for queue in queues:
         for task in stub.GetTasks(queue['name']):
-            if queue_name is None or queue_name == queue['name']:
-                tasks.append(task)
+            tasks.append(task)
 
         if flush:
             stub.FlushQueue(queue["name"])

--- a/djangae/tests/test_test.py
+++ b/djangae/tests/test_test.py
@@ -1,0 +1,27 @@
+from google.appengine.ext import deferred
+
+from djangae.test import TestCase, _get_queued_tasks
+
+
+def my_task():
+    """
+    Basic task for testing task queues.
+    """
+    pass
+
+
+class TaskQueueTests(TestCase):
+
+    def test_get_queued_tasks_flush(self):
+        deferred.defer(my_task)
+        deferred.defer(my_task, _queue='another')
+
+        # We don't use self.assertNumTasksEquals here because we want to flush.
+        tasks = _get_queued_tasks(self.taskqueue_stub, queue_name='default')
+        self.assertEqual(1, len(tasks))
+
+        tasks = _get_queued_tasks(self.taskqueue_stub, queue_name='another')
+        self.assertEqual(1, len(tasks))
+
+        tasks = _get_queued_tasks(self.taskqueue_stub)
+        self.assertEqual(0, len(tasks))


### PR DESCRIPTION
Fixes #[742].

The internal testing function that gets a specific test stub task queue flushed all task queues instead of just the one specified. This caused a bug in `process_task_queues` where new tasks createdwhile processing a queue that do not belong to that queue would be flushed, and therefore never have a chance to execute.