### PR TITLE
Replace MultiQuery with our own version (AsyncMultiQuery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features & improvements:
 
- -
+ - Added AsyncMultiQuery as a replacement for Google's MultiQuery (which doesn't exist on Cloud Datastore)
 
 ### Bug fixes:
 

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -438,7 +438,7 @@ class SelectCommand(object):
 
             return queries[0]
         else:
-            return datastore.MultiQuery(queries, ordering)
+            return meta_queries.AsyncMultiQuery(queries, ordering)
 
     def _fetch_results(self, query):
         # If we're manually excluding PKs, and we've specified a limit to the results

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -34,6 +34,7 @@ from djangae.db import constraints, utils
 from djangae.db.backends.appengine import caching
 from djangae.db.unique_utils import query_is_unique
 
+from . import meta_queries
 
 logger = logging.getLogger(__name__)
 
@@ -125,209 +126,6 @@ def log_once(logging_call, text, args):
 
 log_once.logged = set()
 
-
-def _convert_entity_based_on_query_options(entity, opts):
-    if opts.keys_only:
-        return entity.key()
-
-    if opts.projection:
-        for k in entity.keys()[:]:
-            if k not in list(opts.projection) + [POLYMODEL_CLASS_ATTRIBUTE]:
-                del entity[k]
-
-    return entity
-
-
-class QueryByKeys(object):
-    """ Does the most efficient fetching possible for when we have the keys of the entities we want. """
-
-    def __init__(self, model, queries, ordering, namespace):
-        # `queries` should be filtered by __key__ with keys that have the namespace applied to them.
-        # `namespace` is passed for explicit niceness (mostly so that we don't have to assume that
-        # all the keys belong to the same namespace, even though they will).
-        def _get_key(query):
-            result = query["__key__ ="]
-            return result
-
-        self.model = model
-        self.namespace = namespace
-
-        # groupby requires that the iterable is sorted by the given key before grouping
-        self.queries = sorted(queries, key=_get_key)
-        self.queries_by_key = { a: list(b) for a, b in groupby(self.queries, _get_key) }
-
-        self.ordering = ordering
-        self._Query__kind = queries[0]._Query__kind
-
-    def Run(self, limit=None, offset=None):
-        """
-            Here are the options:
-
-            1. Single key, hit memcache
-            2. Multikey projection, async MultiQueries with ancestors chained
-            3. Full select, datastore get
-        """
-
-        opts = self.queries[0]._Query__query_options
-        key_count = len(self.queries_by_key)
-
-        is_projection = False
-
-        results = None
-        if key_count == 1:
-            # FIXME: Potentially could use get_multi in memcache and the make a query
-            # for whatever remains
-            key = self.queries_by_key.keys()[0]
-            result = caching.get_from_cache_by_key(key)
-            if result is not None:
-                results = [result]
-                cache = False # Don't update cache, we just got it from there
-
-        if results is None:
-            if opts.projection:
-                is_projection = True # Don't cache projection results!
-
-                # Assumes projection ancestor queries are faster than a datastore Get
-                # due to lower traffic over the RPC. This should be faster for queries with
-                # < 30 keys (which is the most common case), and faster if the entities are
-                # larger and there are many results, but there is probably a slower middle ground
-                # because the larger number of RPC calls. Still, if performance is an issue the
-                # user can just do a normal get() rather than values/values_list/only/defer
-
-                to_fetch = (offset or 0) + limit if limit else None
-                additional_cols = set([ x[0] for x in self.ordering if x[0] not in opts.projection])
-
-                multi_query = []
-                final_queries = []
-                orderings = self.queries[0]._Query__orderings
-                for key, queries in self.queries_by_key.iteritems():
-                    for query in queries:
-                        if additional_cols:
-                            # We need to include additional orderings in the projection so that we can
-                            # sort them in memory. Annoyingly that means reinstantiating the queries
-                            query = Query(
-                                kind=query._Query__kind,
-                                filters=query,
-                                projection=list(opts.projection).extend(list(additional_cols)),
-                                namespace=self.namespace,
-                            )
-
-                        query.Ancestor(key) # Make this an ancestor query
-                        multi_query.append(query)
-                        if len(multi_query) == 30:
-                            final_queries.append(datastore.MultiQuery(multi_query, orderings).Run(limit=to_fetch))
-                            multi_query = []
-                else:
-                    if len(multi_query) == 1:
-                        final_queries.append(multi_query[0].Run(limit=to_fetch))
-                    elif multi_query:
-                        final_queries.append(datastore.MultiQuery(multi_query, orderings).Run(limit=to_fetch))
-
-                results = chain(*final_queries)
-            else:
-                results = datastore.Get(self.queries_by_key.keys())
-
-        def iter_results(results):
-            returned = 0
-            # This is safe, because Django is fetching all results any way :(
-            sorted_results = sorted(results, cmp=partial(utils.django_ordering_comparison, self.ordering))
-            sorted_results = [result for result in sorted_results if result is not None]
-            if not is_projection and sorted_results:
-                caching.add_entities_to_cache(
-                    self.model,
-                    sorted_results,
-                    caching.CachingSituation.DATASTORE_GET,
-                    self.namespace,
-                )
-
-            for result in sorted_results:
-                if is_projection:
-                    entity_matches_query = True
-                else:
-                    entity_matches_query = any(
-                        utils.entity_matches_query(result, qry) for qry in self.queries_by_key[result.key()]
-                    )
-
-                if not entity_matches_query:
-                    continue
-
-                if offset and returned < offset:
-                    # Skip entities based on offset
-                    returned += 1
-                    continue
-                else:
-
-                    yield _convert_entity_based_on_query_options(result, opts)
-
-                    returned += 1
-
-                    # If there is a limit, we might be done!
-                    if limit is not None and returned == (offset or 0) + limit:
-                        break
-
-        return iter_results(results)
-
-    def Count(self, limit, offset):
-        return len([x for x in self.Run(limit, offset)])
-
-
-class NoOpQuery(object):
-    def Run(self, limit, offset):
-        return []
-
-    def Count(self, limit, offset):
-        return 0
-
-
-class UniqueQuery(object):
-    """
-        This mimics a normal query but hits the cache if possible. It must
-        be passed the set of unique fields that form a unique constraint
-    """
-    def __init__(self, unique_identifier, gae_query, model, namespace):
-        self._identifier = unique_identifier
-        self._gae_query = gae_query
-        self._model = model
-        self._namespace = namespace
-
-        self._Query__kind = gae_query._Query__kind
-
-    def get(self, x):
-        return self._gae_query.get(x)
-
-    def keys(self):
-        return self._gae_query.keys()
-
-    def Run(self, limit, offset):
-        opts = self._gae_query._Query__query_options
-        if opts.keys_only or opts.projection:
-            return self._gae_query.Run(limit=limit, offset=offset)
-
-        ret = caching.get_from_cache(self._identifier, self._namespace)
-        if ret is not None and not utils.entity_matches_query(ret, self._gae_query):
-            ret = None
-
-        if ret is None:
-            # We do a fast keys_only query to get the result
-            keys_query = Query(self._gae_query._Query__kind, keys_only=True, namespace=self._namespace)
-            keys_query.update(self._gae_query)
-            keys = keys_query.Run(limit=limit, offset=offset)
-
-            # Do a consistent get so we don't cache stale data, and recheck the result matches the query
-            ret = [x for x in datastore.Get(keys) if x and utils.entity_matches_query(x, self._gae_query)]
-            if len(ret) == 1:
-                caching.add_entities_to_cache(
-                    self._model,
-                    [ret[0]],
-                    caching.CachingSituation.DATASTORE_GET,
-                    self._namespace,
-                )
-            return iter(ret)
-
-        return iter([ret])
-
-    def Count(self, limit, offset):
-        return sum(1 for x in self.Run(limit, offset))
 
 
 from djangae.db.backends.appengine.query import transform_query
