### PR TITLE
Inequality filter with defered iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 - Fixed a bug where search indexes weren't saved when they were generated in the local shell
 - Fixed a bug where permissions wouldn't be created when using Django's PermissionsMixin on the datastore (for some reason)
 - Fixed a bug where a user's username would be set to the string 'None' if username was not populated on an admin form
+- Fixed `djangae.contrib.mappers.defer.defer_iteration` to allow inequality filters in querysets
+- Fixed a bug in `djangae.contrib.mappers.defer.defer_iteration` where `_shard` would potentially ignore the first element of the queryset
 
 ### Documentation:
 

--- a/djangae/contrib/mappers/tests.py
+++ b/djangae/contrib/mappers/tests.py
@@ -151,14 +151,16 @@ class TestDeferIteration(TestCase):
         8c3804a8f7ffcd379fcaf6af452a698b4ac6e756 deferring iteration was
         impossible for querysets containing inequality filters.
         """
-        queryset = TestNode.objects.filter(counter__lt=11)
+        queryset = TestNode.objects.filter(counter__lt=1000)
         defer_iteration(queryset, add_onehundred, shard_size=5)
 
-        self.assertTrue(sum(TestNode.objects.values_list("counter", flat=True)))
+        initial_sum = sum(TestNode.objects.filter(counter__lt=1000).values_list("counter", flat=True))
+        num_objects = TestNode.objects.filter(counter__lt=11).count()
+        expected_new_sum = initial_sum + (num_objects * 100)
 
         self.process_task_queues()
 
         self.assertEqual(
-            sum([(x+1) + 100 for x in xrange(10)]),
-            sum(TestNode.objects.values_list("counter", flat=True))
+            sum(TestNode.objects.filter(counter__lt=1000).values_list("counter", flat=True)),
+            expected_new_sum
         )

--- a/djangae/contrib/mappers/tests.py
+++ b/djangae/contrib/mappers/tests.py
@@ -145,3 +145,20 @@ class TestDeferIteration(TestCase):
             sum([(x+1) + 100 for x in xrange(10)]),
             sum(TestNode.objects.values_list("counter", flat=True))
         )
+
+    def test_that_processing_with_inequality_filter_works(self):
+        """ Regression tests: after introducing shards in commit
+        8c3804a8f7ffcd379fcaf6af452a698b4ac6e756 deferring iteration was
+        impossible for querysets containing inequality filters.
+        """
+        queryset = TestNode.objects.filter(counter__lt=11)
+        defer_iteration(queryset, add_onehundred, shard_size=5)
+
+        self.assertTrue(sum(TestNode.objects.values_list("counter", flat=True)))
+
+        self.process_task_queues()
+
+        self.assertEqual(
+            sum([(x+1) + 100 for x in xrange(10)]),
+            sum(TestNode.objects.values_list("counter", flat=True))
+        )

--- a/docs/mappers.md
+++ b/docs/mappers.md
@@ -24,8 +24,5 @@ callback function on each Django model instance in the queryset.
 
 * The shard size is the number of instance which it will attempt to process in a single task, and defaults to 500.
     * Depending on how long your callback function is likely to take on each instance, you should reduce the shard size in order that it can safely process that many instances in App Engine's task time limit of 10 minutes.
-* The ordering of the queryset is set to `order_by('pk')`.
-    * This does not guarantee that objects will be processed in this order.
-    * Due to the Datastore's limitations, this creates a restriction that you cannot use an inequality filter other than on the PK field in your queryset.
 * There is no exception handling around the callback function, so an exception is raised when processing one of the instances then that task will fail and be retried, thus re-processing any prior instances in that same shard.
     * Your callback function should be idempotent.


### PR DESCRIPTION
These changes allow `defer_iteration` to work with querysets that already have inequality filters. This fix was made by Ola (the test as well), but I had to make a new branch and commit the changes myself as I had messed it up while updating the docs and the changelog.

Although, looking at recent changes, it seems that slicing was intentionally removed as it would cause memory leaks, so not sure if this fix is the right one.
