### PR TITLE
Log invalid sender address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Cleaned up and refactored internal implementation of SimulatedContentTypeManager. Now also allows patching ContentType manager in migrations.
 - Add ability to specify GAE target instance for remote command with `--app_id` flag
+- When App Engine raises an `InvalidSenderError` when trying to send an email, Djangae now logs the 'from' address which is invalid (App Engine doesn't include it in the error).
 
 ### Bug fixes:
 

--- a/djangae/mail.py
+++ b/djangae/mail.py
@@ -1,18 +1,15 @@
+# STANDARD LIB
 from email.MIMEBase import MIMEBase
+import logging
 
+# THIRD PARTY
+from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail import EmailMultiAlternatives
-
 from google.appengine.api import mail as aeemail
+from google.appengine.ext import deferred
+from google.appengine.api.mail_errors import InvalidSenderError
 from google.appengine.runtime import apiproxy_errors
-
-
-def _send_deferred(message, fail_silently=False):
-    try:
-        message.send()
-    except (aeemail.Error, apiproxy_errors.Error):
-        if not fail_silently:
-            raise
 
 
 class EmailBackend(BaseEmailBackend):
@@ -61,14 +58,16 @@ class EmailBackend(BaseEmailBackend):
         try:
             message = self._copy_message(message)
         except (ValueError, aeemail.InvalidEmailError), err:
-            import logging
             logging.warn(err)
             if not self.fail_silently:
                 raise
             return False
         if self.can_defer:
-            self._defer_message(message)
+            self._defer_send(message)
             return True
+        return self._do_send(message)
+
+    def _do_send(self, message):
         try:
             message.send()
         except (aeemail.Error, apiproxy_errors.Error):
@@ -77,14 +76,9 @@ class EmailBackend(BaseEmailBackend):
             return False
         return True
 
-    def _defer_message(self, message):
-        from google.appengine.ext import deferred
-        from django.conf import settings
+    def _defer_send(self, message):
         queue_name = getattr(settings, 'EMAIL_QUEUE_NAME', 'default')
-        deferred.defer(_send_deferred,
-                       message,
-                       fail_silently=self.fail_silently,
-                       _queue=queue_name)
+        deferred.defer(self._do_send, message, _queue=queue_name)
 
 
 class AsyncEmailBackend(EmailBackend):

--- a/djangae/mail.py
+++ b/djangae/mail.py
@@ -70,7 +70,9 @@ class EmailBackend(BaseEmailBackend):
     def _do_send(self, message):
         try:
             message.send()
-        except (aeemail.Error, apiproxy_errors.Error):
+        except (aeemail.Error, apiproxy_errors.Error) as e:
+            if isinstance(e, InvalidSenderError):
+                logging.error("Invalid 'from' address: %s", message.sender)
             if not self.fail_silently:
                 raise
             return False

--- a/djangae/tests/test_mail.py
+++ b/djangae/tests/test_mail.py
@@ -2,6 +2,7 @@
 from django.core.mail import send_mail
 from django.test import override_settings
 from google.appengine.api.app_identity import get_application_id
+from google.appengine.api.mail_errors import InvalidSenderError
 
 # DJANGAE
 from djangae.contrib import sleuth
@@ -34,3 +35,22 @@ class EmailBackendTests(TestCase):
             send_mail("Subject", "Hello", self._get_valid_sender_address(), ["1@example.com"])
             self.process_task_queues()
             self.assertTrue(gae_send.called)
+
+    @override_settings(EMAIL_BACKEND='djangae.mail.EmailBackend')
+    def test_invalid_sender_address_is_logged(self):
+        """ If we use an invalid 'from' address, we want this to be logged. App Engine doesn't
+            include the invalid address in its error message, so we have to log it in Djangae.
+        """
+        invalid_from_address = "larry@google.com"
+        with sleuth.watch("djangae.mail.logging.error") as log_err:
+            # The SDK doesn't raise InvalidSenderError, so we have to force it to blow up
+            with sleuth.detonate("djangae.mail.aeemail.EmailMessage.send", InvalidSenderError):
+                try:
+                    send_mail("Subject", "Hello", invalid_from_address, ["1@example.com"])
+                except InvalidSenderError:
+                    pass
+            self.assertTrue(log_err.called)
+            call_args = log_err.calls[0].args
+            # The invalid 'from' address  should be logged somewhere in the args
+            args_str = u"".join(unicode(a)for a in call_args)
+            self.assertTrue(invalid_from_address in args_str)

--- a/djangae/tests/test_mail.py
+++ b/djangae/tests/test_mail.py
@@ -1,0 +1,36 @@
+# THIRD PARTY
+from django.core.mail import send_mail
+from django.test import override_settings
+from google.appengine.api.app_identity import get_application_id
+
+# DJANGAE
+from djangae.contrib import sleuth
+from djangae.test import TestCase
+
+
+class EmailBackendTests(TestCase):
+
+    def _get_valid_sender_address(self):
+        """ Return an email address which will be allowed as a 'from' address for the current App
+            Engine app.
+        """
+        return "example@%s.appspotmail.com" % get_application_id()
+
+    @override_settings(EMAIL_BACKEND='djangae.mail.EmailBackend')
+    def test_send_email(self):
+        """ Test that sending an email using Django results in the email being sent through App
+            Engine.
+        """
+        with sleuth.watch('djangae.mail.aeemail.EmailMessage.send') as gae_send:
+            send_mail("Subject", "Hello", self._get_valid_sender_address(), ["1@example.com"])
+            self.assertTrue(gae_send.called)
+
+    @override_settings(EMAIL_BACKEND='djangae.mail.AsyncEmailBackend')
+    def test_send_email_deferred(self):
+        """ Test that sending an email using Django results in the email being sent through App
+            Engine.
+        """
+        with sleuth.watch('djangae.mail.aeemail.EmailMessage.send') as gae_send:
+            send_mail("Subject", "Hello", self._get_valid_sender_address(), ["1@example.com"])
+            self.process_task_queues()
+            self.assertTrue(gae_send.called)


### PR DESCRIPTION
Fixes #758.

Summary of changes proposed in this Pull Request:
- Added basic tests for the Djangae email backends.
- Slightly refactored code in the email backend to avoid a bit of duplicated code.
- Added logging of the 'from' address when App Engine rejects it with `InvalidSenderError`.

PR checklist:
- [-] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
