### PR TITLE
Limit the batch size when collecting objects for deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed overlap filtering on RelatedListField and RelatedSetField (Thanks Grzes!)
 - Fixed various issues with `djangae.contrib.mappers.defer_iteration`, so that it no longers gets stuck deferring tasks or hitting memory limit errors when uses on large querysets.
 - Fixed an issue where having a ForeignKey to a ContentType would cause an issue when querying due to the large IDs produced by djangae.contrib.contenttypes's SimulatedContentTypesManager.
+- Cascade deletions will now correctly batch object collection within the datastore query limits, fixing errors on deletion.
 
 ### Documentation:
 

--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -161,6 +161,13 @@ class DatabaseOperations(BaseDatabaseOperations):
         'PositiveIntegerField': (0, MAXINT-1),
     }
 
+    def bulk_batch_size(self, field, objs):
+        # This value is used in cascade deletions, and also on bulk insertions
+        # Bulk insertions really need to be limited to 25 elsewhere (so that they can be done)
+        # transactionally, so setting to 30 doesn't matter but for cascade deletions
+        # (which explode to thing_id__in=[]) we need to limit to MAX_ALLOWABLE_QUERIES
+        return datastore.MAX_ALLOWABLE_QUERIES
+
     def quote_name(self, name):
         return name
 

--- a/djangae/test_runner.py
+++ b/djangae/test_runner.py
@@ -60,12 +60,20 @@ DJANGO_TESTS_WHICH_USE_SELECT_RELATED = {
     'model_inheritance.tests.ModelInheritanceDataTests.test_select_related_works_on_parent_model_fields'
 }
 
+# These tests expect a certain number of queries to run, because they hardcode the expected
+# batchsize and due to datastore limitations (e.g. MAX_ALLOWABLE_QUERIES) we need more queries
+# (we test the bulk delete behaviour in djangae.tests.test_connector.CascadeDeletionTests instead).
+DJANGO_TESTS_WHICH_COUNT_QUERIES = {
+    'delete.tests.DeletionTests.test_bulk',
+    'delete.tests.DeletionTests.test_large_delete_related'
+}
 
 DJANGO_TESTS_TO_SKIP = DJANGO_TESTS_WHICH_REQUIRE_ZERO_PKS.union(
     DJANGO_TESTS_WHICH_REQUIRE_AUTH_USER).union(
     DJANGO_TESTS_WHICH_HAVE_BUGS).union(
     DJANGO_TESTS_WHICH_EXPECT_SQL_PARAMS).union(
-    DJANGO_TESTS_WHICH_USE_SELECT_RELATED
+    DJANGO_TESTS_WHICH_USE_SELECT_RELATED).union(
+    DJANGO_TESTS_WHICH_COUNT_QUERIES
 )
 
 def init_testbed():

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -474,7 +474,7 @@ class BackendTests(TestCase):
 
     def test_exclude_nullable_field(self):
         instance = ModelWithNullableCharField.objects.create(some_id=999) # Create a nullable thing
-        instance2 = ModelWithNullableCharField.objects.create(some_id=999, field1="test") # Create a nullable thing
+        ModelWithNullableCharField.objects.create(some_id=999, field1="test") # Create a nullable thing
         self.assertItemsEqual([instance], ModelWithNullableCharField.objects.filter(some_id=999).exclude(field1="test").all())
 
         instance.field1 = "bananas"
@@ -1067,7 +1067,7 @@ class ConstraintTests(TestCase):
                 raise AssertionError()
             return datastore.Put(*args, **kwargs)
 
-        with sleuth.switch("djangae.db.backends.appengine.commands.datastore.Put", wrapped_put) as put_mock:
+        with sleuth.switch("djangae.db.backends.appengine.commands.datastore.Put", wrapped_put):
             with self.assertRaises(Exception):
                 instance.save()
 
@@ -1094,7 +1094,7 @@ class ConstraintTests(TestCase):
                 raise AssertionError()
             return datastore.Put(*args, **kwargs)
 
-        with sleuth.switch("djangae.db.backends.appengine.commands.datastore.Put", wrapped_put) as put_mock:
+        with sleuth.switch("djangae.db.backends.appengine.commands.datastore.Put", wrapped_put):
             with self.assertRaises(Exception):
                 ModelWithUniques.objects.create(name="One")
 

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -2063,3 +2063,32 @@ class TestHelperTests(TestCase):
         self.process_task_queues()
 
         self.assertNumTasksEquals(0) #No tasks
+
+
+class Zoo(models.Model):
+    pass
+
+
+class Enclosure(models.Model):
+    zoo = models.ForeignKey(Zoo)
+
+
+class Animal(models.Model):
+    enclosure = models.ForeignKey(Enclosure)
+
+
+class CascadeDeletionTests(TestCase):
+    def test_deleting_more_than_30_items(self):
+        zoo = Zoo.objects.create()
+
+        for i in xrange(40):
+            enclosure = Enclosure.objects.create(zoo=zoo)
+            for i in xrange(2):
+                Animal.objects.create(enclosure=enclosure)
+
+        self.assertEqual(Animal.objects.count(), 80)
+
+        zoo.delete()
+
+        self.assertEqual(Enclosure.objects.count(), 0)
+        self.assertEqual(Animal.objects.count(), 0)


### PR DESCRIPTION
Fixes #800.

Summary of changes proposed in this Pull Request:
- Set the bulk_batch_size to MAX_ALLOWABLE_QUERIES
- Skip some Django test which expect a certain number of queries to run

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
