### PR TITLE
1 9 49 sdk temporary fix

### DIFF
--- a/djangae/management/commands/runserver.py
+++ b/djangae/management/commands/runserver.py
@@ -19,7 +19,7 @@ if DJANGAE_RUNSERVER_IGNORED_DIR_REGEXES:
     DJANGAE_RUNSERVER_IGNORED_DIR_REGEXES = [re.compile(regex) for regex in DJANGAE_RUNSERVER_IGNORED_DIR_REGEXES]
 
 
-def ignore_file(filename):
+def ignore_file(filename, *args, **kwargs):
     """ Replacement for devappserver2.watchter_common.ignore_file
         - to be monkeypatched into place.
     """
@@ -33,7 +33,7 @@ def ignore_file(filename):
     )
 
 
-def skip_ignored_dirs(dirs):
+def skip_ignored_dirs(*args, **kwargs):
     """ Replacement for devappserver2.watchter_common.skip_ignored_dirs
     - to be monkeypatched into place.
     """
@@ -41,7 +41,21 @@ def skip_ignored_dirs(dirs):
     # Also note that `dirs` is a list of dir *names* not dir *paths*, which means that we can't
     # differentiate between /foo/bar and /moo/bar because we just get 'bar'. But allowing that
     # would require a whole load more monkey patching.
+    from djangae import sandbox
     from google.appengine.tools.devappserver2 import watcher_common
+
+    # since version 1.9.49 (which is incorrectly marked as [0, 0, 0] for now, until
+    # https://code.google.com/p/googleappengine/issues/detail?id=13439 will be fixed,
+    # skip_ignored_dirs have three arguments instead of one. To preserve
+    # backwards compatibilty we check version here and use args to fetch one
+    # or three arguments depending on version. We do not do any further error handling
+    # here to make sure that this explicitly fail if there is another change in
+    # the number of arguments with new SDK versions.
+    current_version = _VersionList(GetVersionObject()['release'])
+    if current_version == sandbox.TEMP_CURRENT_VERSION:
+        dirpath, dirs, skip_files_re = args
+    else:
+        dirs = args[0]
     watcher_common._remove_pred(dirs, lambda d: d.startswith(watcher_common._IGNORED_PREFIX))
     watcher_common._remove_pred(
         dirs,
@@ -204,7 +218,8 @@ class Command(runserver.Command):
 
         # External port is a new flag introduced in 1.9.19
         current_version = _VersionList(GetVersionObject()['release'])
-        if current_version >= _VersionList('1.9.19'):
+        if current_version >= _VersionList('1.9.19') or \
+                current_version == sandbox.TEMP_CURRENT_VERSION:
             sandbox._OPTIONS.external_port = None
 
         # Apply equivalent options for Django args

--- a/djangae/management/commands/runserver.py
+++ b/djangae/management/commands/runserver.py
@@ -52,7 +52,10 @@ def skip_ignored_dirs(*args, **kwargs):
     # here to make sure that this explicitly fail if there is another change in
     # the number of arguments with new SDK versions.
     current_version = _VersionList(GetVersionObject()['release'])
-    if current_version == sandbox.TEMP_CURRENT_VERSION:
+    if current_version == sandbox.TEMP_1_9_49_VERSION_NO:
+        current_version = _VersionList('1.9.49')
+
+    if current_version >= _VersionList('1.9.49'):
         dirpath, dirs, skip_files_re = args
     else:
         dirs = args[0]
@@ -219,7 +222,7 @@ class Command(runserver.Command):
         # External port is a new flag introduced in 1.9.19
         current_version = _VersionList(GetVersionObject()['release'])
         if current_version >= _VersionList('1.9.19') or \
-                current_version == sandbox.TEMP_CURRENT_VERSION:
+                current_version == sandbox.TEMP_1_9_49_VERSION_NO:
             sandbox._OPTIONS.external_port = None
 
         # Apply equivalent options for Django args

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -18,6 +18,14 @@ _SCRIPT_NAME = 'dev_appserver.py'
 _API_SERVER = None
 
 
+# This is a temporary workaround for the issue with 1.9.49 version where
+# version is set to [0, 0, 0] instead of [1, 9, 49]. This could be removed
+# after this: https://code.google.com/p/googleappengine/issues/detail?id=13439
+# issue is resolved. If that is done, we should remove all references to
+# TEMP_CURRENT_VERSION here and in djangae/management/command/runserver.
+TEMP_CURRENT_VERSION = [0, 0, 0]
+
+
 class Filter(object):
     def filter(self, record):
         if record.funcName == '__StarSchemaQueryPlan' and record.module == 'datastore_sqlite_stub':
@@ -97,10 +105,12 @@ def _create_dispatcher(configuration, options):
 
     # External port is a new flag introduced in 1.9.19
     current_version = _VersionList(GetVersionObject()['release'])
-    if current_version >= _VersionList('1.9.19'):
+    if current_version >= _VersionList('1.9.19') or \
+            current_version == TEMP_CURRENT_VERSION:
         dispatcher_args.append(options.external_port)
 
-    if current_version >= _VersionList('1.9.22'):
+    if current_version >= _VersionList('1.9.22') or \
+            current_version == TEMP_CURRENT_VERSION:
         dispatcher_args.insert(8, None) # Custom config setting
 
     _create_dispatcher.singleton = dispatcher.Dispatcher(*dispatcher_args)

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -22,8 +22,8 @@ _API_SERVER = None
 # version is set to [0, 0, 0] instead of [1, 9, 49]. This could be removed
 # after this: https://code.google.com/p/googleappengine/issues/detail?id=13439
 # issue is resolved. If that is done, we should remove all references to
-# TEMP_CURRENT_VERSION here and in djangae/management/command/runserver.
-TEMP_CURRENT_VERSION = [0, 0, 0]
+# TEMP_1_9_49_VERSION_NO here and in djangae/management/command/runserver.
+TEMP_1_9_49_VERSION_NO = [0, 0, 0]
 
 
 class Filter(object):
@@ -106,11 +106,11 @@ def _create_dispatcher(configuration, options):
     # External port is a new flag introduced in 1.9.19
     current_version = _VersionList(GetVersionObject()['release'])
     if current_version >= _VersionList('1.9.19') or \
-            current_version == TEMP_CURRENT_VERSION:
+            current_version == TEMP_1_9_49_VERSION_NO:
         dispatcher_args.append(options.external_port)
 
     if current_version >= _VersionList('1.9.22') or \
-            current_version == TEMP_CURRENT_VERSION:
+            current_version == TEMP_1_9_49_VERSION_NO:
         dispatcher_args.insert(8, None) # Custom config setting
 
     _create_dispatcher.singleton = dispatcher.Dispatcher(*dispatcher_args)


### PR DESCRIPTION
Fixes #797.

Summary of changes proposed in this Pull Request:
- workaround for an incorrect version number in SDK 1.9.49 (it's 0.0.0 until issue: https://code.google.com/p/googleappengine/issues/detail?id=13439 will be fixed)
- change behavior of Djangae's implementaton of `skip_ignored_dirs` to work with SDK versions below and above 1.9.49