@@ -630,13 +428,13 @@ class SelectCommand(object):
 
         if can_perform_datastore_get(self.query):
             # Yay for optimizations!
-            return QueryByKeys(self.query.model, queries, ordering, self.namespace)
+            return meta_queries.QueryByKeys(self.query.model, queries, ordering, self.namespace)
 
         if len(queries) == 1:
             identifier = query_is_unique(self.query.model, queries[0])
             if identifier:
                 # Yay for optimizations!
-                return UniqueQuery(identifier, queries[0], self.query.model, self.namespace)
+                return meta_queries.UniqueQuery(identifier, queries[0], self.query.model, self.namespace)
 
             return queries[0]
         else:
@@ -674,7 +472,7 @@ class SelectCommand(object):
                 # didn't seem to indicate much of a performance difference, even when doing the pk__in
                 # with GetAsync while the count was running. That might not be true of prod though so
                 # if anyone comes up with a faster idea let me know!
-                if isinstance(query, QueryByKeys):
+                if isinstance(query, meta_queries.QueryByKeys):
                     # If this is a QueryByKeys, just do the datastore Get and count the results
                     resultset = (x.key() for x in query.Run(limit=limit, offset=offset) if x)
                 else:
@@ -1115,7 +913,7 @@ class UpdateCommand(object):
                 return False
 
             if (
-                isinstance(self.select.gae_query, (Query, UniqueQuery)) # ignore QueryByKeys and NoOpQuery
+                isinstance(self.select.gae_query, (Query, meta_queries.UniqueQuery)) # ignore QueryByKeys and NoOpQuery
                 and not utils.entity_matches_query(result, self.select.gae_query)
             ):
                 # Due to eventual consistency they query may have returned an entity which no longer

