### PR TITLE
Improve contenttypes migration dependency skipping

### DIFF
--- a/djangae/contrib/contenttypes/migrations/0001_patch_contenttypes_migrations.py
+++ b/djangae/contrib/contenttypes/migrations/0001_patch_contenttypes_migrations.py
@@ -42,8 +42,10 @@ def get_installed_app_labels_with_migrations():
         if not hasattr(module, "__path__"):
             continue
 
-        # Make sure there are python files in the migration folder
-        has_files = any(x for x in os.listdir(module.__path__[0]) if x.endswith(".py"))
+        # Make sure there are python files in the migration folder (other than the init file)
+        has_files = any(
+            x for x in os.listdir(module.__path__[0]) if x.endswith(".py") and x != "__init__.py"
+        )
         if not has_files:
             continue
 

--- a/djangae/contrib/contenttypes/migrations/0001_patch_contenttypes_migrations.py
+++ b/djangae/contrib/contenttypes/migrations/0001_patch_contenttypes_migrations.py
@@ -23,14 +23,15 @@ class PatchMigrationsOperation(Operation):
 
 
 def get_installed_app_labels_with_migrations():
-    """ Get the app labels, because settings.INSTALLED_APPS doesn't necessarily give us the labels. 
-        Remove django.contrib.contenttypes because we want it to run before us. 
-        Return list of tuples like ('admin', '__first__') 
+    """ Get the app labels, because settings.INSTALLED_APPS doesn't necessarily give us the labels.
+        Remove django.contrib.contenttypes because we want it to run before us.
+        Return list of tuples like ('admin', '__first__')
     """
     from django.apps import apps
     apps_with_migrations = []
     for app in apps.get_app_configs():
-        if app.label == 'contenttypes': continue # Ignore the contenttypes app
+        if app.label == 'contenttypes':
+            continue  # Ignore the contenttypes app
 
         migrations_module = MigrationLoader.migrations_module(app.label)
         try:

--- a/djangae/contrib/contenttypes/migrations/0001_patch_contenttypes_migrations.py
+++ b/djangae/contrib/contenttypes/migrations/0001_patch_contenttypes_migrations.py
@@ -43,7 +43,7 @@ def get_installed_app_labels_with_migrations():
             continue
 
         # Make sure there are python files in the migration folder
-        has_files = bool(x for x in os.listdir(module.__path__[0]) if x.endswith(".py"))
+        has_files = any(x for x in os.listdir(module.__path__[0]) if x.endswith(".py"))
         if not has_files:
             continue
 


### PR DESCRIPTION
Improves the fix in #747.

Summary of changes proposed in this Pull Request:
In djangae.contrib.contentypes we inject our migration as a dependency of every other app's migrations, excluding ones which don't have migrations.  This change improves that excluding to cover apps which have a 'migrations' folder but with an `__init__.py` file but which don't actually have any migrations files.

Not updating the CHANGELOG as it's essentially part of the previous entry.

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
