### PR TITLE
improve sandbox argument passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Updated `AppEngineSecurityMiddleware` to work with Django >= 1.10
 - Added a test for prefetching via RelatedSetField/RelatedListField. Cleaned up some related code.
 - Allow the sandbox argument to be at any position.
+- Added some test for the management command code.
 
 ### Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - The default GCS bucket name is now cached when first read, saving on RPC calls
 - Updated `AppEngineSecurityMiddleware` to work with Django >= 1.10
 - Added a test for prefetching via RelatedSetField/RelatedListField. Cleaned up some related code.
+- Allow the sandbox argument to be at any position.
 
 ### Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Updated `AppEngineSecurityMiddleware` to work with Django >= 1.10
 - Added a test for prefetching via RelatedSetField/RelatedListField. Cleaned up some related code.
 - Allow the sandbox argument to be at any position.
-- Added some test for the management command code.
+- Added some tests for the management command code.
 
 ### Bug fixes:
 

--- a/djangae/core/management/__init__.py
+++ b/djangae/core/management/__init__.py
@@ -48,22 +48,18 @@ def _execute_from_command_line(sandbox_name, argv, **sandbox_overrides):
 def execute_from_command_line(argv=None, **sandbox_overrides):
     """Wraps Django's `execute_from_command_line` to initialize a djangae
     sandbox before running a management command.
-
-    Note: The '--sandbox' arg must come first. All other args are forwarded to
-          Django as normal.
     """
     argv = argv or sys.argv
     parser = argparse.ArgumentParser(prog='manage.py')
     parser.add_argument(
         '--sandbox', default=sandbox.LOCAL, choices=sandbox.SANDBOXES.keys())
     parser.add_argument('--app_id', default=None, help='GAE APPLICATION ID')
-    parser.add_argument('args', nargs=argparse.REMAINDER)
-    namespace = parser.parse_args(argv[1:])
+    namespace, other_args = parser.parse_known_args(argv[1:])
 
     overrides = DJANGO_DEFAULTS
     overrides.update(sandbox_overrides, app_id=namespace.app_id)
 
-    return _execute_from_command_line(namespace.sandbox, ['manage.py'] + namespace.args, **overrides)
+    return _execute_from_command_line(namespace.sandbox, ['manage.py'] + other_args, **overrides)
 
 
 def remote_execute_from_command_line(argv=None, **sandbox_overrides):

--- a/djangae/tests/test_management.py
+++ b/djangae/tests/test_management.py
@@ -1,0 +1,45 @@
+# LIBRARIES
+from contextlib import contextmanager
+
+# DJANGAE
+from djangae.contrib import sleuth
+from djangae.core.management import execute_from_command_line
+from djangae.test import TestCase
+
+
+@contextmanager
+def test_context_manager(*args, **kwargs):
+    yield
+
+class ManagementCommandsTest(TestCase):
+    def test_arguments_are_passed_through_correctly(self):
+        with sleuth.switch("django.core.management.execute_from_command_line", lambda *args, **kwargs: None) as django_execute_mock, \
+             sleuth.switch("djangae.sandbox.activate", test_context_manager):
+            execute_from_command_line(['manage.py', 'arg1', 'arg2', 'arg3',])
+            self.assertEqual(1, django_execute_mock.call_count)
+            self.assertEqual((['manage.py', 'arg1', 'arg2', 'arg3',],), django_execute_mock.calls[0].args)
+
+    def test_sandbox_can_be_specified(self):
+        with sleuth.switch("django.core.management.execute_from_command_line", lambda *args, **kwargs: None) as django_execute_mock, \
+             sleuth.switch("djangae.sandbox.activate", test_context_manager) as activate_sandbox_mock:
+
+            # test default sandbox is used if no sandbox argument
+            execute_from_command_line(['manage.py', 'arg1', 'arg2',])
+            self.assertEqual(1, activate_sandbox_mock.call_count)
+            self.assertEqual('local', activate_sandbox_mock.calls[0].args[0])
+            self.assertEqual(1, django_execute_mock.call_count)
+            self.assertEqual((['manage.py', 'arg1', 'arg2',],), django_execute_mock.calls[0].args)
+
+            # test that sandbox argument is used when given
+            execute_from_command_line(['manage.py', '--sandbox=test', 'arg1', 'arg2',])
+            self.assertEqual(2, activate_sandbox_mock.call_count)
+            self.assertEqual('test', activate_sandbox_mock.calls[1].args[0])
+            self.assertEqual(2, django_execute_mock.call_count)
+            self.assertEqual((['manage.py', 'arg1', 'arg2',],), django_execute_mock.calls[1].args)
+
+            # test that sandbox argument can be in any position
+            execute_from_command_line(['manage.py', 'arg1', '--sandbox=test', 'arg2',])
+            self.assertEqual(3, activate_sandbox_mock.call_count)
+            self.assertEqual('test', activate_sandbox_mock.calls[2].args[0])
+            self.assertEqual(3, django_execute_mock.call_count)
+            self.assertEqual((['manage.py', 'arg1', 'arg2',],), django_execute_mock.calls[2].args)

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -21,7 +21,7 @@ Add the `remote_api` built-in to app.yaml, and deploy that change.
 
 You also need to ensure that the `application` in app.yaml is set to the application which you wish to connect to.
 
-Then run your management command specifying the `remote` sandbox.  Note that the `--sandbox` argument needs to come before the name of the management command, e.g.:
+Then run your management command specifying the `remote` sandbox.
 
     ./manage.py --sandbox=remote shell
 


### PR DESCRIPTION
Fixes #338

Summary of changes proposed in this Pull Request:
- Allow for the sandbox argument to be at any position in the args list, for the call to the management command.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change