### PR TITLE
Use serving url for Cloud Storage images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed `./manage.py runserver` not working with Django 1.10 and removed a RemovedInDjango110Warning message at startup.
 - Restore `--nothreading` functionality to runserver (this went away when we dropped support for the old dev_appserver)
 - Fixed a bug where the `dumpurls` command had stopped working due to subtle import changes.
+- Utlise `get_serving_url` to get the correct url for serving images from Cloud Storage
 
 ### Documentation:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed `./manage.py runserver` not working with Django 1.10 and removed a RemovedInDjango110Warning message at startup.
 - Restore `--nothreading` functionality to runserver (this went away when we dropped support for the old dev_appserver)
 - Fixed a bug where the `dumpurls` command had stopped working due to subtle import changes.
-- Utlise `get_serving_url` to get the correct url for serving images from Cloud Storage
+- Utilise `get_serving_url` to get the correct url for serving images from Cloud Storage
 
 ### Documentation:
 


### PR DESCRIPTION
Fixes #748 

Changed the cloud storage url method so that it gets the serving url. This now returns the correct path for images, and also makes use of the cache which stores the serving urls.