### PR TITLE
Add BSD licence header and update setup.py

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+# BSD 3-Clause License
+
 Copyright (c) Luke Benstead 2014, Potato London Ltd. 2014-, and all contributors.
 All rights reserved.
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD 3-Clause License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
     ],


### PR DESCRIPTION
`./LICENCE.md` is infact the BSD 3-Clause License and not the MIT licence as defined in setup.py
* Add the title to the license file
* Update setup.py from MIT to BSD

Fixes #[include a number of issue this PR is fixing].

Summary of changes proposed in this Pull Request:
- 
- 
- 

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
