### PR TITLE
Defer iteration fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@
 - Fixed a minor bug where entities were still added to memcache (but not fetched from it) with `DJANGAE_CACHE_ENABLED=False`.  This fix now allows disabling the cache to be a successful workaround for https://code.google.com/p/googleappengine/issues/detail?id=7876.
 - Fixed a bug where entities could still be fetched from memcache with `DJANGAE_CACHE_ENABLED=False` when saving in a transaction or deleting them.
 - Fixed overlap filtering on RelatedListField and RelatedSetField (Thanks Grzes!)
+- Fixed various issues with `djangae.contrib.mappers.defer_iteration`, so that it no longers gets stuck deferring tasks or hitting memory limit errors when uses on large querysets.
 
 ### Documentation:
 
--
+- Improved documentation for `djangae.contrib.mappers.defer_iteration`.
+
 
 ## v0.9.8 (release date: 6th December 2016)
 

--- a/djangae/contrib/locking/views.py
+++ b/djangae/contrib/locking/views.py
@@ -5,9 +5,9 @@ import logging
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils import timezone
+from google.appengine.ext.deferred import defer
 
 # DJANGAE
-from djangae.contrib.mappers import defer_iteration
 from .models import DatastoreLock
 
 
@@ -23,11 +23,22 @@ QUEUE = getattr(settings, 'DJANGAE_CLEANUP_LOCKS_QUEUE', 'default')
 
 def cleanup_locks(request):
     """ Delete all Lock objects that are older than 10 minutes. """
+    logger.info("Deferring djangae.contrib.lock cleanup task")
+    defer(cleanup_locks_task, _queue=QUEUE)
+    return HttpResponse("Cleanup locks task is running")
+
+
+def cleanup_locks_task():
+    """ Task function that deletes lock objects that are older than 10 minutes.
+        Due to its restriction of not being able to use an inequality filter, we can' use
+        defer_iteration for this, but if we can't delete all the objects in this one task then it
+        will just fail and retry, and everntually it will get through all of them.
+    """
     logger.info("Starting djangae.contrib.lock cleanup task")
     cut_off = timezone.now() - timezone.timedelta(seconds=DELETE_LOCKS_OLDER_THAN_SECONDS)
     queryset = DatastoreLock.objects.filter(timestamp__lt=cut_off)
-    defer_iteration(queryset, _delete_lock, _queue=QUEUE)
-    return HttpResponse("Cleanup locks task is running")
+    queryset.delete()
+    logger.info("Finished djangae.contrib.lock cleanup task")
 
 
 def _delete_lock(lock):

--- a/docs/mappers.md
+++ b/docs/mappers.md
@@ -18,6 +18,14 @@ Note that currently only the 'map' stage is implemented.  There is currently no 
 
 ### djangae.contrib.mappers.defer_iteration
 
-This function takes a queryset and a callback, and also optionally a shard_size and a _queue. It
+This function takes a `queryset` and a `callback`, and also optionally a `shard_size` and a `_queue`. It
 defers background tasks to iterate over the entire queryset on the specified task queue calling your
-callback function each time.
+callback function on each Django model instance in the queryset.
+
+* The shard size is the number of instance which it will attempt to process in a single task, and defaults to 500.
+    * Depending on how long your callback function is likely to take on each instance, you should reduce the shard size in order that it can safely process that many instances in App Engine's task time limit of 10 minutes.
+* The ordering of the queryset is set to `order_by('pk')`.
+    * This does not guarantee that objects will be processed in this order.
+    * Due to the Datastore's limitations, this creates a restriction that you cannot use an inequality filter other than on the PK field in your queryset.
+* There is no exception handling around the callback function, so an exception is raised when processing one of the instances then that task will fail and be retried, thus re-processing any prior instances in that same shard.
+    * Your callback function should be idempotent.


### PR DESCRIPTION
Fixes #790.

Summary of changes proposed in this Pull Request:

* Fixes a bug where if we hit DeadlineExceededError when doing the sharding, we would redefer but then not `return`, so the sharding task would fail and be retried, thus duplicating the sharding task(s).  In other words, if we couldn’t defer all the shards in one go, we would get stuck in an exponentially-expanding cycle of redefering the first X shards.
* The sharding tasks now redefers itself, (hopefully) _before_ hitting DeadlineExceededError, for a better chance of a successful redefer.
* Now orders the querset by PK and uses `filter(pk__gt=x)` rather than slicing.  This avoids an issue where the slicing would cause us to use more and more memory the further we got through the queryset, eventually hitting the App Engine memory limit.
    * This introduces a new limitation that the queryset can't have an inequality filter (unless it's the PK), but I think this is a worthwhile tradeoff for having the thing actually work!
* Now uses `.iterator()` for more memory-saving goodness.
* Updated the locks cleanup task (in djangae.contrib.locking) to avoid using `defer_iteration` with an inequality filter.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change (it's got tests already, and the issues that this fixes only happen with large amounts of data, real memory limits and real deadlines).
