### PR TITLE
Fixes for DJANGAE_CACHE_ENABLED=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Fixed fetching url for non images after introduction of `get_serving_url` call inside CloudStorage url method.
 - Fixed fetching url for files after introduction of `get_serving_url` call inside BlobstoreStorage url method when file is bigger than 32MB.
 - Fixed gauth middleware to update user email address if it gets changed
+- Don't add entities to memcache if DJANGAE_CACHE_ENABLED=False
+- Fix bug where entities could still be fetched from memcache with DJANGAE_CACHE_ENABLED=False when saving in a transaction or deleting them
 
 ### Documentation:
 

--- a/djangae/db/backends/appengine/caching.py
+++ b/djangae/db/backends/appengine/caching.py
@@ -215,6 +215,9 @@ def _get_entity_from_memcache_by_key(key):
 
 
 def add_entities_to_cache(model, entities, situation, namespace, skip_memcache=False):
+    if not CACHE_ENABLED:
+        return None
+
     # Don't cache on Get if we are inside a transaction, even in the context
     # This is because transactions don't see the current state of the datastore
     # We can still cache in the context on Put() but not in memcache
@@ -257,6 +260,9 @@ def remove_entities_from_cache_by_key(keys, namespace, memcache_only=False):
         Given an iterable of datastore.Keys objects, remove the corresponding entities from caches,
         both context and memcache, or just memcache if specified.
     """
+    if not CACHE_ENABLED:
+        return None
+
     context = get_context()
     if not memcache_only:
         for key in keys:


### PR DESCRIPTION
Fixes #783 .

Summary of changes proposed in this Pull Request:
- Fix bug where entities were still fetched from memcache when deleting them within a transaction.
- Don't add entities to the cache.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
