### PR TITLE
Fix dumpurls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed a bug in our forced contenttypes migration
 - Fixed `./manage.py runserver` not working with Django 1.10 and removed a RemovedInDjango110Warning message at startup.
 - Restore `--nothreading` functionality to runserver (this went away when we dropped support for the old dev_appserver)
+- Fixed a bug where the `dumpurls` command had stopped working due to subtle import changes.
 
 ### Documentation:
 

--- a/djangae/contrib/security/commands_utils.py
+++ b/djangae/contrib/security/commands_utils.py
@@ -1,5 +1,5 @@
 import re, inspect
-from django.contrib import admindocs
+from django.contrib.admindocs import views as admindocs_views
 from django.core.exceptions import ViewDoesNotExist
 from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 
@@ -179,11 +179,12 @@ non_named_group_matcher = re.compile(
     r'\)' # the closing bracket of the group
 )
 
+
 def simplify_regex(pattern):
     """ Do the same as django.contrib.admindocs.views.simplify_regex but with our improved regex.
     """
-    original_regex = admindocs.views.non_named_group_matcher
-    admindocs.views.non_named_group_matcher = non_named_group_matcher
-    result = admindocs.views.simplify_regex(pattern)
-    admindocs.views.non_named_group_matcher = original_regex
+    original_regex = admindocs_views.non_named_group_matcher
+    admindocs_views.non_named_group_matcher = non_named_group_matcher
+    result = admindocs_views.simplify_regex(pattern)
+    admindocs_views.non_named_group_matcher = original_regex
     return result

--- a/djangae/contrib/security/tests.py
+++ b/djangae/contrib/security/tests.py
@@ -1,0 +1,10 @@
+from djangae.test import TestCase
+from djangae.contrib.security.management.commands import dumpurls
+
+
+class DumpUrlsTests(TestCase):
+    def test_dumpurls(self):
+        print ("*" * 50) + "\n\n\n"
+        """ Test that the `dumpurls` command runs without dying. """
+        command = dumpurls.Command()
+        command.handle()


### PR DESCRIPTION
Previously, when running the `dumpurls` management command, it would error with `AttributeError: 'module' object has no attribute 'views'` because `admindocs.views` had not been imported.

This fixes that.

PR checklist:
- [-] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
