### PR TITLE
'patterns' is deprecated in django 1.8-1.9 and removed in 1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed an error when submitting an empty JSONFormField
 - Fixed a bug where an error would be thrown if you loaded an entity with a JSONField that had non-JSON data, now the data is returned unaltered
 - Fixed a bug where only("pk") wouldn't perform a keys_only query
+- Dropping the deprecated patterns() from contrib.locking.urls
 
 ### Documentation:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Fixed an error when submitting an empty JSONFormField
 - Fixed a bug where an error would be thrown if you loaded an entity with a JSONField that had non-JSON data, now the data is returned unaltered
 - Fixed a bug where only("pk") wouldn't perform a keys_only query
-- Dropping the deprecated patterns() from contrib.locking.urls
+- Dropped the deprecated patterns() from contrib.locking.urls
 
 ### Documentation:
 

--- a/djangae/contrib/locking/urls.py
+++ b/djangae/contrib/locking/urls.py
@@ -1,10 +1,10 @@
 # THIRD PARTY
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 # DJANGAE
 from .views import cleanup_locks
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^djangae-cleanup-locks/$', cleanup_locks, name="cleanup_locks"),
-)
+]

--- a/testapp/testapp/urls.py
+++ b/testapp/testapp/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     url(r'^_ah/', include(djangae.urls)),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^auth/', include('djangae.contrib.gauth.urls')),
+    url(r'^locking/', include('djangae.contrib.locking.urls')),
     url(r'^$', view_that_defers),
 ]
 


### PR DESCRIPTION
`django.conf.urls.patterns` is removed in django>=1.10, this removes the last remaining reference to it.