### PR TITLE
Django 1.10 models do not have a _deferred attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed various issues with `djangae.contrib.mappers.defer_iteration`, so that it no longers gets stuck deferring tasks or hitting memory limit errors when uses on large querysets.
 - Fixed an issue where having a ForeignKey to a ContentType would cause an issue when querying due to the large IDs produced by djangae.contrib.contenttypes's SimulatedContentTypesManager.
 - Cascade deletions will now correctly batch object collection within the datastore query limits, fixing errors on deletion.
+- Fixed missing `_deferred` attribute in Django models for versions >= 1.10
 
 ### Documentation:
 

--- a/djangae/contrib/contenttypes/models.py
+++ b/djangae/contrib/contenttypes/models.py
@@ -58,7 +58,7 @@ class SimulatedContentTypeManager(models.Manager):
     def _get_opts(self, model, for_concrete_model):
         if for_concrete_model:
             model = model._meta.concrete_model
-        elif model._deferred:
+        elif getattr(model, '_deferred', False) or model is getattr(models, 'DEFERRED', None):
             model = model._meta.proxy_for_model
         return model._meta
 

--- a/djangae/contrib/contenttypes/tests.py
+++ b/djangae/contrib/contenttypes/tests.py
@@ -33,6 +33,11 @@ class SimulatedContentTypesTests(TestCase):
         self.assertEqual(ct.model, DummyModel._meta.model_name)
         self.assertEqual(ct.app_label, DummyModel._meta.app_label)
 
+    def test_get_for_model_not_concrete(self):
+        ct = ContentType.objects.get_for_model(DummyModel, for_concrete_model=False)
+        self.assertEqual(ct.model, DummyModel._meta.model_name)
+        self.assertEqual(ct.app_label, DummyModel._meta.app_label)
+
     def test_get_by_natural_key(self):
         ct = ContentType.objects.get_by_natural_key(
             DummyModel._meta.app_label, DummyModel._meta.model_name)


### PR DESCRIPTION
Django models do not contain a `_deferred` attribute anymore, and instead they are part of the `models.DEFERRED` list. 