### PR TITLE
Make calls to get serving url non transactional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 - Fixed `./manage.py runserver` not working with Django 1.10 and removed a RemovedInDjango110Warning message at startup.
 - Restore `--nothreading` functionality to runserver (this went away when we dropped support for the old dev_appserver)
 - Fixed a bug where the `dumpurls` command had stopped working due to subtle import changes.
-- Utilise `get_serving_url` to get the correct url for serving images from Cloud Storage
+- Utilise `get_serving_url` to get the correct url for serving images from Cloud Storage.
+- Fixed a side effect of that ^ introduction of `get_serving_url` which would add an entity group to any transaction in which it was called (due to the Datastore read done by `get_serving_url`).
 
 ### Documentation:
 

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -237,7 +237,9 @@ class BlobstoreStorage(Storage, BlobstoreUploadMixin):
         try:
             # Return a protocol-less URL, because django can't/won't pass
             # down an argument saying whether it should be secure or not
-            url = get_serving_url(self._get_blobinfo(name))
+            with transaction.non_atomic():
+                # This causes a Datastore lookup which we don't want to interfere with transactions
+                url = get_serving_url(self._get_blobinfo(name))
             return re.sub("http://", "//", url)
         except (NotImageError, BlobKeyRequiredError, TransformationError):
             # Django doesn't expect us to return None from this function, and in fact
@@ -301,7 +303,9 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
             self.write_options['x-goog-acl'] = google_acl
 
     def url(self, filename):
-        url = get_serving_url(self._get_blobkey(filename))
+        with transaction.non_atomic():
+            # This causes a Datastore lookup which we don't want to interfere with transactions
+            url = get_serving_url(self._get_blobkey(filename))
         return re.sub("http://", "//", url)
 
     def _get_blobkey(self, name):

--- a/djangae/tests/test_storage.py
+++ b/djangae/tests/test_storage.py
@@ -1,15 +1,17 @@
 # coding: utf-8
+# STANDARD LIB
+from unittest import skipIf
 import httplib
 import os
 import urlparse
-from unittest import skipIf
 
+# THIRD PARTY
+from django.core.files.base import File, ContentFile
+from django.test.utils import override_settings
 from google.appengine.api import urlfetch
 from google.appengine.api.images import TransformationError
 
-from django.core.files.base import File, ContentFile
-from django.test.utils import override_settings
-
+# DJANGAE
 from djangae.contrib import sleuth
 from djangae.storage import BlobstoreStorage, CloudStorage, has_cloudstorage
 from djangae.test import TestCase


### PR DESCRIPTION
Fixes one of the side effects of #763, which is that calling `get_serving_url` causes a Datastore read, and therefore if you access `my_model_instance.image_field.url` inside a transaction it adds an entity group to that transaction.

Summary of changes proposed in this Pull Request:
- In both the `CloudStorage` and `BlobstoreStorage`, wrap calls to `get_serving_url` in `transaction.non_atomic`.

PR checklist:
- [ ] Updated relevant documentation
- [X] Updated CHANGELOG.md 
- [X] Added tests for my change
