### PR TITLE
849 tests incorrectly load search indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Fixed a bug where it wasn't possible to add validators to djangae.fields.CharField
 - Fixed a bug where entries in `RelatedSetField`s and `RelatedListField`s weren't being converted to the same type as the primary key of the model
 - Fixed a bug where running tests would incorrectly load the real search stub before the test version
+- Fixed a bug where IDs weren't reserved with the datastore allocator immediately and so could end up with a race-condition where an ID could be reused
 
 ### Documentation:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,12 @@
 - Fixed an incompatibility between appstats and the cloud storage backend due to RPC calls being made in the __init__ method
 - Fixed a bug where it wasn't possible to add validators to djangae.fields.CharField
 - Fixed a bug where entries in `RelatedSetField`s and `RelatedListField`s weren't being converted to the same type as the primary key of the model
+- Fixed a bug where running tests would incorrectly load the real search stub before the test version
 
 ### Documentation:
 
 - Improved documentation for `djangae.contrib.mappers.defer_iteration`.
+- Changed the installation documentation to reflect the correct way to launch tests
 
 
 ## v0.9.8 (release date: 6th December 2016)

--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -473,34 +473,13 @@ class DatabaseCreation(BaseDatabaseCreation):
         return []
 
     def _create_test_db(self, verbosity, autoclobber, *args):
-        from google.appengine.ext import testbed # Imported lazily to prevent warnings on GAE
-
-        assert not self.testbed
-
         if args:
             logger.warning("'keepdb' argument is not currently supported on the AppEngine backend")
 
-        # We allow users to disable scattered IDs in tests. This primarily for running Django tests that
-        # assume implicit ordering (yeah, annoying)
-        use_scattered = not getattr(settings, "DJANGAE_SEQUENTIAL_IDS_IN_TESTS", False)
-
-        kwargs = {
-            "use_sqlite": True,
-            "auto_id_policy": testbed.AUTO_ID_POLICY_SCATTERED if use_scattered else testbed.AUTO_ID_POLICY_SEQUENTIAL,
-            "consistency_policy": datastore_stub_util.PseudoRandomHRConsistencyPolicy(probability=1)
-        }
-
-        self.testbed = testbed.Testbed()
-        self.testbed.activate()
-        self.testbed.init_datastore_v3_stub(**kwargs)
-        self.testbed.init_memcache_stub()
         get_context().reset()
 
     def _destroy_test_db(self, name, verbosity):
-        if self.testbed:
-            get_context().reset()
-            self.testbed.deactivate()
-            self.testbed = None
+        get_context().reset()
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -816,7 +816,7 @@ class FlushCommand(object):
 def reserve_id(kind, id_or_name, namespace):
     from google.appengine.api.datastore import _GetConnection
     key = datastore.Key.from_path(kind, id_or_name, namespace=namespace)
-    _GetConnection()._async_reserve_keys(None, [key])
+    _GetConnection()._reserve_keys([key])
 
 
 class BulkInsertError(IntegrityError, NotSupportedError):