--- a/djangae/db/backends/appengine/dnf.py
+++ b/djangae/db/backends/appengine/dnf.py
@@ -208,12 +208,12 @@ def normalize_query(query):
 
     MAX_ALLOWABLE_QUERIES = getattr(
         settings,
-        "DJANGAE_MAX_ALLOWABLE_QUERIES", DEFAULT_MAX_ALLOWABLE_QUERIES
+        "DJANGAE_MAX_QUERY_BRANCHES", DEFAULT_MAX_ALLOWABLE_QUERIES
     )
 
     if (not all_pks) and len(query.where.children) > MAX_ALLOWABLE_QUERIES:
         raise NotSupportedError(
-            "Unable to run query as it required more than {} subqueries".format(
+            "Unable to run query as it required more than {} subqueries (limit is configurable with DJANGAE_MAX_QUERY_BRANCHES)".format(
                 MAX_ALLOWABLE_QUERIES
             )
         )

--- a/djangae/db/backends/appengine/meta_queries.py
+++ b/djangae/db/backends/appengine/meta_queries.py
@@ -1,3 +1,4 @@
+import copy
 import threading
 
 from functools import partial
@@ -124,7 +125,8 @@ class AsyncMultiQuery(object):
     def Count(self, **kwargs):
         def query_decorator(query):
             # Force keys_only
-            import copy
+            # we copy to prevent changing the original query
+            # unexpectedly
             query = copy.deepcopy(query)
             query._Query__query_options = QueryOptions(keys_only=True)
 

--- a/djangae/db/backends/appengine/meta_queries.py
+++ b/djangae/db/backends/appengine/meta_queries.py
@@ -1,0 +1,331 @@
+import threading
+
+from functools import partial
+from itertools import chain, groupby
+
+from djangae.db.backends.appengine import caching
+from djangae.db import utils
+
+from djangae.db.backends.appengine import POLYMODEL_CLASS_ATTRIBUTE
+
+from google.appengine.api import datastore
+from google.appengine.api.datastore import Query
+
+
+class AsyncMultiQuery(object):
+    """
+        Runs multiple queries simultaneously and merges the result sets based on the
+        shared ordering.
+    """
+    THREAD_COUNT = 2
+
+    def __init__(self, queries, orderings):
+        self._queries = queries
+        self._orderings = orderings
+        self._min_max_cache = {}
+
+    def _spawn_thread(self, i, query, result_queues, **query_run_args):
+        class Thread(threading.Thread):
+            def __init__(self, *args, **kwargs):
+                self.results_fetched = False
+                super(Thread, self).__init__(*args, **kwargs)
+
+            def run(self):
+                result_queues[i] = (x for x in query.Run(**query_run_args))
+                self.results_fetched = True
+
+        thread = Thread()
+        thread.start()
+        return thread
+
+    def _fetch_results(self):
+        threads = []
+
+        # We need to grab a set of results per query
+        result_queues = [None] * len(self._queries)
+
+        # Go through the queries, trigger new threads as they become available
+        for i, query in enumerate(self._queries):
+            while len(threads) >= self.THREAD_COUNT:
+                try:
+                    complete = (x for x in threads if x.is_finished).next()
+                except StopIteration:
+                    # No threads available, continue waiting
+                    continue
+
+                # Remove the complete thread
+                complete.join()
+                threads.remove(complete)
+
+            # Spawn a new thread
+            threads.append(self._spawn_thread(i, query, result_queues))
+
+        [x.join() for x in threads] # Wait until all the threads are done
+
+        return result_queues
+
+    def _compare_entities(self, lhs, rhs):
+        def get_extreme_if_list_property(entity_key, column, value, order):
+            if not isinstance(value, list):
+                return value
+
+            if (entity_key, column) in self._min_max_cache:
+                return self._min_max_cache[(entity_key, column)]
+
+            if order == Query.DESCENDING:
+                value = min(value)
+            else:
+                value = max(value)
+            self._min_max_cache[(entity_key, column)] = value
+
+        if not lhs:
+            return cmp(lhs, rhs)
+
+        for column, order in self._orderings:
+            lhs_value = lhs.key() if column == "__key__" else lhs[column]
+            rhs_value = rhs.key() if column == "__key__" else rhs[column]
+
+            lhs_value = get_extreme_if_list_property(lhs.key(), column, lhs_value, order)
+            rhs_value = get_extreme_if_list_property(lhs.key(), column, rhs_value, order)
+
+            result = cmp(lhs_value, rhs_value)
+
+            if order == Query.DESCENDING:
+                result = -result
+            if result:
+                return result
+
+        return cmp(lhs.key(), rhs.key())
+
+
+    def Run(self, **kwargs):
+        self._min_max_cache = []
+        results = self._fetch_results()
+
+        next_entries = [None] * len(results)
+        for i, queue in enumerate(results):
+            try:
+                next_entries[i] = results[i].next()
+            except StopIteration:
+                next_entries[i] = None
+
+        seen_keys = set() #For de-duping results
+        while any(next_entries):
+            next = sorted(next_entries, self._compare_entities)[0]
+
+            i = next_entries.index(next)
+            try:
+                next_entries[i] = results[i].next()
+            except StopIteration:
+                next_entries[i] = None
+
+            # Make sure we haven't seen this result before before yielding
+            if next.key() not in seen_keys:
+                seen_keys.add(next.key())
+                yield next
+
+
+def _convert_entity_based_on_query_options(entity, opts):
+    if opts.keys_only:
+        return entity.key()
+
+    if opts.projection:
+        for k in entity.keys()[:]:
+            if k not in list(opts.projection) + [POLYMODEL_CLASS_ATTRIBUTE]:
+                del entity[k]
+
+    return entity
+
+
+class QueryByKeys(object):
+    """ Does the most efficient fetching possible for when we have the keys of the entities we want. """
+
+    def __init__(self, model, queries, ordering, namespace):
+        # `queries` should be filtered by __key__ with keys that have the namespace applied to them.
+        # `namespace` is passed for explicit niceness (mostly so that we don't have to assume that
+        # all the keys belong to the same namespace, even though they will).
+        def _get_key(query):
+            result = query["__key__ ="]
+            return result
+
+        self.model = model
+        self.namespace = namespace
+
+        # groupby requires that the iterable is sorted by the given key before grouping
+        self.queries = sorted(queries, key=_get_key)
+        self.queries_by_key = { a: list(b) for a, b in groupby(self.queries, _get_key) }
+
+        self.ordering = ordering
+        self._Query__kind = queries[0]._Query__kind
+
+    def Run(self, limit=None, offset=None):
+        """
+            Here are the options:
+
+            1. Single key, hit memcache
+            2. Multikey projection, async MultiQueries with ancestors chained
+            3. Full select, datastore get
+        """
+
+        opts = self.queries[0]._Query__query_options
+        key_count = len(self.queries_by_key)
+
+        is_projection = False
+
+        results = None
+        if key_count == 1:
+            # FIXME: Potentially could use get_multi in memcache and the make a query
+            # for whatever remains
+            key = self.queries_by_key.keys()[0]
+            result = caching.get_from_cache_by_key(key)
+            if result is not None:
+                results = [result]
+                cache = False # Don't update cache, we just got it from there
+
+        if results is None:
+            if opts.projection:
+                is_projection = True # Don't cache projection results!
+
+                # Assumes projection ancestor queries are faster than a datastore Get
+                # due to lower traffic over the RPC. This should be faster for queries with
+                # < 30 keys (which is the most common case), and faster if the entities are
+                # larger and there are many results, but there is probably a slower middle ground
+                # because the larger number of RPC calls. Still, if performance is an issue the
+                # user can just do a normal get() rather than values/values_list/only/defer
+
+                to_fetch = (offset or 0) + limit if limit else None
+                additional_cols = set([ x[0] for x in self.ordering if x[0] not in opts.projection])
+
+                multi_query = []
+                final_queries = []
+                orderings = self.queries[0]._Query__orderings
+                for key, queries in self.queries_by_key.iteritems():
+                    for query in queries:
+                        if additional_cols:
+                            # We need to include additional orderings in the projection so that we can
+                            # sort them in memory. Annoyingly that means reinstantiating the queries
+                            query = Query(
+                                kind=query._Query__kind,
+                                filters=query,
+                                projection=list(opts.projection).extend(list(additional_cols)),
+                                namespace=self.namespace,
+                            )
+
+                        query.Ancestor(key) # Make this an ancestor query
+                        multi_query.append(query)
+                        if len(multi_query) == 30:
+                            final_queries.append(datastore.MultiQuery(multi_query, orderings).Run(limit=to_fetch))
+                            multi_query = []
+                else:
+                    if len(multi_query) == 1:
+                        final_queries.append(multi_query[0].Run(limit=to_fetch))
+                    elif multi_query:
+                        final_queries.append(datastore.MultiQuery(multi_query, orderings).Run(limit=to_fetch))
+
+                results = chain(*final_queries)
+            else:
+                results = datastore.Get(self.queries_by_key.keys())
+
+        def iter_results(results):
+            returned = 0
+            # This is safe, because Django is fetching all results any way :(
+            sorted_results = sorted(results, cmp=partial(utils.django_ordering_comparison, self.ordering))
+            sorted_results = [result for result in sorted_results if result is not None]
+            if not is_projection and sorted_results:
+                caching.add_entities_to_cache(
+                    self.model,
+                    sorted_results,
+                    caching.CachingSituation.DATASTORE_GET,
+                    self.namespace,
+                )
+
+            for result in sorted_results:
+                if is_projection:
+                    entity_matches_query = True
+                else:
+                    entity_matches_query = any(
+                        utils.entity_matches_query(result, qry) for qry in self.queries_by_key[result.key()]
+                    )
+
+                if not entity_matches_query:
+                    continue
+
+                if offset and returned < offset:
+                    # Skip entities based on offset
+                    returned += 1
+                    continue
+                else:
+
+                    yield _convert_entity_based_on_query_options(result, opts)
+
+                    returned += 1
+
+                    # If there is a limit, we might be done!
+                    if limit is not None and returned == (offset or 0) + limit:
+                        break
+
+        return iter_results(results)
+
+    def Count(self, limit, offset):
+        return len([x for x in self.Run(limit, offset)])
+
+
+class NoOpQuery(object):
+    def Run(self, limit, offset):
+        return []
+
+    def Count(self, limit, offset):
+        return 0
+
+
+class UniqueQuery(object):
+    """
+        This mimics a normal query but hits the cache if possible. It must
+        be passed the set of unique fields that form a unique constraint
+    """
+    def __init__(self, unique_identifier, gae_query, model, namespace):
+        self._identifier = unique_identifier
+        self._gae_query = gae_query
+        self._model = model
+        self._namespace = namespace
+
+        self._Query__kind = gae_query._Query__kind
+
+    def get(self, x):
+        return self._gae_query.get(x)
+
+    def keys(self):
+        return self._gae_query.keys()
+
+    def Run(self, limit, offset):
+        opts = self._gae_query._Query__query_options
+        if opts.keys_only or opts.projection:
+            return self._gae_query.Run(limit=limit, offset=offset)
+
+        ret = caching.get_from_cache(self._identifier, self._namespace)
+        if ret is not None and not utils.entity_matches_query(ret, self._gae_query):
+            ret = None
+
+        if ret is None:
+            # We do a fast keys_only query to get the result
+            keys_query = Query(self._gae_query._Query__kind, keys_only=True, namespace=self._namespace)
+            keys_query.update(self._gae_query)
+            keys = keys_query.Run(limit=limit, offset=offset)
+
+            # Do a consistent get so we don't cache stale data, and recheck the result matches the query
+            ret = [x for x in datastore.Get(keys) if x and utils.entity_matches_query(x, self._gae_query)]
+            if len(ret) == 1:
+                caching.add_entities_to_cache(
+                    self._model,
+                    [ret[0]],
+                    caching.CachingSituation.DATASTORE_GET,
+                    self._namespace,
+                )
+            return iter(ret)
+
+        return iter([ret])
+
+    def Count(self, limit, offset):
+        return sum(1 for x in self.Run(limit, offset))
+
+

--- a/djangae/tests/test_async_multi_query.py
+++ b/djangae/tests/test_async_multi_query.py
@@ -1,0 +1,53 @@
+from django.test import override_settings
+from django.db import NotSupportedError
+from django.db import models
+from djangae.test import TestCase
+
+
+class MultiQueryModel(models.Model):
+    field1 = models.IntegerField()
+
+
+class AsyncMultiQueryTest(TestCase):
+    """
+        Specific tests for multiquery
+    """
+
+    def test_hundred_or(self):
+        for i in range(100):
+            MultiQueryModel.objects.create(field1=i)
+
+        self.assertEqual(
+            len(MultiQueryModel.objects.filter(field1__in=list(range(100)))),
+            100
+        )
+
+        self.assertEqual(
+            MultiQueryModel.objects.filter(field1__in=list(range(100))).count(),
+            100
+        )
+
+        self.assertItemsEqual(
+            MultiQueryModel.objects.filter(
+                field1__in=list(range(100))
+            ).values_list("field1", flat=True),
+            list(range(100))
+        )
+
+        self.assertItemsEqual(
+            MultiQueryModel.objects.filter(
+                field1__in=list(range(100))
+            ).order_by("-field1").values_list("field1", flat=True),
+            list(range(100))[::-1]
+        )
+
+    @override_settings(DJANGAE_MAX_QUERY_BRANCHES=10)
+    def test_max_limit_enforced(self):
+        for i in range(11):
+            MultiQueryModel.objects.create(field1=i)
+
+        self.assertRaises(NotSupportedError,
+            lambda: list(MultiQueryModel.objects.filter(
+                field1__in=range(11)
+            ))
+        )

--- a/djangae/tests/test_async_multi_query.py
+++ b/djangae/tests/test_async_multi_query.py
@@ -46,8 +46,7 @@ class AsyncMultiQueryTest(TestCase):
         for i in range(11):
             MultiQueryModel.objects.create(field1=i)
 
-        self.assertRaises(NotSupportedError,
-            lambda: list(MultiQueryModel.objects.filter(
-                field1__in=range(11)
-            ))
+        self.assertRaises(
+            NotSupportedError,
+            list, MultiQueryModel.objects.filter(field1__in=range(11))
         )

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -445,7 +445,7 @@ class BackendTests(TestCase):
             list(TestUser.objects.filter(username="test"))
             self.assertEqual(1, query_mock.call_count)
 
-        with sleuth.switch("djangae.db.backends.appengine.commands.datastore.MultiQuery.Run", lambda *args, **kwargs: []) as query_mock:
+        with sleuth.switch("djangae.db.backends.appengine.meta_queries.AsyncMultiQuery.Run", lambda *args, **kwargs: []) as query_mock:
             list(TestUser.objects.filter(username__in=["test", "cheese"]))
             self.assertEqual(1, query_mock.call_count)
 
@@ -453,7 +453,7 @@ class BackendTests(TestCase):
             list(TestUser.objects.filter(pk=1))
             self.assertEqual(1, get_mock.call_count)
 
-        with sleuth.switch("djangae.db.backends.appengine.commands.datastore.MultiQuery.Run", lambda *args, **kwargs: []) as query_mock:
+        with sleuth.switch("djangae.db.backends.appengine.meta_queries.AsyncMultiQuery.Run", lambda *args, **kwargs: []) as query_mock:
             list(TestUser.objects.exclude(username__startswith="test"))
             self.assertEqual(1, query_mock.call_count)
 

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -346,16 +346,15 @@ class BackendTests(TestCase):
                 # Make sure the query is an ancestor of the key
                 self.assertEqual(query_anc.calls[0].args[1], datastore.Key.from_path(TestFruit._meta.db_table, "0", namespace=DEFAULT_NAMESPACE))
 
-        # Now check projections work with more than 30 things
-        with sleuth.watch('google.appengine.api.datastore.MultiQuery.__init__') as query_init:
+        # Now check projections work with fewer than 100 things
+        with sleuth.watch('djangae.db.backends.appengine.meta_queries.AsyncMultiQuery.__init__') as query_init:
             with sleuth.watch('google.appengine.api.datastore.Query.Ancestor') as query_anc:
                 keys = [str(x) for x in range(32)]
                 results = list(TestFruit.objects.only("color").filter(pk__in=keys).order_by("name"))
 
-                self.assertEqual(query_init.call_count, 2) # Two multi queries
+                self.assertEqual(query_init.call_count, 1) # One multiquery
                 self.assertEqual(query_anc.call_count, 32) # 32 Ancestor calls
-                self.assertEqual(len(query_init.calls[0].args[1]), 30)
-                self.assertEqual(len(query_init.calls[1].args[1]), 2)
+                self.assertEqual(len(query_init.calls[0].args[1]), 32)
 
                 # Confirm the ordering is correct
                 self.assertEqual(sorted(keys), [ x.pk for x in results ])

--- a/djangae/tests/test_connector.py
+++ b/djangae/tests/test_connector.py
@@ -1688,6 +1688,7 @@ class EdgeCaseTests(TestCase):
             list(dates)
         )
 
+    @override_settings(DJANGAE_MAX_QUERY_BRANCHES=30)
     def test_in_query(self):
         """ Test that the __in filter works, and that it cannot be used with more than 30 values,
             unless it's used on the PK field.
@@ -1700,7 +1701,6 @@ class EdgeCaseTests(TestCase):
         self.assertItemsEqual(results, [self.u1, self.u2])
         # Check that using more than 30 items in an __in query not on the pk causes death
         query = TestUser.objects.filter(username__in=list([x for x in letters[:31]]))
-        # This currently raises an error from App Engine, should we raise our own?
         self.assertRaises(Exception, list, query)
         # Check that it's ok with PKs though
         query = TestUser.objects.filter(pk__in=list(range(1, 32)))

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -188,7 +188,7 @@ There is also an equivalent function for ensuring the consistency of multiple it
 * Doing filter(pk__in=Something.objects.values_list('pk', flat=True)) will implicitly evaluate the inner query while preparing to run the outer one. This means two queries, not one like SQL would do!
 * IN queries and queries with OR branches which aren't filtered on PK result in multiple queries to the datastore. By default you will get an error
   if you exceed 100 IN filters but this is configurable via the `DJANGAE_MAX_QUERY_BRANCHES` setting. Be aware that
-  the more IN/OR filters in a query, the slower the query becomes. 100 is already a high values for this setting so
+  the more IN/OR filters in a query, the slower the query becomes. 100 is already a high value for this setting so
   raising it isn't recommended (it's probably better to rethink your data structure or querying)
 
 ## Unique Constraint Checking

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -35,7 +35,7 @@ Here is a brief list of hard limitations you may encounter when using the Djanga
 
  - `bulk_create()` is limited to 25 instances if the model has active unique constraints, or the instances being inserted have
    the primary key specified. In other cases the limit is 1000.
- - `filter(field__in=[...])` queries are limited to 30 entries in the list if `field` is not the primary key
+ - `filter(field__in=[...])` queries are limited to 100 entries (by default) in the list if `field` is not the primary key
  - `filter(pk__in=[...])` queries are limited to 1000 entries
  - You are limited to a single inequality filter per query, although excluding by primary key is not included in this count
  - Queries without primary key equality filters are not allowed within an `atomic` block
@@ -186,9 +186,10 @@ There is also an equivalent function for ensuring the consistency of multiple it
 * Doing an `.only('foo')` or `.defer('bar')` with a `pk_in=[...]` filter may not be more efficient. This is because we must perform a projection query for each key, and although we send them over the RPC in batches of 30, the RPC costs may outweigh the savings of a plain old datastore.Get. You should profile and check to see whether using only/defer results in a speed improvement for your use case.
 * Due to the way it has to be implemented on the Datastore, an `update()` query is not particularly fast, and other than avoiding calling the `save()` method on each object it doesn't offer much speed advantage over iterating over the objects and modifying them.  However, it does offer significant integrity advantages, see [General behaviours](#general-behaviours) section above.
 * Doing filter(pk__in=Something.objects.values_list('pk', flat=True)) will implicitly evaluate the inner query while preparing to run the outer one. This means two queries, not one like SQL would do!
-
-
-
+* IN queries and queries with OR branches which aren't filtered on PK result in multiple queries to the datastore. By default you will get an error
+  if you exceed 100 IN filters but this is configurable via the `DJANGAE_MAX_QUERY_BRANCHES` setting. Be aware that
+  the more IN/OR filters in a query, the slower the query becomes. 100 is already a high values for this setting so
+  raising it isn't recommended (it's probably better to rethink your data structure or querying)
 
 ## Unique Constraint Checking
 


### PR DESCRIPTION
Fixes #875 

Summary of changes proposed in this Pull Request:
- Move meta queries into their own file
- Implement a multithreaded MultiQuery alternative which replaces the 30 query limit with a configurable one
- Switch to using the new MultiQuery exclusively

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
