### PR TITLE
Cache default bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
     - This change requires you to update your application to reference/import from the new paths.
     - The old paths still work for now but will trigger deprecation warnings.
 - Cleaned up the query fetching code to be more readable. Moved where result fetching happens to be inline with other backends, which makes Django Debug Toolbar query profiling output correct
+- The default GCS bucket name is now cached when first read, saving on RPC calls
+
 
 ### Bug fixes:
 
@@ -37,6 +39,7 @@
 - Fixed a bug where a user's username would be set to the string 'None' if username was not populated on an admin form
 - Fixed `djangae.contrib.mappers.defer.defer_iteration` to allow inequality filters in querysets
 - Fixed a bug in `djangae.contrib.mappers.defer.defer_iteration` where `_shard` would potentially ignore the first element of the queryset
+- Fixed an incompatibility between appstats and the cloud storage backend due to RPC calls being made in the __init__ method
 
 ### Documentation:
 

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -154,15 +154,21 @@ def serve_file(request, blob_key_or_info, as_download=False, content_type=None, 
     return response
 
 
+DEFAULT_GCS_BUCKET = None
+
 def get_bucket_name():
     """
         Returns the bucket name for Google Cloud Storage, either from your
         settings or the default app bucket.
     """
+    global DEFAULT_GCS_BUCKET
+
     bucket = getattr(settings, BUCKET_KEY, None)
     if not bucket:
         # No explicit setting, lets try the default bucket for your application.
-        bucket = app_identity.get_default_gcs_bucket_name()
+        bucket = DEFAULT_GCS_BUCKET or app_identity.get_default_gcs_bucket_name()
+        DEFAULT_GCS_BUCKET = bucket
+
     if not bucket:
         from django.core.exceptions import ImproperlyConfigured
         message = '%s not set or no default bucket configured' % BUCKET_KEY

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -293,7 +293,7 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
     write_options = None
 
     def __init__(self, bucket=None, google_acl=None):
-        if bucket and callable(bucket):
+        if callable(bucket):
             # If the bucket is callable, just store the callable
             self._bucket_calculator = bucket
         else:


### PR DESCRIPTION
Fixes a bug when appstats is combined with the CloudStorage backend. Also reduces RPC calls.

Summary of changes proposed in this Pull Request:
- Cache the default bucket name the first time it is accessed (globally, so per-instance)
- Make CloudStorageBackend.bucket lazy (fixes appstats infinite loop bug)
- Allow passing a callable as 'bucket'

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
