### PR TITLE
Properly shut down the search stub in the local sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Fixed a bug where an error would be thrown if you loaded an entity with a JSONField that had non-JSON data, now the data is returned unaltered
 - Fixed a bug where only("pk") wouldn't perform a keys_only query
 - Dropped the deprecated patterns() from contrib.locking.urls
-- Fixed a bug where search indexes weren't saved when they were generated in the local sandbox
+- Fixed a bug where search indexes weren't saved when they were generated in the local shell
 
 ### Documentation:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed a bug where an error would be thrown if you loaded an entity with a JSONField that had non-JSON data, now the data is returned unaltered
 - Fixed a bug where only("pk") wouldn't perform a keys_only query
 - Dropped the deprecated patterns() from contrib.locking.urls
+- Fixed a bug where search indexes weren't saved when they were generated in the local sandbox
 
 ### Documentation:
 

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -174,11 +174,12 @@ def _local(devappserver2=None, configuration=None, options=None, wsgi_request_in
         request_data, storage_path, options, configuration)
 
     from .blobstore_service import start_blobstore_service, stop_blobstore_service
-
+    from google.appengine.tools.devappserver2 import api_server
     start_blobstore_service()
     try:
         yield
     finally:
+        api_server.cleanup_stubs()
         os.environ = original_environ
         stop_blobstore_service()
 


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Properly cleans up the App Engine stubs when the local sandbox shuts down. Search indexes are now saved after management commands and the shell.

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
