### PR TITLE
Use a named logger

### DIFF
--- a/djangae/blobstore_service.py
+++ b/djangae/blobstore_service.py
@@ -3,6 +3,8 @@ import threading
 import logging
 import re
 
+
+logger = logging.getLogger(__name__)
 blobstore_service = None
 server = None
 
@@ -70,11 +72,11 @@ def start_blobstore_service():
 
     port = int(os.environ['SERVER_PORT'])
     host = os.environ['SERVER_NAME']
-    logging.info("Starting blobstore service on %s:%s", host, port)
+    logger.info("Starting blobstore service on %s:%s", host, port)
     try:
         server = make_server(host, port, handler, handler_class=NoLogRequestHandler)
     except socket_error:
-        logging.warning("Not starting blobstore service, it may already be running")
+        logger.warning("Not starting blobstore service, it may already be running")
         return
 
     blobstore_service = threading.Thread(target=server.serve_forever)

--- a/djangae/contrib/consistency/consistency.py
+++ b/djangae/contrib/consistency/consistency.py
@@ -11,6 +11,9 @@ from google.appengine.datastore.datastore_rpc import BaseConnection
 from djangae.contrib.consistency.caches import get_caches
 
 
+logger = logging.getLogger(__name__)
+
+
 DEFAULT_CONFIG = {
     "cache_on_creation": True,
     "cache_on_modification": False,
@@ -43,7 +46,7 @@ def improve_queryset_consistency(queryset):
         # Note that this is imperfect because not all of the objects from recent_pks will
         # necessarily match the query, so we might limit more than necessary.
         imposed_limit = max_existing_pks + (queryset.query.low_mark or 0)
-        logging.info("Limiting queryset for %s to %d", queryset.model, imposed_limit)
+        logger.info("Limiting queryset for %s to %d", queryset.model, imposed_limit)
         queryset = queryset.all()[:imposed_limit]
 
     pks = list(queryset.all().values_list('pk', flat=True)) # this may include recently-created objects
@@ -128,7 +131,7 @@ def object_matches_a_check(obj, checks):
                 else:
                     return True
             except AttributeError:
-                logging.error("Invalid filter for model %s, %s", obj.__class__, check)
+                logger.error("Invalid filter for model %s, %s", obj.__class__, check)
                 raise
     return False
 

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -9,6 +9,9 @@ from django.utils.encoding import smart_text
 from djangae.crc64 import CRC64
 
 
+logger = logging.getLogger(__name__)
+
+
 class SimulatedContentTypeManager(models.Manager):
     """
         Simulates content types without actually hitting the datastore.
@@ -162,7 +165,7 @@ class SimulatedContentTypeManager(models.Manager):
 
     def create(self, **kwargs):
         self._repopulate_if_necessary()
-        logging.warning(
+        logger.warning(
             "Created simulated content type, this will not persist and will remain only on this "
             "app instance"
         )

--- a/djangae/contrib/locking/views.py
+++ b/djangae/contrib/locking/views.py
@@ -10,6 +10,10 @@ from django.utils import timezone
 from djangae.contrib.mappers import defer_iteration
 from .models import DatastoreLock
 
+
+logger = logging.getLogger(__name__)
+
+
 # GAE background tasks and crons can run for a maximum of 10 minutes, so in theory you shouldn't
 # be locking a block of code which takes longer than that, and even if you're using backends which
 # can run for longer, you would still be mad to lock a block of code which runs for > 10 minutes
@@ -19,7 +23,7 @@ QUEUE = getattr(settings, 'DJANGAE_CLEANUP_LOCKS_QUEUE', 'default')
 
 def cleanup_locks(request):
     """ Delete all Lock objects that are older than 10 minutes. """
-    logging.info("Starting djangae.contrib.lock cleanup task")
+    logger.info("Starting djangae.contrib.lock cleanup task")
     cut_off = timezone.now() - timezone.timedelta(seconds=DELETE_LOCKS_OLDER_THAN_SECONDS)
     queryset = DatastoreLock.objects.filter(timestamp__lt=cut_off)
     defer_iteration(queryset, _delete_lock, _queue=QUEUE)
@@ -27,5 +31,5 @@ def cleanup_locks(request):
 
 
 def _delete_lock(lock):
-    logging.info("Deleting stale lock '%s' with timestamp %r", lock.identifier, lock.timestamp)
+    logger.info("Deleting stale lock '%s' with timestamp %r", lock.identifier, lock.timestamp)
     lock.delete()

--- a/djangae/contrib/mappers/readers.py
+++ b/djangae/contrib/mappers/readers.py
@@ -6,6 +6,9 @@ from djangae import utils
 from djangae.storage import UniversalNewLineBlobReader
 
 
+logger = logging.getLogger(__name__)
+
+
 class DjangoInputReader(input_readers.InputReader):
 
     REQUIRED_PARAMS = ('model',)
@@ -54,7 +57,7 @@ class DjangoInputReader(input_readers.InputReader):
 
         # Grab the input parameters for the split
         params = input_readers._get_params(mapper_spec)
-        logging.info("Params: %r", params)
+        logger.info("Params: %r", params)
 
         db = params['db']
         # Unpickle the query
@@ -75,7 +78,7 @@ class DjangoInputReader(input_readers.InputReader):
 
         pk_range = last_id - first_id
 
-        logging.info("Query range: %s - %s = %s", first_id, last_id, pk_range)
+        logger.info("Query range: %s - %s = %s", first_id, last_id, pk_range)
 
         if pk_range < shard_count or shard_count == 1:
             return [DjangoInputReader(first_id-1, last_id, params['model'], db=db)]
@@ -98,7 +101,7 @@ class DjangoInputReader(input_readers.InputReader):
             if shard_end_id > last_id:
                 shard_end_id = last_id
 
-            logging.info("Creating shard: %s - %s", shard_start_id, shard_end_id)
+            logger.info("Creating shard: %s - %s", shard_start_id, shard_end_id)
             reader = DjangoInputReader(shard_start_id, shard_end_id, params['model'], db=db)
             reader.shard_id = shard_id
             readers.append(reader)

--- a/djangae/contrib/security/middleware.py
+++ b/djangae/contrib/security/middleware.py
@@ -9,6 +9,10 @@ from google.appengine.api import urlfetch
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 
+
+logger = logging.getLogger(__name__)
+
+
 class ApiSecurityException(Exception):
     """Error when attempting to call an unsafe API."""
     pass
@@ -79,7 +83,7 @@ def _HttpUrlLoggingWrapper(func):
             arg_value = get_default_argument(func, 'url')
 
         if arg_value and not arg_value.startswith('https://'):
-            logging.warn('SECURITY : fetching non-HTTPS url %r', arg_value)
+            logger.warn('SECURITY : fetching non-HTTPS url %r', arg_value)
         return func(*args, **kwargs)
     return _CheckAndLog
 
@@ -119,7 +123,7 @@ class AppEngineSecurityMiddleware(object):
 
             for setting in ("CSRF_COOKIE_SECURE", "SESSION_COOKIE_HTTPONLY", "SESSION_COOKIE_SECURE"):
                 if not getattr(settings, setting, False):
-                    logging.warning("settings.%s is not set to True, this is insecure", setting)
+                    logger.warning("settings.%s is not set to True, this is insecure", setting)
 
             PATCHES_APPLIED = True
         raise MiddlewareNotUsed()

--- a/djangae/contrib/uniquetool/models.py
+++ b/djangae/contrib/uniquetool/models.py
@@ -18,6 +18,9 @@ from djangae.db.unique_utils import unique_identifiers_from_entity
 from djangae.db.constraints import UniqueMarker
 from djangae.db.caching import disable_cache
 
+
+logger = logging.getLogger(__name__)
+
 ACTION_TYPES = [
     ('check', 'Check'),  # Verify all models unique contraint markers exist and are assigned to it.
     ('repair', 'Repair'),  # Recreate any missing markers
@@ -239,7 +242,7 @@ class CleanMapper(RawMapperMixin, MapReduceTask):
             try:
                 instance = model.objects.using(alias).get(pk=instance_id)
             except model.DoesNotExist:
-                logging.info("Deleting unique marker %s because the associated instance no longer exists", entity.key().id_or_name())
+                logger.info("Deleting unique marker %s because the associated instance no longer exists", entity.key().id_or_name())
                 datastore.Delete(entity)
                 return
 
@@ -248,5 +251,5 @@ class CleanMapper(RawMapperMixin, MapReduceTask):
             identifiers = unique_identifiers_from_entity(model, instance_entity, ignore_pk=True)
             identifier_keys = [datastore.Key.from_path(UniqueMarker.kind(), i, namespace=entity["instance"].namespace()) for i in identifiers]
             if entity.key() not in identifier_keys:
-                logging.info("Deleting unique marker %s because the it no longer represents the associated instance state", entity.key().id_or_name())
+                logger.info("Deleting unique marker %s because the it no longer represents the associated instance state", entity.key().id_or_name())
                 datastore.Delete(entity)

--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -43,6 +43,9 @@ from .commands import (
 from djangae.db.backends.appengine import dbapi as Database
 
 
+logger = logging.getLogger(__name__)
+
+
 class Connection(object):
     """ Dummy connection class """
     def __init__(self, wrapper, params):
@@ -470,7 +473,7 @@ class DatabaseCreation(BaseDatabaseCreation):
         assert not self.testbed
 
         if args:
-            logging.warning("'keepdb' argument is not currently supported on the AppEngine backend")
+            logger.warning("'keepdb' argument is not currently supported on the AppEngine backend")
 
         # We allow users to disable scattered IDs in tests. This primarily for running Django tests that
         # assume implicit ordering (yeah, annoying)
@@ -522,10 +525,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
 
     def add_field(self, model, field):
         pass
-        
+
     def alter_index_together(self, model, old_index_together, new_index_together):
         pass
-        
+
     def delete_model(self, model):
         pass
 

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -34,7 +34,8 @@ from djangae.db import constraints, utils
 from djangae.db.backends.appengine import caching
 from djangae.db.unique_utils import query_is_unique
 
-DJANGAE_LOG = logging.getLogger("djangae")
+
+logger = logging.getLogger(__name__)
 
 OPERATORS_MAP = {
     'exact': '=',
@@ -746,7 +747,7 @@ class SelectCommand(object):
             return result
         except:
             # We never want this to cause things to die
-            logging.exception("Unable to translate query to string")
+            logger.exception("Unable to translate query to string")
             return "QUERY TRANSLATION ERROR"
 
     def __repr__(self):
@@ -946,7 +947,7 @@ class InsertCommand(object):
             return result
         except:
             # We never want this to cause things to die
-            logging.info("InsertCommand is unable to translate query to string")
+            logger.info("InsertCommand is unable to translate query to string")
             return u"QUERY TRANSLATION ERROR"
 
     def __repr__(self):
@@ -1179,7 +1180,7 @@ class UpdateCommand(object):
                 except:
                     # We ignore the exception because raising will rollback the transaction causing
                     # an inconsistent state
-                    logging.exception("Unable to update the context cache")
+                    logger.exception("Unable to update the context cache")
                     pass
 
             # Return true to indicate update success

--- a/djangae/db/backends/appengine/indexing.py
+++ b/djangae/db/backends/appengine/indexing.py
@@ -14,6 +14,7 @@ from djangae.fields import iterable
 from djangae.sandbox import allow_mode_write
 
 
+logger = logging.getLogger(__name__)
 _project_special_indexes = {}
 _app_special_indexes = {}
 _last_loaded_times = {}
@@ -136,7 +137,7 @@ def load_special_indexes():
                 ).setdefault(field_name, []).extend(values)
 
     _indexes_loaded = True
-    logging.debug("Loaded special indexes for %d models", len(_merged_indexes()))
+    logger.debug("Loaded special indexes for %d models", len(_merged_indexes()))
 
 
 def special_index_exists(model_class, field_name, index_type):

--- a/djangae/db/backends/appengine/parsers/base.py
+++ b/djangae/db/backends/appengine/parsers/base.py
@@ -27,7 +27,7 @@ from djangae import environment
 from djangae.db.utils import get_top_concrete_parent
 
 
-DJANGAE_LOG = logging.getLogger("djangae")
+logger = logging.getLogger(__name__)
 
 
 INVALID_ORDERING_FIELD_MESSAGE = (
@@ -374,7 +374,7 @@ class BaseParser(object):
 
             if len(cross_table_ordering):
                 log_once(
-                    DJANGAE_LOG.warning if environment.is_development_environment() else DJANGAE_LOG.debug,
+                    logger.warning if environment.is_development_environment() else logger.debug,
                     "The following orderings were ignored as cross-table orderings are not supported on the datastore: %s", cross_table_ordering
                 )
 
@@ -490,7 +490,7 @@ class BaseParser(object):
         if len(final) != len(result):
             diff = set(result) - set(final)
             log_once(
-                DJANGAE_LOG.warning if environment.is_development_environment() else DJANGAE_LOG.debug,
+                logger.warning if environment.is_development_environment() else logger.debug,
                 "The following orderings were ignored as cross-table and random orderings are not supported on the datastore: %s", diff
             )
 

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -41,7 +41,7 @@ from djangae.db.utils import (
 from google.appengine.api import datastore
 
 
-DJANGAE_LOG = logging.getLogger("djangae")
+logger = logging.getLogger(__name__)
 
 
 VALID_QUERY_KINDS = (
@@ -353,7 +353,7 @@ class Query(object):
             raise NotSupportedError("{} is not a valid column for the queried model. Did you try to join?".format(column))
 
         if field.db_type(self.connection) in ("bytes", "text", "list", "set"):
-            DJANGAE_LOG.warn("Disabling projection query as %s is an unprojectable type", column)
+            logger.warn("Disabling projection query as %s is an unprojectable type", column)
             self.columns = None
             self.projection_possible = False
             return

--- a/djangae/db/constraints.py
+++ b/djangae/db/constraints.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 
 from django.conf import settings
 from django.core.exceptions import NON_FIELD_ERRORS
@@ -10,9 +9,6 @@ from google.appengine.ext import db
 from .unique_utils import unique_identifiers_from_entity
 from .utils import key_exists
 from djangae.db.backends.appengine.dbapi import IntegrityError, NotSupportedError
-
-
-DJANGAE_LOG = logging.getLogger("djangae")
 
 
 def has_active_unique_constraints(model_or_instance):

--- a/djangae/mail.py
+++ b/djangae/mail.py
@@ -12,6 +12,9 @@ from google.appengine.api.mail_errors import InvalidSenderError
 from google.appengine.runtime import apiproxy_errors
 
 
+logger = logging.getLogger(__name__)
+
+
 class EmailBackend(BaseEmailBackend):
     can_defer = False
 
@@ -58,7 +61,7 @@ class EmailBackend(BaseEmailBackend):
         try:
             message = self._copy_message(message)
         except (ValueError, aeemail.InvalidEmailError), err:
-            logging.warn(err)
+            logger.warn(err)
             if not self.fail_silently:
                 raise
             return False
@@ -72,7 +75,7 @@ class EmailBackend(BaseEmailBackend):
             message.send()
         except (aeemail.Error, apiproxy_errors.Error) as e:
             if isinstance(e, InvalidSenderError):
-                logging.error("Invalid 'from' address: %s", message.sender)
+                logger.error("Invalid 'from' address: %s", message.sender)
             if not self.fail_silently:
                 raise
             return False

--- a/djangae/tests/test_mail.py
+++ b/djangae/tests/test_mail.py
@@ -42,7 +42,7 @@ class EmailBackendTests(TestCase):
             include the invalid address in its error message, so we have to log it in Djangae.
         """
         invalid_from_address = "larry@google.com"
-        with sleuth.watch("djangae.mail.logging.error") as log_err:
+        with sleuth.watch("djangae.mail.logger.error") as log_err:
             # The SDK doesn't raise InvalidSenderError, so we have to force it to blow up
             with sleuth.detonate("djangae.mail.aeemail.EmailMessage.send", InvalidSenderError):
                 try:

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -9,6 +9,10 @@ import warnings
 
 from socket import socket, SHUT_RDWR
 
+
+logger = logging.getLogger(__name__)
+
+
 class DjangaeDeprecation(DeprecationWarning):
     pass
 
@@ -107,14 +111,14 @@ def retry(func, *args, **kwargs):
                 i += 1
                 return func(*args, **kwargs)
             except (datastore_errors.Error, apiproxy_errors.Error, TransactionFailedError), exc:
-                logging.info("Retrying function: %s(%s, %s) - %s", str(func), str(args), str(kwargs), str(exc))
+                logger.info("Retrying function: %s(%s, %s) - %s", str(func), str(args), str(kwargs), str(exc))
                 time.sleep(timeout_ms / 1000000.0)
                 timeout_ms *= 2
                 if i > retries:
                     raise exc
 
     except DeadlineExceededError:
-        logging.error("Timeout while running function: %s(%s, %s)", str(func), str(args), str(kwargs))
+        logger.error("Timeout while running function: %s(%s, %s)", str(func), str(args), str(kwargs))
         raise
 
 

--- a/djangae/views.py
+++ b/djangae/views.py
@@ -11,6 +11,9 @@ from djangae import environment
 from djangae.core.signals import module_started, module_stopped
 
 
+logger = logging.getLogger(__name__)
+
+
 def warmup(request):
     """
         Provides default procedure for handling warmup requests on App
@@ -46,27 +49,27 @@ def deferred(request):
     response = HttpResponse()
 
     if 'HTTP_X_APPENGINE_TASKEXECUTIONCOUNT' in request.META:
-        logging.debug("[DEFERRED] Retry %s of deferred task", request.META['HTTP_X_APPENGINE_TASKEXECUTIONCOUNT'])
+        logger.debug("[DEFERRED] Retry %s of deferred task", request.META['HTTP_X_APPENGINE_TASKEXECUTIONCOUNT'])
 
     if 'HTTP_X_APPENGINE_TASKNAME' not in request.META:
-        logging.critical('Detected an attempted XSRF attack. The header "X-AppEngine-Taskname" was not set.')
+        logger.critical('Detected an attempted XSRF attack. The header "X-AppEngine-Taskname" was not set.')
         response.status_code = 403
         return response
 
     in_prod = environment.is_production_environment()
 
     if in_prod and os.environ.get("REMOTE_ADDR") != "0.1.0.2":
-        logging.critical('Detected an attempted XSRF attack. This request did not originate from Task Queue.')
+        logger.critical('Detected an attempted XSRF attack. This request did not originate from Task Queue.')
         response.status_code = 403
         return response
 
     try:
         run(request.body)
     except SingularTaskFailure:
-        logging.debug("Failure executing task, task retry forced")
+        logger.debug("Failure executing task, task retry forced")
         response.status_code = 408
     except PermanentTaskFailure:
-        logging.exception("Permanent failure attempting to execute task")
+        logger.exception("Permanent failure attempting to execute task")
 
     return response
 
@@ -77,7 +80,7 @@ def internalupload(request):
     try:
         return HttpResponse(str(request.FILES['file'].blobstore_info.key()))
     except Exception:
-        logging.exception("DJANGAE UPLOAD FAILED: The internal upload handler couldn't retrieve the blob info key.")
+        logger.exception("DJANGAE UPLOAD FAILED: The internal upload handler couldn't retrieve the blob info key.")
         return HttpResponseServerError()
 
 
@@ -88,6 +91,6 @@ def clearsessions(request):
     try:
         engine.SessionStore.clear_expired()
     except NotImplementedError:
-        logging.exception("Session engine '%s' doesn't support clearing "
-                          "expired sessions.\n" % settings.SESSION_ENGINE)
+        logger.exception("Session engine '%s' doesn't support clearing "
+                          "expired sessions.\n", settings.SESSION_ENGINE)
     return HttpResponse("Ok.")


### PR DESCRIPTION
Hi,

This pull request changes Djangae to use a named logger. The idea is this should make it simpler to configure logging, specifically when you want to suppress Djangae's messages.

It also removes and updates some existing named loggers so that they work the same as all the new ones (the DJANGAE_LOG variables).

One test broke because of these changes because it was testing that the global logger was called.

David B.
