### PR TITLE
Changes the session_csrf security check to check the MIDDLEWARE setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New features & improvements:
 
+- The system check for session_csrf now works with the MIDDLEWARE setting when using Django >= 1.10.
 - System check for deferred builtin which should always be switched off.
 - Implemented weak (memcache) locking to contrib.locking
 - The `disable_cache` decorator now wraps the returned function with functools.wraps

--- a/djangae/checks.py
+++ b/djangae/checks.py
@@ -27,7 +27,13 @@ CSP_SOURCE_NAMES = [
 @register(Tags.security)
 def check_session_csrf_enabled(app_configs, **kwargs):
     errors = []
-    if "session_csrf.CsrfMiddleware" not in settings.MIDDLEWARE_CLASSES:
+
+    # Django >= 1.10 has a MIDDLEWARE setting, which is None by default. Convert
+    # it to a list, it might be a tuple.
+    middleware = list(getattr(settings, 'MIDDLEWARE') or [])
+    middleware.extend(getattr(settings, 'MIDDLEWARE_CLASSES', []))
+
+    if 'session_csrf.CsrfMiddleware' not in middleware:
         errors.append(Error(
             "SESSION_CSRF_DISABLED",
             hint="Please add 'session_csrf.CsrfMiddleware' to MIDDLEWARE_CLASSES",


### PR DESCRIPTION
Django 1.10 introduced a new MIDDLEWARE setting, and session_csrf works
fine with it. This check will work with pre-1.10 projects which don't
have the MIDDLEWARE setting defined at all, with 1.10 projects which
use MIDDLEWARE in place of MIDDLEWARE_CLASSES, and with 1.10 projects
which use MIDDLEWARE_CLASSES but not MIDDLEWARE (in which case the
default for MIDDLEWARE is `None`).

This fixes #857.
