### PR TITLE
Use argparse for runserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ### New features & improvements:
 
-- 
+-
 -
 
 ### Bug fixes:
 
-- 
+- Fixed `./manage.py runserver` not working with Django 1.10 and removed a RemovedInDjango110Warning message at startup.
 -
 
 ### Documentation:
 
 -
-- 
+-
 
 
 ## v0.9.7 (release date: 11th August 2016)

--- a/djangae/contrib/security/management/commands/dumpurls.py
+++ b/djangae/contrib/security/management/commands/dumpurls.py
@@ -1,10 +1,7 @@
-import inspect
 import functools
-from optparse import make_option
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
-from django.contrib.admindocs.views import simplify_regex
+from django.core.management.base import BaseCommand
 from djangae.contrib.security.commands_utils import (
     extract_views_from_urlpatterns,
     display_as_table,


### PR DESCRIPTION
Fixes #749 .

Summary of changes proposed in this Pull Request:

- Cleaned up unused imports in Djangae's dumpurls command.
- Updated Djangae's runserver command to use the argparse way of adding arguments (which also fixes a RemovedInDjango110Warning deprecation message at startup).

This branch was forked from the v0.9.7 tag because I thought it would be good to push a new release with this fix, since that version advertises support for Django 1.10 but the bug prevents one running Djangae's local development server.

David B.