### PR TITLE
Use functools.wraps in the disable_cache decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - System check for deferred builtin which should always be switched off.
 - Implemented weak (memcache) locking to contrib.locking
+- The `disable_cache` decorator now wraps the returned function with functools.wraps
 
 ### Bug fixes:
 

--- a/djangae/db/caching.py
+++ b/djangae/db/caching.py
@@ -1,5 +1,4 @@
-from google.appengine.api import datastore
-
+import functools
 from djangae.db.backends.appengine import caching
 
 
@@ -28,7 +27,7 @@ class DisableCache(object):
         if not self.func:
             assert args and callable(args[0])
             self.func = args[0]
-            return call_func
+            return functools.wraps(self.func)(call_func)
 
         if self.func:
             return call_func(*args, **kwargs)


### PR DESCRIPTION
Fixes #793 

Summary of changes proposed in this Pull Request:
- Use functools.wraps in the disable_cache decorator

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
