### PR TITLE
Clean up the result fetching code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Moved everything from `contrib.gauth.common.*` to the parent `contrib.gauth` module.  I.e. removed the `.common` part.
     - This change requires you to update your application to reference/import from the new paths.
     - The old paths still work for now but will trigger deprecation warnings.
+- Cleaned up the query fetching code to be more readable. Moved where result fetching happens to be inline with other backends, which makes Django Debug Toolbar query profiling output correct
 
 ### Bug fixes:
 

--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -125,14 +125,12 @@ class Cursor(object):
             return []
 
         result = []
-        i = 0
-        while i < size:
+        for i in xrange(size):
             entity = self.fetchone(delete_flag)
             if entity is None:
                 break
 
             result.append(entity)
-            i += 1
 
         return result
 

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -343,12 +343,6 @@ def convert_django_ordering_to_gae(ordering):
             result.append((column, datastore.Query.ASCENDING))
     return result
 
-def wrap_result_with_functor(results, func):
-    for result in results:
-        result = func(result)
-        if result is not None:
-            yield result
-
 def limit_results_generator(results, limit):
     for result in results:
         yield result
@@ -382,6 +376,111 @@ def can_perform_datastore_get(normalized_query):
                 return False
 
     return True
+
+class EntityTransforms:
+    @staticmethod
+    def convert_key_to_entity(result):
+        class FakeEntity(dict):
+            def __init__(self, key):
+                self._key = key
+
+            def key(self):
+                return self._key
+
+        return FakeEntity(result)
+
+    @staticmethod
+    def rename_pk_field(model, concrete_model, result):
+        if result is None:
+            return result
+
+        value = result.key().id_or_name()
+        result[model._meta.pk.column] = value
+        result[concrete_model._meta.pk.column] = value
+        return result
+
+    @staticmethod
+    def process_extra_selects(query, result):
+        """
+            We handle extra selects by generating the new columns from
+            each result. We can handle simple boolean logic and operators.
+        """
+        if result is None:
+            return result
+
+        extra_selects = query.extra_selects
+        model_fields = query.model._meta.fields
+
+        DATE_FORMATS = ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S")
+
+        def process_arg(arg):
+            if arg.startswith("'") and arg.endswith("'"):
+                # String literal
+                arg = arg.strip("'")
+                # Check to see if this is a date
+                for date in DATE_FORMATS:
+                    try:
+                        value = datetime.strptime(arg, date)
+                        return value
+                    except ValueError:
+                        continue
+                return arg
+            elif arg in [x.column for x in model_fields]:
+                # Column value
+                return result.get(arg)
+
+            # Handle NULL
+            if arg.lower() == 'null':
+                return None
+            elif arg.lower() == 'true':
+                return True
+            elif arg.lower() == 'false':
+                return False
+
+            # See if it's an integer
+            try:
+                arg = int(arg)
+            except (TypeError, ValueError):
+                pass
+
+            # Just a plain old literal
+            return arg
+
+        for col, select in extra_selects:
+            result[col] = select[0](*[ process_arg(x) for x in select[1] ])
+
+        return result
+
+    @staticmethod
+    def convert_datetime_fields(query, result):
+        if result is None:
+            return result
+
+        fields = [
+            x for x in query.model._meta.fields
+            if x.get_internal_type() in ("DateTimeField", "DateField", "TimeField")
+        ]
+
+        for field in fields:
+            column = field.column
+            if isinstance(result, dict): # sometimes it's a key!
+                value = result.get(column)
+            else:
+                value = None
+
+            if value is not None:
+                result[column] = ensure_datetime(value)
+        return result
+
+    @staticmethod
+    def ignore_excluded_pks(excluded_pks, result):
+        if result is None:
+            return result
+            
+        if result.key() in excluded_pks:
+            return None
+
+        return result
 
 
 class SelectCommand(object):
@@ -582,155 +681,63 @@ class SelectCommand(object):
                     count_query = Query(query._Query__kind, keys_only=True, namespace=self.namespace)
                     count_query.update(query)
                     resultset = count_query.Run(limit=limit, offset=offset)
-                self.results = (x for x in [ len([ y for y in resultset if y not in excluded_pks]) ])
+                self.results = [ len([ y for y in resultset if y not in excluded_pks]) ]
+                self.results_returned = 1
             else:
-                self.results = (x for x in [query.Count(limit=limit, offset=offset)])
+                self.results = [query.Count(limit=limit, offset=offset)]
+                self.results_returned = 1
             return
         elif self.query.kind == "AVERAGE":
             raise ValueError("AVERAGE not yet supported")
-        else:
-            self.results = query.Run(limit=limit, offset=offset)
 
         # Ensure that the results returned is reset
         self.results_returned = 0
+        self.results = []
 
-        def increment_returned_results(result):
-            self.results_returned += 1
-            return result
+        seen = set()
 
-        def convert_key_to_entity(result):
-            class FakeEntity(dict):
-                def __init__(self, key):
-                    self._key = key
-
-                def key(self):
-                    return self._key
-
-            return FakeEntity(result)
-
-        def rename_pk_field(result):
-            if result is None:
+        def dedupe(result):
+            # FIXME: This logic can't be right. I think we need to store the distinct fields
+            # somewhere on the query
+            if getattr(self.original_query, "annotation_select", None):
+                columns = self.original_query.annotation_select.keys()
+            else:
+                columns = self.query.columns or []
+            if not columns:
                 return result
 
