### PR TITLE
Serving url tranformation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed a bug where the `dumpurls` command had stopped working due to subtle import changes.
 - Utilise `get_serving_url` to get the correct url for serving images from Cloud Storage.
 - Fixed a side effect of that ^ introduction of `get_serving_url` which would add an entity group to any transaction in which it was called (due to the Datastore read done by `get_serving_url`).
+- Fixed fetching url for non images after introduction of `get_serving_url` call inside CloudStorage url method.
 
 ### Documentation:
 

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -311,6 +311,8 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
                 url = get_serving_url(self._get_blobkey(filename))
             return re.sub("http://", "//", url)
         except (TransformationError):
+            # Sometimes TransformationError will be thrown if you call get_serving_url on video files
+            # this is probably a bug in App Engine but it'll probably never be fixed even if we report it :(
             quoted_filename = urllib.quote(self._add_bucket(filename))
             return '{0}{1}'.format(self.api_url, quoted_filename)
 

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -86,7 +86,7 @@ def _get_from_cache(blob_key_or_info):
     with CACHE_LOCK:
         return KEY_CACHE.get(blob_key_or_info)
 
-def _get_or_create_cached_serving_url(blob_key_or_info):
+def _get_or_create_cached_blob_key_and_info(blob_key_or_info):
     cached_value = _get_from_cache(blob_key_or_info)
     if cached_value:
         blob_key, info = cached_value
@@ -121,7 +121,7 @@ def serve_file(request, blob_key_or_info, as_download=False, content_type=None, 
     if info == None:
         # Lack of blobstore_info means this is a Google Cloud Storage file
         if has_cloudstorage:
-            blob_key, info = _get_or_create_cached_serving_url(blob_key_or_info)
+            blob_key, info = _get_or_create_cached_blob_key_and_info(blob_key_or_info)
         else:
             raise ImportError("To serve a Cloud Storage file you need to install cloudstorage")
 
@@ -315,7 +315,7 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
             return '{0}{1}'.format(self.api_url, quoted_filename)
 
     def _get_blobkey(self, name):
-        blob_key, info = _get_or_create_cached_serving_url(self._add_bucket(name))
+        blob_key, info = _get_or_create_cached_blob_key_and_info(self._add_bucket(name))
         return blob_key
 
     def _open(self, name, mode='r'):

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -313,6 +313,7 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
         except (TransformationError):
             # Sometimes TransformationError will be thrown if you call get_serving_url on video files
             # this is probably a bug in App Engine but it'll probably never be fixed even if we report it :(
+            # Probably related to this: https://code.google.com/p/googleappengine/issues/detail?id=8601
             quoted_filename = urllib.quote(self._add_bucket(filename))
             return '{0}{1}'.format(self.api_url, quoted_filename)
 


### PR DESCRIPTION
This PR fixes fetching url in CloudStorage for non-image files. 

Summary of changes proposed in this Pull Request:
- fix `CloutStorage.url` method to deal with image as well as non-image files
- regression test added
- rename `_get_or_create_cached_serving_url` into `_get_or_create_cached_blob_key_and_info` to reflect what actually the function does

PR checklist:
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