--- a/djangae/settings_base.py
+++ b/djangae/settings_base.py
@@ -56,4 +56,4 @@ DJANGAE_RUNSERVER_IGNORED_FILES_REGEXES = ['^.+$(?<!\.py)(?<!\.yaml)(?<!\.html)'
 # Note that these should match a directory name, not directory path:
 DJANGAE_RUNSERVER_IGNORED_DIR_REGEXES = [r"^google_appengine$"]
 
-TEST_RUNNER = 'djangae.test_runner.DjangaeDiscoverRunner'
+TEST_RUNNER = 'djangae.test.DjangaeDiscoverRunner'

--- a/djangae/settings_base.py
+++ b/djangae/settings_base.py
@@ -55,3 +55,5 @@ ALLOWED_HOSTS = ("*",)
 DJANGAE_RUNSERVER_IGNORED_FILES_REGEXES = ['^.+$(?<!\.py)(?<!\.yaml)(?<!\.html)']
 # Note that these should match a directory name, not directory path:
 DJANGAE_RUNSERVER_IGNORED_DIR_REGEXES = [r"^google_appengine$"]
+
+TEST_RUNNER = 'djangae.test_runner.DjangaeDiscoverRunner'

--- a/djangae/test.py
+++ b/djangae/test.py
@@ -24,10 +24,6 @@ def inconsistent_db(probability=0, connection='default'):
 
     conn = connections[connection]
 
-    if not hasattr(conn.creation, "testbed") or "datastore_v3" not in conn.creation.testbed._enabled_stubs:
-        raise RuntimeError("Tried to use the inconsistent_db stub when not testing")
-
-
     stub = apiproxy_stub_map.apiproxy.GetStub('datastore_v3')
 
     # Set the probability of the datastore stub

--- a/djangae/test.py
+++ b/djangae/test.py
@@ -4,6 +4,8 @@ import os
 
 from django import test
 from django.test import Client
+from django.test.runner import DiscoverRunner
+from djangae.test_runner import bed_wrap
 
 from djangae.environment import get_application_root
 
@@ -171,3 +173,10 @@ class TestCase(HandlerAssertionsMixin, TestCaseMixin, test.TestCase):
 
 class TransactionTestCase(HandlerAssertionsMixin, TestCaseMixin, test.TransactionTestCase):
     pass
+
+
+class DjangaeDiscoverRunner(DiscoverRunner):
+    def build_suite(self, *args, **kwargs):
+        suite = super(DjangaeDiscoverRunner, self).build_suite(*args, **kwargs)
+        suite._tests[:] = [bed_wrap(test) for test in suite._tests]
+        return suite

--- a/djangae/test_runner.py
+++ b/djangae/test_runner.py
@@ -1,3 +1,7 @@
+## The test runner in here is for running the Djangae test suite itself. Projects using Djangae
+## should either use djangae.test.DjangaeDiscoverRunner or if using Nose, use the noseplugin
+## both of which will setup and teardown the App Engine testbed for each test
+
 import unittest
 import os
 from unittest import TextTestResult
@@ -204,10 +208,3 @@ class SkipUnsupportedRunner(DjangaeTestSuiteRunner):
             resultclass=SkipUnsupportedTestResult
         ).run(suite)
 
-
-class DjangaeDiscoverRunner(DiscoverRunner):
-    def build_suite(self, *args, **kwargs):
-        suite = super(DjangaeDiscoverRunner, self).build_suite(*args, **kwargs)
-        suite._tests[:] = [bed_wrap(test) for test in suite._tests]
-        return suite
-        

--- a/djangae/test_runner.py
+++ b/djangae/test_runner.py
@@ -193,3 +193,11 @@ class SkipUnsupportedRunner(DjangaeTestSuiteRunner):
             failfast=self.failfast,
             resultclass=SkipUnsupportedTestResult
         ).run(suite)
+
+
+class DjangaeDiscoverRunner(DiscoverRunner):
+    def build_suite(self, *args, **kwargs):
+        suite = super(DjangaeDiscoverRunner, self).build_suite(*args, **kwargs)
+        suite._tests[:] = [bed_wrap(test) for test in suite._tests]
+        return suite
+        

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,7 @@ if __name__ == "__main__":
     from djangae.core.management import execute_from_command_line, test_execute_from_command_line
 
     if "test" in sys.argv:
+        # This prevents the local sandbox initializing when running tests
         test_execute_from_command_line(sys.argv)
     else:
         execute_from_command_line(sys.argv)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,9 +34,12 @@ Make your `manage.py` look something like this:
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myapp.settings")
 
-    from djangae.core.management import execute_from_command_line
+    from djangae.core.management import execute_from_command_line, test_execute_from_command_line
 
-    execute_from_command_line(sys.argv)
+    if "test" in sys.argv:
+        test_execute_from_command_line(sys.argv)
+    else:
+        execute_from_command_line(sys.argv)
 ```
 
 Use the Djangae WSGI handler in your wsgi.py, something like


### PR DESCRIPTION
Fixes #849 .

Summary of changes proposed in this Pull Request:
- The slow startup performance for some projects appeared to be down to the real search stub being loaded before the test version. We've changed the way that the testbeds & stubs are being setup, by adding a new test runner which will be used by default. 
- These changes also highlighted an issue with how we reserve IDs. This was a long standing sporadic issue, which occurred every time the tests were run after the new changes to the test bed setup & tear down.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