-            value = result.key().id_or_name()
-            result[self.query.model._meta.pk.column] = value
-            result[self.query.concrete_model._meta.pk.column] = value
-            return result
-
-        def process_extra_selects(result):
-            """
-                We handle extra selects by generating the new columns from
-                each result. We can handle simple boolean logic and operators.
-            """
-            extra_selects = self.query.extra_selects
-            model_fields = self.query.model._meta.fields
-
-            DATE_FORMATS = ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S")
-
-            def process_arg(arg):
-                if arg.startswith("'") and arg.endswith("'"):
-                    # String literal
-                    arg = arg.strip("'")
-                    # Check to see if this is a date
-                    for date in DATE_FORMATS:
-                        try:
-                            value = datetime.strptime(arg, date)
-                            return value
-                        except ValueError:
-                            continue
-                    return arg
-                elif arg in [x.column for x in model_fields]:
-                    # Column value
-                    return result.get(arg)
-
-                # Handle NULL
-                if arg.lower() == 'null':
-                    return None
-                elif arg.lower() == 'true':
-                    return True
-                elif arg.lower() == 'false':
-                    return False
-
-                # See if it's an integer
-                try:
-                    arg = int(arg)
-                except (TypeError, ValueError):
-                    pass
-
-                # Just a plain old literal
-                return arg
-
-            for col, select in extra_selects:
-                result[col] = select[0](*[ process_arg(x) for x in select[1] ])
-
-            return result
-
-        def convert_datetime_fields(result):
-            fields = [
-                x for x in self.query.model._meta.fields
-                if x.get_internal_type() in ("DateTimeField", "DateField", "TimeField")
-            ]
-
-            for field in fields:
-                column = field.column
-                if isinstance(result, dict): # sometimes it's a key!
-                    value = result.get(column)
-                else:
-                    value = None
-
-                if value is not None:
-                    result[column] = ensure_datetime(value)
-            return result
-
-        def ignore_excluded_pks(result):
-            if result.key() in excluded_pks:
+            key = tuple([ result[x] for x in self._exclude_pk(columns) if x in result ])
+            if key in seen:
                 return None
+            seen.add(key)
             return result
 
-        self.results = wrap_result_with_functor(self.results, increment_returned_results)
+        for entity in query.Run(limit=limit, offset=offset):
+            # If this is a keys only query, we need to generate a fake entity
+            # for each key in the result set
+            if self.keys_only:
+                entity = EntityTransforms.convert_key_to_entity(entity)
 
-        # If this is a keys only query, we need to generate a fake entity
-        # for each key in the result set
-        if self.keys_only:
-            self.results = wrap_result_with_functor(self.results, convert_key_to_entity)
+            entity = EntityTransforms.ignore_excluded_pks(excluded_pks, entity)
+            entity = EntityTransforms.convert_datetime_fields(self.query, entity)
+            entity = EntityTransforms.rename_pk_field(self.query.model, self.query.concrete_model, entity)
+            entity = EntityTransforms.process_extra_selects(self.query, entity)
 
-        self.results = wrap_result_with_functor(self.results, ignore_excluded_pks)
-        self.results = wrap_result_with_functor(self.results, convert_datetime_fields)
-        self.results = wrap_result_with_functor(self.results, rename_pk_field)
-        self.results = wrap_result_with_functor(self.results, process_extra_selects)
+            if self.query.distinct and self.query.extra_selects:
+                entity = dedupe(entity)
 
-        if self.query.distinct and self.query.extra_selects:
-            # If we had extra selects, and we're distinct, we must deduplicate results
-            def deduper_factory():
-                seen = set()
+            if entity:
+                self.results.append(entity)
+                self.results_returned += 1
 
-                def dedupe(result):
-                    # FIXME: This logic can't be right. I think we need to store the distinct fields
-                    # somewhere on the query
-                    if getattr(self.original_query, "annotation_select", None):
-                        columns = self.original_query.annotation_select.keys()
-                    else:
-                        columns = self.query.columns or []
-                    if not columns:
-                        return result
-
-                    key = tuple([ result[x] for x in self._exclude_pk(columns) if x in result ])
-                    if key in seen:
-                        return None
-                    seen.add(key)
-                    return result
-
-                return dedupe
-
-            self.results = wrap_result_with_functor(self.results, deduper_factory())
-
-        if limit:
-            self.results = limit_results_generator(self.results, limit - excluded_pk_count)
-
+            if limit and self.results_returned >= (limit - excluded_pk_count):
+                break
 
     def execute(self):
         self.gae_query = self._build_query()
         self._fetch_results(self.gae_query)
+        self.results = iter(self.results)
+        return self.results_returned
 
     def __unicode__(self):
         # TODO: should we print out the namespace in here too?


### PR DESCRIPTION
This results in a number of improvements/changes:

 - Queries are now fetched in cursor.execute() not during iteration which is more like other backends. This has the nice side-effect that Django Debug Toolbar now correctly shows query times
 - Results are not wrapped in generators, making tracebacks from Djangae/AppEngine much more readable
 - SelectCommand.execute() now returns the number of returned results, so cursor.rowcount is correctly set
 - Transforms which are applied to entities are now outside _fetch_results() making the code lots more readable, and also makes profiling easier
 - Performance should be marginally improved due to fewer variables / function calls

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
