### PR TITLE
Add a `task_or_admin_only` view decorator to djangae.environment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Allow the sandbox argument to be at any position.
 - Added some tests for the management command code.
 - Added a test to prove that the ordering specified on a model's `_meta` is used for pagination, when no custom order has been specified on the query set.
+- Added a `@task_or_admin_only` decorator to `djangae.environment` to allow restricting views to tasks (including crons) or admins of the application.
 
 ### Bug fixes:
 

--- a/djangae/environment.py
+++ b/djangae/environment.py
@@ -1,4 +1,12 @@
+# STANDARD LIBRARY
+from functools import wraps
 import os
+
+# THIRD PARTY
+from django.http import HttpResponseForbidden
+from google.appengine.api import users
+
+# DJANGAE
 from djangae.utils import memoized
 
 
@@ -104,3 +112,20 @@ def get_application_root():
                 path = parent
 
     raise RuntimeError("Unable to locate app.yaml. Did you add it to skip_files?")
+
+
+def task_or_admin_only(view_function):
+    """ View decorator for restricting access to tasks (and crons) and admins of the application
+        only.
+    """
+    @wraps(view_function)
+    def replacement(*args, **kwargs):
+        if not any((
+            is_in_task(),
+            is_in_cron(),
+            users.is_current_user_admin(),
+        )):
+            return HttpResponseForbidden("Access denied.")
+        return view_function(*args, **kwargs)
+
+    return replacement

--- a/djangae/tests/test_environment.py
+++ b/djangae/tests/test_environment.py
@@ -1,0 +1,53 @@
+
+
+from djangae.environment import task_or_admin_only
+from djangae.test import TestCase
+from djangae.contrib import sleuth
+from django.http import HttpResponse
+
+
+class TaskOrAdminOnlyTestCase(TestCase):
+    """ Tests for the @task_or_admin_only decorator. """
+
+    def test_403_if_not_task_or_admin(self):
+        # If we are neither in a task or logged in as an admin, we expect a 403 response
+
+        @task_or_admin_only
+        def view(request):
+            return HttpResponse("Hello")
+
+        response = view(None)
+        self.assertEqual(response.status_code, 403)
+
+    def test_allowed_if_in_task(self):
+        """ If we're in an App Engine task then it should allow the request through. """
+
+        @task_or_admin_only
+        def view(request):
+            return HttpResponse("Hello")
+
+        with sleuth.fake("djangae.environment.is_in_task", True):
+            response = view(None)
+        self.assertEqual(response.status_code, 200)
+
+    def test_allowed_if_in_cron(self):
+        """ If the view is being called by the GAE cron, then it should allow the request through. """
+
+        @task_or_admin_only
+        def view(request):
+            return HttpResponse("Hello")
+
+        with sleuth.fake("djangae.environment.is_in_cron", True):
+            response = view(None)
+        self.assertEqual(response.status_code, 200)
+
+    def test_allowed_if_admin_user(self):
+        """ If we're logged in as an admin of the GAE application then we should allow through. """
+
+        @task_or_admin_only
+        def view(request):
+            return HttpResponse("Hello")
+
+        with sleuth.fake("djangae.environment.users.is_current_user_admin", True):
+            response = view(None)
+        self.assertEqual(response.status_code, 200)

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -35,3 +35,7 @@ Returns true if the code is running in a task on the task queue
 
 Returns the number of times the task has retried, or 0 if the code is not
 running on a queue
+
+## djangae.environment.task_or_admin_only
+
+View decorator to allow restricting views to tasks (including crons) or admins of the application.


### PR DESCRIPTION
Adds a `@task_or_admin_only` decorator to `djangae.environment` to allow restricting views to tasks (including crons) or admins of the application.


PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
