### PR TITLE
Added a test to prove the model meta ordering is used for pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - The default GCS bucket name is now cached when first read, saving on RPC calls
 - Updated `AppEngineSecurityMiddleware` to work with Django >= 1.10
 - Added a test for prefetching via RelatedSetField/RelatedListField. Cleaned up some related code.
+- Added a test to prove that the ordering specified on a model's _meta is used for pagination, when no custom order has been specified on the query set.
 
 ### Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - The default GCS bucket name is now cached when first read, saving on RPC calls
 - Updated `AppEngineSecurityMiddleware` to work with Django >= 1.10
 - Added a test for prefetching via RelatedSetField/RelatedListField. Cleaned up some related code.
-- Added a test to prove that the ordering specified on a model's `meta` is used for pagination, when no custom order has been specified on the query set.
+- Added a test to prove that the ordering specified on a model's `_meta` is used for pagination, when no custom order has been specified on the query set.
 
 ### Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - The default GCS bucket name is now cached when first read, saving on RPC calls
 - Updated `AppEngineSecurityMiddleware` to work with Django >= 1.10
 - Added a test for prefetching via RelatedSetField/RelatedListField. Cleaned up some related code.
-- Added a test to prove that the ordering specified on a model's _meta is used for pagination, when no custom order has been specified on the query set.
+- Added a test to prove that the ordering specified on a model's `meta` is used for pagination, when no custom order has been specified on the query set.
 
 ### Bug fixes:
 


### PR DESCRIPTION
Fixes #465 

Summary of changes proposed in this Pull Request:
- Added a test to prove that the ordering specified on a model's `_meta` is used for pagination, when no custom order has been specified on the query set.

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
