### PR TITLE
SimulatedContentTypeManager improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features & improvements:
 
-- 
+- Cleaned up and refactored internal implementation of SimulatedContentTypeManager. Now also allows patching ContentType manager in migrations. 
 -
 
 ### Bug fixes:

--- a/djangae/contrib/contenttypes/migrations/0001_patch_contenttypes_migrations.py
+++ b/djangae/contrib/contenttypes/migrations/0001_patch_contenttypes_migrations.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.db.migrations.operations.base import Operation
+from djangae.contrib.contenttypes.models import SimulatedContentTypeManager
+
+
+class PatchMigrationsOperation(Operation):
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        pass
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        pass
+
+    def state_forwards(self, app_label, state):
+        """ Patch manager on ModelState during migrations """
+        contenttype = state.models[('contenttypes', 'contenttype')]
+        contenttype.managers[0] = ('objects', SimulatedContentTypeManager(model=contenttype))
+
+
+def get_installed_app_labels():
+    """ Get the app labels, because settings.INSTALLED_APPS doesn't necessarily give us the labels. 
+        Remove django.contrib.contenttypes because we want it to run before us. 
+        Return list of tuples like ('admin', '__first__') 
+    """
+    from django.apps import apps
+    app_labels = [app.label for app in apps.get_app_configs() if app.label != 'contenttypes']
+    return [(x, '__first__') for x in app_labels]
+    
+
+class Migration(migrations.Migration):
+
+    run_before = get_installed_app_labels()
+    
+    dependencies = [
+        ('contenttypes', '__first__')
+    ]
+
+    operations = [
+        PatchMigrationsOperation(),
+    ]

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -173,15 +173,17 @@ class SimulatedContentTypeManager(models.Manager):
 
     def get_or_create(self, **kwargs):
         ContentType = self._get_model()
+        original_kwargs = kwargs
         try:
             if "defaults" in kwargs:
                 del kwargs["defaults"]
             return self.get(**kwargs), False
         except ContentType.DoesNotExist:
-            raise NotImplementedError("You can't manually create simulated content types")
+            return self.create(**original_kwargs), True
 
     def filter(self, **kwargs):
         self._repopulate_if_necessary()
+
         def _condition(ct):
             for attr, val in kwargs.items():
                 if getattr(ct, attr) != val:

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -6,7 +6,6 @@ import django
 from django.db import router, connections, models
 from django.apps import apps
 from django.utils.encoding import smart_text
-from django.utils import six
 from djangae.crc64 import CRC64
 
 
@@ -21,7 +20,7 @@ class SimulatedContentTypeManager(models.Manager):
         crc = CRC64()
         crc.append(app_label)
         crc.append(model)
-        return crc.fini() - (2 ** 63) #GAE integers are signed so we shift down
+        return crc.fini() - (2 ** 63)  # GAE integers are signed so we shift down
 
     def _get_opts(self, model, for_concrete_model):
         if for_concrete_model:
@@ -59,7 +58,7 @@ class SimulatedContentTypeManager(models.Manager):
         self._update_queries(models)
 
         if not hasattr(self._store, "content_types"):
-            all_models = [ (x._meta.app_label, x._meta.model_name, x) for x in apps.get_models() ]
+            all_models = [(x._meta.app_label, x._meta.model_name, x) for x in apps.get_models()]
 
             self._update_queries([(x[0], x[1]) for x in all_models])
 
@@ -90,7 +89,7 @@ class SimulatedContentTypeManager(models.Manager):
         for_concrete_model = kwargs.get("for_concrete_models", True)
 
         self._update_queries(
-            [ (self._get_opts(x, for_concrete_model).app_label, self._get_opts(x, for_concrete_model).model_name) for x in models ]
+            [(self._get_opts(x, for_concrete_model).app_label, self._get_opts(x, for_concrete_model).model_name) for x in models]
         )
         ret = {}
         for model in models:

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -175,13 +175,13 @@ class SimulatedContentTypeManager(models.Manager):
 
     def get_or_create(self, **kwargs):
         ContentType = self._get_model()
-        original_kwargs = kwargs
+        defaults = kwargs.pop("defaults", None)
         try:
-            if "defaults" in kwargs:
-                del kwargs["defaults"]
             return self.get(**kwargs), False
         except ContentType.DoesNotExist:
-            return self.create(**original_kwargs), True
+            if defaults:
+                kwargs.update(**defaults)
+            return self.create(**kwargs), True
 
     def filter(self, **kwargs):
         self._repopulate_if_necessary()
@@ -196,7 +196,7 @@ class SimulatedContentTypeManager(models.Manager):
 
     def all(self, **kwargs):
         self._repopulate_if_necessary()
-        
+
         result = []
 
         for ct in self._store.content_types.keys():

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -163,6 +163,7 @@ class SimulatedContentTypeManager(models.Manager):
             return self.get(id=new_id)
 
     def get_or_create(self, **kwargs):
