### PR TITLE
Switch the default storage backend to CloudStorage. Fixes #870

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### New features & improvements:
 
- -
+ - Switched the default storage backend (in settings_base.py) to cloud storage. If you need to retain compatibility make sure you
+ override the `DEFAULT_FILE_STORAGE` setting to point to `'djangae.storage.BlobstoreStorage'`
 
 ### Bug fixes:
 

--- a/djangae/settings_base.py
+++ b/djangae/settings_base.py
@@ -1,4 +1,4 @@
-DEFAULT_FILE_STORAGE = 'djangae.storage.BlobstoreStorage'
+DEFAULT_FILE_STORAGE = 'djangae.storage.CloudStorage'
 FILE_UPLOAD_MAX_MEMORY_SIZE = 1024 * 1024
 FILE_UPLOAD_HANDLERS = (
     'djangae.storage.BlobstoreFileUploadHandler',

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -329,10 +329,13 @@ class CloudStorage(Storage, BlobstoreUploadMixin):
                 # This causes a Datastore lookup which we don't want to interfere with transactions
                 url = get_serving_url(self._get_blobkey(filename))
             return re.sub("http://", "//", url)
-        except (TransformationError):
+        except (TransformationError, cloudstorage.NotFoundError):
             # Sometimes TransformationError will be thrown if you call get_serving_url on video files
             # this is probably a bug in App Engine
             # Probably related to this: https://code.google.com/p/googleappengine/issues/detail?id=8601
+
+            # Also, Django requires that url() return something 'truthy' even if the file field hasn't been
+            # saved yet so we do the same thing if the file is not found (just add the bucket to the filename)
             quoted_filename = urllib.quote(self._add_bucket(filename))
             return '{0}{1}'.format(self.api_url, quoted_filename)
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -2,6 +2,8 @@
 
 Djangae provides two storage backends. `djangae.storage.CloudStorage` and `djangae.storage.BlobstoreStorage`.
 
+If you've imported `djangae.settings_base.*`, then the default backend is `djangae.storage.CloudStorage`
+
 ## Cloud Storage
 
 `djangae.storage.CloudStorage` is a  django storage backend that works with Google Cloud Storage, you can treat it just as


### PR DESCRIPTION
Although this means that the cloudstorage library must be available, it's a far better choice
for a future-proof backend, especially for new projects. If you still require the Blobstore just
override the DEFAULT_FILE_STORAGE setting.

Fixes #870 
Summary of changes proposed in this Pull Request:
- Switches the default storage backend from Blobstore to Cloudstorage (meaning 'cloudstorage' is now a requirement although you can just override the default if you don't want it)

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
