### PR TITLE
Don't depend on apps which don't have migrations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - Fixed an issue where Django Debug Toolbar would get a `UnicodeDecodeError` if a query contained a non-ascii character.
 - Fixed an issue where getting and flushing a specific TaskQueue using the test stub (including when using `djangae.test.TestCase.process_task_queues`) would flush all task queues.
--
+- Fixed a bug in our forced contenttypes migration
 
 ### Documentation:
 


### PR DESCRIPTION
Fixes #[include a number of issue this PR is fixing].

Summary of changes proposed in this Pull Request:

Recently we added a clever hack to patch our simulated contenttypes manager even when
running migrations. This was necessary to get Wagtail working on GAE.

Our hack works by creating a migration which is a dependency of everything, however when calculating
the app list we were taking into account apps which didn't even have migrations. This commit
fixes that by ignoring apps which don't have a migrations module, or have on without files.

PR checklist:
- [ ] Updated relevant documentation
- [X] Updated CHANGELOG.md 
- [ ] Added tests for my change