+        from django.contrib.contenttypes.models import ContentType
         try:
             del kwargs["defaults"]
             return self.get(**kwargs)
@@ -180,6 +181,8 @@ class SimulatedContentTypeManager(models.Manager):
         return [ct for ct in self.all() if _condition(ct)]
 
     def all(self, **kwargs):
+        self._repopulate_if_necessary()
+        
         result = []
 
         for ct in self._store.content_types.keys():

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -54,7 +54,7 @@ class SimulatedContentTypeManager(models.Manager):
                 if model not in self._store.queried_models:
                     conn.queries.append("select * from {}".format(ContentType._meta.db_table))
                     break
-        
+
         if not hasattr(self._store, "queried_models"):
             self._store.queried_models = set()
 
@@ -161,9 +161,11 @@ class SimulatedContentTypeManager(models.Manager):
             return result
 
     def create(self, **kwargs):
-        ContentType = self._get_model()
         self._repopulate_if_necessary()
-        logging.warning("Created simulated content type, this will not persist and will remain thread-local")
+        logging.warning(
+            "Created simulated content type, this will not persist and will remain only on this "
+            "app instance"
+        )
         new_id = self._get_id(kwargs["app_label"], kwargs["model"])
         kwargs["id"] = new_id
         if "pk" in kwargs:

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -176,8 +176,9 @@ class SimulatedContentTypeManager(models.Manager):
     def get_or_create(self, **kwargs):
         ContentType = self._get_model()
         try:
-            del kwargs["defaults"]
-            return self.get(**kwargs)
+            if "defaults" in kwargs:
+                del kwargs["defaults"]
+            return self.get(**kwargs), False
         except ContentType.DoesNotExist:
             raise NotImplementedError("You can't manually create simulated content types")
 

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -162,16 +162,14 @@ class SimulatedContentTypeManager(models.Manager):
 
     def create(self, **kwargs):
         ContentType = self._get_model()
-        try:
-            return self.get(**kwargs)
-        except ContentType.DoesNotExist:
-            logging.warning("Created simulated content type, this will not persist and will remain thread-local")
-            new_id = self._get_id(kwargs["app_label"], kwargs["model"])
-            kwargs["id"] = new_id
-            if "pk" in kwargs:
-                del kwargs["pk"]
-            self._store.content_types[new_id] = kwargs
-            return self.get(id=new_id)
+        self._repopulate_if_necessary()
+        logging.warning("Created simulated content type, this will not persist and will remain thread-local")
+        new_id = self._get_id(kwargs["app_label"], kwargs["model"])
+        kwargs["id"] = new_id
+        if "pk" in kwargs:
+            del kwargs["pk"]
+        self._store.content_types[new_id] = kwargs
+        return self.get(id=new_id)
 
     def get_or_create(self, **kwargs):
         ContentType = self._get_model()

--- a/djangae/contrib/contenttypes/tests.py
+++ b/djangae/contrib/contenttypes/tests.py
@@ -1,0 +1,71 @@
+# SYSTEM
+from __future__ import absolute_import
+
+# LIBRARIES
+from django.db import models
+from django.test import TestCase
+from django.contrib.contenttypes.models import ContentType
+from djangae.contrib.contenttypes.models import SimulatedContentTypeManager
+
+
+class DummyModel(models.Model):
+    pass
+
+
+class SimulatedContentTypesTests(TestCase):
+
+    def test_contenttypes_patch_is_applied(self):
+        self.assertEqual(ContentType.objects.__class__, SimulatedContentTypeManager)
+        
+    def test_passing_model_to_simulated_manager_work(self):
+        manager = SimulatedContentTypeManager(model=DummyModel)
+        self.assertEqual(manager._get_model(), DummyModel)
+
+    def test_get_all_contenttype_objects(self):
+        self.assertTrue(len(ContentType.objects.all()) > 0)
+        
+    def test_get_for_model(self):
+        ct = ContentType.objects.get_for_model(DummyModel)
+        self.assertEqual(ct.model, DummyModel._meta.model_name)
+        self.assertEqual(ct.app_label, DummyModel._meta.app_label)
+        
+    def test_get_by_natural_key(self):
+        ct = ContentType.objects.get_by_natural_key(
+            DummyModel._meta.app_label, DummyModel._meta.model_name)
+        self.assertEqual(ct.model, DummyModel._meta.model_name)
+        self.assertEqual(ct.app_label, DummyModel._meta.app_label)
+        
+    def test_get_for_id(self):
+        ct = ContentType.objects.get_for_model(DummyModel)
+        by_id = ContentType.objects.get_for_id(ct.id)
+        self.assertEqual(by_id.model, DummyModel._meta.model_name)
+        self.assertEqual(by_id.app_label, DummyModel._meta.app_label)
+
+    def test_create_contenttype(self):
+        ct = ContentType.objects.create(app_label='test', model='test')
+        self.assertEqual(ct.app_label, 'test')
+        self.assertEqual(ct.model, 'test')
+        self.assertIsNotNone(ct.pk)
+        
+    def test_get_or_create_contenttype(self):
+        ct, created = ContentType.objects.get_or_create(
+            app_label=DummyModel._meta.app_label,
+            model=DummyModel._meta.model_name
+        )
+        
+        self.assertEqual(ct.model, DummyModel._meta.model_name)
+        self.assertEqual(ct.app_label, DummyModel._meta.app_label)
+        self.assertFalse(created)
+        
+        ct, created = ContentType.objects.get_or_create(
+            app_label=DummyModel._meta.app_label,
+            model='different_model'
+        )
+        
+        self.assertEqual(ct.model, 'different_model')
+        self.assertEqual(ct.app_label, DummyModel._meta.app_label)
+        self.assertTrue(created)
+        
+    def test_filter_contenttypes(self):
+        self.assertTrue(len(ContentType.objects.all()) > 1)
+        self.assertEqual(1, len(ContentType.objects.filter(app_label=DummyModel._meta.app_label)))

