### PR TITLE
Updated AppEngineSecurityMiddleware to work with Django >= 1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - The old paths still work for now but will trigger deprecation warnings.
 - Cleaned up the query fetching code to be more readable. Moved where result fetching happens to be inline with other backends, which makes Django Debug Toolbar query profiling output correct
 - The default GCS bucket name is now cached when first read, saving on RPC calls
+- Updated `AppEngineSecurityMiddleware` to work with Django >= 1.10
 
 
 ### Bug fixes:

--- a/djangae/contrib/security/middleware.py
+++ b/djangae/contrib/security/middleware.py
@@ -9,6 +9,11 @@ from google.appengine.api import urlfetch
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +94,7 @@ def _HttpUrlLoggingWrapper(func):
 
 PATCHES_APPLIED = False
 
-class AppEngineSecurityMiddleware(object):
+class AppEngineSecurityMiddleware(MiddlewareMixin):
     """
         This middleware patches over some more insecure parts of the Python and AppEngine libraries.
 


### PR DESCRIPTION
Django middleware changed in 1.10. See more [here](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)