### PR TITLE
Prove that empty Q() filters don't cause an error. Fixes #746

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed overlap filtering on RelatedListField and RelatedSetField (Thanks Grzes!)
 - Fixed various issues with `djangae.contrib.mappers.defer_iteration`, so that it no longers gets stuck deferring tasks or hitting memory limit errors when uses on large querysets.
 - Fixed an issue where having a ForeignKey to a ContentType would cause an issue when querying due to the large IDs produced by djangae.contrib.contenttypes's SimulatedContentTypesManager.
+- Fix a problem with query parsing which would throw a NotSupportedError on Django 1.8 if you used an empty Q() object in a filter
 
 ### Documentation:
 

--- a/djangae/db/backends/appengine/parsers/version_18.py
+++ b/djangae/db/backends/appengine/parsers/version_18.py
@@ -1,5 +1,6 @@
 from django.db.models.expressions import Star
 from django.db.models.sql.datastructures import EmptyResultSet
+from django.db.models.sql.where import SubqueryConstraint
 
 from .version_19 import Parser as BaseParser
 
@@ -10,6 +11,15 @@ class Parser(BaseParser):
         if isinstance(self.django_query.where, EmptyWhere):
             # Empty where means return nothing!
             raise EmptyResultSet()
+
+    def _where_node_leaf_callback(self, node, negated, new_parent, connection, model, compiler):
+        if not isinstance(node, SubqueryConstraint):
+            # Only do this test if it's not a subquery, the parent method deals with that
+            if not hasattr(node, "lhs") and not hasattr(node, "rhs"):
+                # Empty Q() object - basically an empty where node that needs nothing doing to it
+                return
+
+        return super(Parser, self)._where_node_leaf_callback(node, negated, new_parent, connection, model, compiler)
 
     def _determine_query_kind(self):
         query = self.django_query

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -745,6 +745,13 @@ class BackendTests(TestCase):
         expected = [(t, dt)]
         self.assertItemsEqual(result, expected)
 
+    def test_filter_with_empty_q(self):
+        t1 = TestUser.objects.create(username='foo', field2='bar')
+        condition = Q() | Q(username='foo')
+        self.assertEqual(t1, TestUser.objects.filter(condition).first())
+
+        condition = Q()
+        self.assertEqual(t1, TestUser.objects.filter(condition).first())
 
 class ModelFormsetTest(TestCase):
     def test_reproduce_index_error(self):


### PR DESCRIPTION
Fixes #746

Summary of changes proposed in this Pull Request:
- Adds a test for running a filter with an empty Q()
- 
- 

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
