### PR TITLE
Fix chaining none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Implemented weak (memcache) locking to contrib.locking
 - The `disable_cache` decorator now wraps the returned function with functools.wraps
 - `prefetch_related()` now works on RelatedListField and RelatedSetField
+- Added a test for Model.objects.none().filter(pk=xyz) type filters
 
 ### Bug fixes:
 

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -753,6 +753,11 @@ class BackendTests(TestCase):
         condition = Q()
         self.assertEqual(t1, TestUser.objects.filter(condition).first())
 
+    def test_chaining_none_filter(self):
+        t1 = TestUser.objects.create()
+        self.assertFalse(TestUser.objects.none().filter(pk=t1.pk))
+
+
 class ModelFormsetTest(TestCase):
     def test_reproduce_index_error(self):
         class TestModelForm(ModelForm):


### PR DESCRIPTION
Fixes #771 

Summary of changes proposed in this Pull Request:
- Adds a test to prove that .none().filter() doesn't explode like it used to

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
