### PR TITLE
Guard against no MIDDLEWARE setting when checking for session_csrf.

### DIFF
--- a/djangae/checks.py
+++ b/djangae/checks.py
@@ -30,7 +30,7 @@ def check_session_csrf_enabled(app_configs, **kwargs):
 
     # Django >= 1.10 has a MIDDLEWARE setting, which is None by default. Convert
     # it to a list, it might be a tuple.
-    middleware = list(getattr(settings, 'MIDDLEWARE') or [])
+    middleware = list(getattr(settings, 'MIDDLEWARE', []) or [])
     middleware.extend(getattr(settings, 'MIDDLEWARE_CLASSES', []))
 
     if 'session_csrf.CsrfMiddleware' not in middleware:


### PR DESCRIPTION
This was supposed to be handled already by using `getattr`, but I was
totally thinking of how `{}.get('foo')` returns `None` if a key is
missing, whereas `getattr(obj, 'foo')` will raise AttributeError if
you don't specify a default.

Fixes #861.
