### PR TITLE
Remove redundant default using or operator

### DIFF
--- a/djangae/checks.py
+++ b/djangae/checks.py
@@ -30,7 +30,7 @@ def check_session_csrf_enabled(app_configs, **kwargs):
 
     # Django >= 1.10 has a MIDDLEWARE setting, which is None by default. Convert
     # it to a list, it might be a tuple.
-    middleware = list(getattr(settings, 'MIDDLEWARE', []) or [])
+    middleware = list(getattr(settings, 'MIDDLEWARE', []))
     middleware.extend(getattr(settings, 'MIDDLEWARE_CLASSES', []))
 
     if 'session_csrf.CsrfMiddleware' not in middleware:


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Now that we're specifying a default in the call to `getattr`, we no longer need to use the or operator to provide a default list. 

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
