### PR TITLE
Assert that value in JSONFormField is a string or None.

### DIFF
--- a/djangae/forms/fields.py
+++ b/djangae/forms/fields.py
@@ -78,6 +78,7 @@ class JSONFormField(forms.CharField):
 
     def clean(self, value):
         """ (Try to) parse JSON string back to python. """
+        assert isinstance(value, six.string_types) or value is None, "JSONField value must be a string or None"
 
         value = super(JSONFormField, self).clean(value)
 


### PR DESCRIPTION
* there is a chance that if we use custom widgets for the field, we
might end up with non-string value, which is wrong. This assert will
help identify potential issues. JSONFormField expects text or None only
and if we provide anything else (i.e. dictionary) we will have assertion
error raised very quickly.
