### PR TITLE
Handle LargeImageError in BlobstoreStorage.url()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Utilise `get_serving_url` to get the correct url for serving images from Cloud Storage.
 - Fixed a side effect of that ^ introduction of `get_serving_url` which would add an entity group to any transaction in which it was called (due to the Datastore read done by `get_serving_url`).
 - Fixed fetching url for non images after introduction of `get_serving_url` call inside CloudStorage url method.
+- Fixed fetching url for files after introduction of `get_serving_url` call inside BlobstoreStorage url method when file is bigger than 32MB.
 
 ### Documentation:
 

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -29,6 +29,7 @@ from google.appengine.api.images import (
     NotImageError,
     BlobKeyRequiredError,
     TransformationError,
+    LargeImageError,
 )
 from google.appengine.ext.blobstore import (
     BlobInfo,
@@ -241,7 +242,7 @@ class BlobstoreStorage(Storage, BlobstoreUploadMixin):
                 # This causes a Datastore lookup which we don't want to interfere with transactions
                 url = get_serving_url(self._get_blobinfo(name))
             return re.sub("http://", "//", url)
-        except (NotImageError, BlobKeyRequiredError, TransformationError):
+        except (NotImageError, BlobKeyRequiredError, TransformationError, LargeImageError):
             # Django doesn't expect us to return None from this function, and in fact
             # relies on the "truthiness" of the return value when accessing .url on an
             # unsaved fieldfile. We just return the name which is effectively what Django

--- a/djangae/tests/test_storage.py
+++ b/djangae/tests/test_storage.py
@@ -10,7 +10,7 @@ from django.core.files.base import File, ContentFile
 from django.db import models
 from django.test.utils import override_settings
 from google.appengine.api import urlfetch
-from google.appengine.api.images import TransformationError
+from google.appengine.api.images import TransformationError, LargeImageError
 
 # DJANGAE
 from djangae.contrib import sleuth
@@ -195,4 +195,9 @@ class BlobstoreStorageTests(TestCase):
     def test_transformation_error(self):
         storage = BlobstoreStorage()
         with sleuth.detonate('djangae.storage.get_serving_url', TransformationError):
+            self.assertEqual('thing', storage.url('thing'))
+
+    def test_large_image_error(self):
+        storage = BlobstoreStorage()
+        with sleuth.detonate('djangae.storage.get_serving_url', LargeImageError):
             self.assertEqual('thing', storage.url('thing'))


### PR DESCRIPTION
url() method was not handling big files (>32MB) and broke when the `get_serving_url` was throwing `LargeImageError`

Summary of changes proposed in this Pull Request:
- catch `LargeImageError` in try clause when we attempt `get_serving_url` 

PR checklist:
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
