### PR TITLE
Allow additional validators to be specified on djangae.fields.CharField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - The old paths still work for now but will trigger deprecation warnings.
 - Cleaned up the query fetching code to be more readable. Moved where result fetching happens to be inline with other backends, which makes Django Debug Toolbar query profiling output correct
 - The default GCS bucket name is now cached when first read, saving on RPC calls
+- Fixed a bug where it wasn't possible to add validators to djangae.fields.CharField
 
 
 ### Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 - Cleaned up app_id handling in --sandbox management calls
 - The default GCS bucket name is now cached when first read, saving on RPC calls
 - Updated `AppEngineSecurityMiddleware` to work with Django >= 1.10
-- Fixed a bug where it wasn't possible to add validators to djangae.fields.CharField
 
 ### Bug fixes:
 
@@ -43,6 +42,7 @@
 - Fixed `djangae.contrib.mappers.defer.defer_iteration` to allow inequality filters in querysets
 - Fixed a bug in `djangae.contrib.mappers.defer.defer_iteration` where `_shard` would potentially ignore the first element of the queryset
 - Fixed an incompatibility between appstats and the cloud storage backend due to RPC calls being made in the __init__ method
+- Fixed a bug where it wasn't possible to add validators to djangae.fields.CharField
 
 ### Documentation:
 

--- a/djangae/fields/__init__.py
+++ b/djangae/fields/__init__.py
@@ -83,4 +83,8 @@ class CharField(models.CharField):
             "%ss max_length must not be grater than %d bytes." % (self.__class__.__name__, _MAX_STRING_LENGTH)
 
         super(CharField, self).__init__(max_length=max_length, *args, **kwargs)
-        self.validators = [validators.MaxBytesValidator(limit_value=max_length)]
+
+        # Append the MaxBytesValidator if it's not been included already
+        self.validators = [
+            x for x in self.validators if not isinstance(x, validators.MaxBytesValidator)
+        ] + [validators.MaxBytesValidator(limit_value=max_length)]

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.db.utils import IntegrityError
 from django.conf import settings
 from django.core.exceptions import ValidationError, ImproperlyConfigured
+from django.core.validators import EmailValidator
 
 # DJANGAE
 from djangae.contrib import sleuth
@@ -165,6 +166,7 @@ class JSONFieldWithDefaultModel(models.Model):
 class ModelWithCharField(models.Model):
     char_field_with_max = CharField(max_length=10, default='', blank=True)
     char_field_without_max = CharField(default='', blank=True)
+    char_field_as_email = CharField(validators=[EmailValidator(message='failed')], blank=True)
 
 
 class ModelWithCharOrNoneField(models.Model):
@@ -1179,6 +1181,10 @@ class CharFieldModelTests(TestCase):
             u'Ensure this value has at most 1500 bytes (it has 1504).',
             test_instance.full_clean,
          )
+
+    def test_additional_validators_work(self):
+        test_instance = ModelWithCharField(char_field_as_email='bananas')
+        self.assertRaisesMessage(ValidationError, 'failed', test_instance.full_clean)
 
     def test_too_long_max_value_set(self):
         try:


### PR DESCRIPTION
Fixes #850 

Summary of changes proposed in this Pull Request:
- Fixes a bug where the Djangae CharField would get its validators overridden

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
