### PR TITLE
Stoping exceptions when django tries to call  on our queries. Fixes #775

### DIFF
--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -753,6 +753,9 @@ class SelectCommand(object):
     def __repr__(self):
         return self.__unicode__().encode("utf-8")
 
+    def __mod__(self, params):
+        return repr(self)
+
     def lower(self):
         """
             This exists solely for django-debug-toolbar compatibility.

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -463,6 +463,12 @@ class BackendTests(TestCase):
 
             self.assertEqual(1, get_mock.call_count)
 
+    def test_gae_query_display(self):
+        # Shouldn't raise any exceptions:
+        representation = str(TestUser.objects.filter(username='test').query)
+        self.assertTrue('test' in representation)
+        self.assertTrue('username' in representation)
+
     def test_range_behaviour(self):
         IntegerModel.objects.create(integer_field=5)
         IntegerModel.objects.create(integer_field=10)


### PR DESCRIPTION
Doesn't fix #775, but fixes a similar issue:

We currently raise an exception that the Commands don't work with the `%` operator, because Django is trying to run `sql % params` where sql is our SelectCommand class.
