### PR TITLE
851 ensure related fields store pks as integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Fixed a bug in `djangae.contrib.mappers.defer.defer_iteration` where `_shard` would potentially ignore the first element of the queryset
 - Fixed an incompatibility between appstats and the cloud storage backend due to RPC calls being made in the __init__ method
 - Fixed a bug where it wasn't possible to add validators to djangae.fields.CharField
+- Fixed a bug where entries in `RelatedSetField`s and `RelatedListField`s weren't being converted to the same type as the primary key of the model
 
 ### Documentation:
 

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -482,6 +482,9 @@ class RelatedIteratorField(ForeignObject):
 
         if isinstance(ret, set):
             ret = list(ret)
+
+        ret = [self.rel.model._meta.pk.clean(x, self.rel.model) for x in ret]
+
         return ret
 
     def get_db_prep_lookup(self, *args, **kwargs):

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -483,7 +483,7 @@ class RelatedIteratorField(ForeignObject):
         if isinstance(ret, set):
             ret = list(ret)
 
-        ret = [self.rel.model._meta.pk.clean(x, self.rel.model) for x in ret]
+        ret = [self.rel.to._meta.pk.clean(x, self.rel.to) for x in ret]
 
         return ret
 


### PR DESCRIPTION
Fixes #851 

Summary of changes proposed in this Pull Request:
- Fixes a bug where where entries in RelatedSetField and RelatedListField weren't being converted to the same type as the primary key of the model

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