--- a/djangae/contrib/contenttypes/tests.py
+++ b/djangae/contrib/contenttypes/tests.py
@@ -67,5 +67,5 @@ class SimulatedContentTypesTests(TestCase):
         self.assertTrue(created)
         
     def test_filter_contenttypes(self):
-        self.assertTrue(len(ContentType.objects.all()) > 1)
-        self.assertEqual(1, len(ContentType.objects.filter(app_label=DummyModel._meta.app_label)))
+        original_count = len(ContentType.objects.all())
+        self.assertTrue(original_count > len(ContentType.objects.filter(app_label=DummyModel._meta.app_label)))

--- a/djangae/contrib/contenttypes/tests.py
+++ b/djangae/contrib/contenttypes/tests.py
@@ -16,25 +16,25 @@ class SimulatedContentTypesTests(TestCase):
 
     def test_contenttypes_patch_is_applied(self):
         self.assertEqual(ContentType.objects.__class__, SimulatedContentTypeManager)
-        
+
     def test_passing_model_to_simulated_manager_work(self):
         manager = SimulatedContentTypeManager(model=DummyModel)
         self.assertEqual(manager._get_model(), DummyModel)
 
     def test_get_all_contenttype_objects(self):
         self.assertTrue(len(ContentType.objects.all()) > 0)
-        
+
     def test_get_for_model(self):
         ct = ContentType.objects.get_for_model(DummyModel)
         self.assertEqual(ct.model, DummyModel._meta.model_name)
         self.assertEqual(ct.app_label, DummyModel._meta.app_label)
-        
+
     def test_get_by_natural_key(self):
         ct = ContentType.objects.get_by_natural_key(
             DummyModel._meta.app_label, DummyModel._meta.model_name)
         self.assertEqual(ct.model, DummyModel._meta.model_name)
         self.assertEqual(ct.app_label, DummyModel._meta.app_label)
-        
+
     def test_get_for_id(self):
         ct = ContentType.objects.get_for_model(DummyModel)
         by_id = ContentType.objects.get_for_id(ct.id)
@@ -46,26 +46,26 @@ class SimulatedContentTypesTests(TestCase):
         self.assertEqual(ct.app_label, 'test')
         self.assertEqual(ct.model, 'test')
         self.assertIsNotNone(ct.pk)
-        
+
     def test_get_or_create_contenttype(self):
         ct, created = ContentType.objects.get_or_create(
             app_label=DummyModel._meta.app_label,
             model=DummyModel._meta.model_name
         )
-        
+
         self.assertEqual(ct.model, DummyModel._meta.model_name)
         self.assertEqual(ct.app_label, DummyModel._meta.app_label)
         self.assertFalse(created)
-        
+
         ct, created = ContentType.objects.get_or_create(
             app_label=DummyModel._meta.app_label,
             model='different_model'
         )
-        
+
         self.assertEqual(ct.model, 'different_model')
         self.assertEqual(ct.app_label, DummyModel._meta.app_label)
         self.assertTrue(created)
-        
+
     def test_filter_contenttypes(self):
         original_count = len(ContentType.objects.all())
         self.assertTrue(original_count > len(ContentType.objects.filter(app_label=DummyModel._meta.app_label)))


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Fixes lots of small issues (missing imports, missing repopulation etc) around SimulatedContentTypeManager
- `get_or_create` now uses `create` method on create and doesn't raise an error anymore
- `create` method no longer does `get` first. Thought that's what it really should do. 
- Adds ability to pass `model` into SimulatedContentTypeManager
- Adds migration to patch ContentType manager in migrations as well
- Adds basic test suite.

PR checklist:
- Updated relevant documentation - n/a
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
