### PR TITLE
Test sandbox fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
  - The default ports for the API server, admin server and blobstore service have changed to 8010, 8011, and 8012 respectively to avoid clashes with modules
  - Switched the default storage backend (in settings_base.py) to cloud storage. If you need to retain compatibility make sure you
  override the `DEFAULT_FILE_STORAGE` setting to point to `'djangae.storage.BlobstoreStorage'`.
-- Added AsyncMultiQuery as a replacement for Google's MultiQuery (which doesn't exist on Cloud Datastore).  This is the first step towards support for Cloud Datastore and therefore Flexible Environment.
+ - Added AsyncMultiQuery as a replacement for Google's MultiQuery (which doesn't exist on Cloud Datastore).  This is the first step towards support for Cloud Datastore and therefore Flexible Environment.
 
 ### Bug fixes:
 
  - When running the local sandbox, if a port clash is detected then the next port will be used (this was broken before)
+ - Accessing the Datastore from outside tests will no longer throw an error when using the test sandbox
+ - The in-context cache is now reliably wiped when the testbed is initialized for each test
 
 ## v0.9.9 (release date: 27th March 2017)
 

--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -19,7 +19,6 @@ from django.db.backends.base.creation import BaseDatabaseCreation
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 
 from google.appengine.api.datastore_types import Blob, Text
-from google.appengine.datastore import datastore_stub_util
 from google.appengine.api import datastore, datastore_errors
 
 #DJANGAE
@@ -29,7 +28,6 @@ from djangae.db.utils import (
     get_datastore_key,
 )
 
-from djangae.db.backends.appengine.caching import get_context
 from djangae.db.backends.appengine.indexing import load_special_indexes
 from .commands import (
     SelectCommand,
@@ -473,13 +471,10 @@ class DatabaseCreation(BaseDatabaseCreation):
         return []
 
     def _create_test_db(self, verbosity, autoclobber, *args):
-        if args:
-            logger.warning("'keepdb' argument is not currently supported on the AppEngine backend")
-
-        get_context().reset()
+        pass
 
     def _destroy_test_db(self, name, verbosity):
-        get_context().reset()
+        pass
 
 
 class DatabaseIntrospection(BaseDatabaseIntrospection):

--- a/djangae/test_runner.py
+++ b/djangae/test_runner.py
@@ -11,6 +11,7 @@ from django.db import NotSupportedError
 from django.conf import settings
 
 from djangae import environment
+from djangae.db.backends.appengine.caching import get_context
 
 from google.appengine.datastore import datastore_stub_util
 from google.appengine.ext import testbed
@@ -106,6 +107,8 @@ def init_testbed():
             "consistency_policy": datastore_stub_util.PseudoRandomHRConsistencyPolicy(probability=1)
         }
     }
+
+    get_context().reset(); # Reset any context caching
     bed = testbed.Testbed()
     bed.activate()
     for init_name in testbed.INIT_STUB_METHOD_NAMES.values():

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -61,3 +61,13 @@ App Engine tasks are stored in the Datastore, so when you are in the remote shel
     >>> from my_code import my_function
     >>> from google.appengine.ext.deferred import defer
     >>> defer(my_function, arg1, arg2, _queue="queue_name")
+
+
+# Testing
+
+Along with the local/remote sandboxes, Djangae ships with a test sandbox. This should be called explicitly
+from your manage.py when tests are being run. This sandbox sets up the bare minimum to use the Datastore
+connector (the memcache and Datastore stubs only). This prevents accesses to the Datastore from throwing an error
+when you do so outside a test case (e.g. from `settings.py`).
+
+Your tests should setup and teardown a full testbed instance (see `DjangaeDiscoverRunner` and the nose plugin).


### PR DESCRIPTION
Fixes #879 

Summary of changes proposed in this Pull Request:
- Reset the in-context cache in `init_testbed()` rather than in the Datastore connector test methods
- Set up a minimal testbed in the test sandbox so that things don't die horribly if you try to access the Datastore before the test run (e.g. in settings.py)

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
