### PR TITLE
Fixing a typo in a super() call, fixing how overlap preps iterable va…

### DIFF
--- a/djangae/fields/iterable.py
+++ b/djangae/fields/iterable.py
@@ -68,7 +68,7 @@ class OverlapLookup(Lookup):
         if not isinstance(self.rhs, (list, set)):
             raise ValueError("__overlap takes a list or set as a value")
 
-        return super(OverlapLookup, self).get_prep_lookup()
+        return [self.lhs.output_field.get_prep_lookup(self.lookup_name, v) for v in self.rhs]
 
 
 class IterableTransform(Transform):

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -268,7 +268,7 @@ class RelatedOverlapLookup(OverlapLookup):
     def get_prep_lookup(self):
         # Transform any instances to primary keys
         self.rhs = [ x.pk if isinstance(x, models.Model) else x for x in self.rhs ]
-        return super(RelatedContainsLookup, self).get_prep_lookup()
+        return super(RelatedOverlapLookup, self).get_prep_lookup()
 
 
 class RelatedIteratorField(ForeignObject):

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -440,6 +440,18 @@ class RelatedListFieldModelTests(TestCase):
         thing.related_list.field.save_form_data(thing, [])
         self.assertNotEqual(before_list.all(), thing.related_list.all())
 
+    def test_filtering_on_iterable_fields(self):
+        related1 = ISOther.objects.create()
+        related2 = ISOther.objects.create()
+        related3 = ISOther.objects.create()
+        thing = ISModel.objects.create(related_list=[related1, related2])
+        # filtering using __contains lookup with ListField:
+        qry = ISModel.objects.filter(related_list__contains=related1)
+        self.assertEqual(sorted(x.pk for x in qry), [thing.pk])
+        # filtering using __overlap lookup with ListField:
+        qry = ISModel.objects.filter(related_list__overlap=[related2, related3])
+        self.assertEqual(sorted(x.pk for x in qry), [thing.pk])
+
     def test_saving_forms(self):
         class TestForm(forms.ModelForm):
             class Meta:


### PR DESCRIPTION
Fixes #794.

The first problem was a typo in a super() call. We referenced the wrong superclass. @kevincarrogan once said: "never copy/paste - always re-type" - it avoids problems like these : )

But turns out fixing this revealed a deeper problem. We called the default get_prep_lookup which just by accident didn't modify the value at all. When the field was a related field and all the Django internals figured out what the values on the list really where (AutoId in this case) it tried to coerce the passed value to an int(). I think the correct behaviour here is to call get_prep_lookup on each list/set value individually.

…lues. Fixes #794