### PR TITLE
Fix keys only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed missing `_deferred` attribute in Django models for versions >= 1.10
 - Fixed an error when submitting an empty JSONFormField
 - Fixed a bug where an error would be thrown if you loaded an entity with a JSONField that had non-JSON data, now the data is returned unaltered
+- Fixed a bug where only("pk") wouldn't perform a keys_only query
 
 ### Documentation:
 


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Fixes a bug where only("pk") wouldn't result in a keys_only query

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
