### PR TITLE
Improve caching performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Switched the default storage backend (in settings_base.py) to cloud storage. If you need to retain compatibility make sure you
  override the `DEFAULT_FILE_STORAGE` setting to point to `'djangae.storage.BlobstoreStorage'`.
  - Added AsyncMultiQuery as a replacement for Google's MultiQuery (which doesn't exist on Cloud Datastore).  This is the first step towards support for Cloud Datastore and therefore Flexible Environment.
+ - Added a configurable memory limit to the context cache, limited the number of instances cached from query results and corrected `disable_cache` behaviour.
 
 ### Bug fixes:
 

--- a/djangae/db/backends/appengine/caching.py
+++ b/djangae/db/backends/appengine/caching.py
@@ -218,6 +218,12 @@ def add_entities_to_cache(model, entities, situation, namespace, skip_memcache=F
     if not CACHE_ENABLED:
         return None
 
+    context = get_context()
+
+    if not (context.context_enabled or context.memcache_enabled):
+        # Don't cache anything if caching is disabled
+        return
+
     # Don't cache on Get if we are inside a transaction, even in the context
     # This is because transactions don't see the current state of the datastore
     # We can still cache in the context on Put() but not in memcache

--- a/djangae/db/backends/appengine/caching.py
+++ b/djangae/db/backends/appengine/caching.py
@@ -12,7 +12,7 @@ from django.core.cache.backends.base import default_key_func
 
 from djangae.db import utils
 from djangae.db.unique_utils import unique_identifiers_from_entity, _format_value_for_identifier
-from djangae.db.backends.appengine.context import ContextCache
+from djangae.db.backends.appengine.context import ContextCache, key_or_entity_compare
 
 _local = threading.local()
 
@@ -266,7 +266,7 @@ def remove_entities_from_cache_by_key(keys, namespace, memcache_only=False):
     context = get_context()
     if not memcache_only:
         for key in keys:
-            identifiers = context.stack.top.reverse_cache.get(key, [])
+            identifiers = context.stack.top.cache.get_reversed(key, compare_func=key_or_entity_compare)
             for identifier in identifiers:
                 if identifier in context.stack.top.cache:
                     del context.stack.top.cache[identifier]

--- a/djangae/db/backends/appengine/context.py
+++ b/djangae/db/backends/appengine/context.py
@@ -1,34 +1,128 @@
 import copy
-import collections
+import sys
 
 from google.appengine.api import datastore
 
-class CopyDict(collections.MutableMapping):
+
+def key_or_entity_compare(lhs, rhs):
     """
-        It's important we don't pass references around in and out
-        of the cache, so this just ensures we copy stuff going in, and
-        copy it going out!
+        Returns true if lhs is an entity with a key that matches rhs or
+        if lhs is a key which matches rhs, or if lhs is a key which maches
+        rhs.key()
     """
-    def __init__(self, *args, **kwargs):
-        self._store = {}
-        super(CopyDict, self).__init__(*args, **kwargs)
+    if hasattr(rhs, "key"):
+        rhs = rhs.key()
 
-    def __setitem__(self, key, value):
-        value = copy.deepcopy(value)
-        self._store[key] = value
+    if hasattr(lhs, "key"):
+        lhs = lhs.key()
 
-    def __getitem__(self, key):
-        value = self._store[key]
-        return copy.deepcopy(value)
+    return lhs == rhs
 
-    def __delitem__(self, key):
-        del self._store[key]
+
+class CacheDict(object):
+    """
+        This is a special dictionary-like object which does the following:
+
+        1. Copys items in and out to prevent storing references
+        2. The cache dict is restricted to a maximum size in bytes
+        3. Unaccessed entries are removed first
+    """
+
+    def __init__(self, max_size_in_bytes=(1024 * 1024 * 32)):
+        self.key_priority = []
+        self.entries = {}
+        self.total_value_size = 0
+        self.max_size_in_bytes = max_size_in_bytes
+
+    def _check_size_and_limit(self):
+        while self.total_value_size > self.max_size_in_bytes:
+            next_key = self.key_priority[-1]
+            del self[next_key]
+
+    def __setitem__(self, k, v):
+        v = copy.deepcopy(v)
+        self.entries[k] = v
+
+        try:
+            # If the key already exists, we don't reorder based on a set
+            # we only promote keys if they are accessed.
+            self.key_priority.index(k)
+        except ValueError:
+            # Insert new keys in the middle of the priority list, with usage
+            # they will either go up or down the list from there
+            insert_position = len(self.key_priority) // 2
+            self.key_priority.insert(insert_position, k)
+
+        self.total_value_size += sys.getsizeof(v)
+        self._check_size_and_limit()
+
+    def __getitem__(self, k):
+        v = self.entries[k] # Find the entry
+
+        # Move the key up the key priority
+        index = self.key_priority.index(k)
+        self.key_priority.pop(index)
+        self.key_priority.insert(0, k)
+        return copy.deepcopy(v)
+
+    def __delitem__(self, k):
+        v = self.entries[k]
+        del self.entries[k]
+        index = self.key_priority.index(k)
+        self.key_priority.pop(index)
+        self.total_value_size -= sys.getsizeof(v)
+
+    def __repr__(self):
+        return "{%s}" % ", ".join([":".join([repr(k), repr(v)]) for k, v in self.items()])
+
+    def __eq__(self, rhs):
+        unshared_items = set(self.items()).difference(set(rhs.items()))
+        return len(unshared_items) == 0
+
+    def __contains__(self, k):
+        return k in self.entries
+
+    def update(self, other):
+        for k, v in other.items():
+            self[k] = v
 
     def __iter__(self):
-        return iter(self._store)
+        return iter(self.key_priority)
 
-    def __len__(self):
-        return len(self._store)
+    def get(self, k, default=None):
+        try:
+            return self[k]
+        except KeyError:
+            return default
+
+    def keys(self):
+        """ Returns the keys in priority order (recently used first)"""
+        return self.key_priority[:]
+
+    def values(self):
+        return self.entries.values()
+
+    def items(self):
+        for k in self.keys():
+            # Intentionally don't reorganize the key priority if we're iterating
+            # that would be *slow* and unlikely to lead to what you want
+            yield (k, self.entries[k])
+
+    def get_reversed(self, value, compare_func=None):
+        """
+            Returns the keys for the specified value.
+
+            If compare_func is specified then it will be called for
+            each value in the cache dict with value until compare_func
+            returns True
+        """
+        results = []
+        for k, v in self.entries.items():
+            if compare_func and compare_func(v, value):
+                results.append(k)
+            elif v == value:
+                results.append(k)
+        return results
 
 
 class ContextCache(object):
@@ -55,8 +149,7 @@ class ContextCache(object):
 class Context(object):
 
     def __init__(self, stack):
-        self.cache = CopyDict()
-        self.reverse_cache = CopyDict()
+        self.cache = CacheDict()
         self._stack = stack
 
     def apply(self, other):
@@ -67,37 +160,26 @@ class Context(object):
             if k not in other.cache:
                 del self.cache[k]
 
-        self.reverse_cache.update(other.reverse_cache)
-
-        # We have to delete things that don't exist in the other
-        for k in self.reverse_cache.keys():
-            if k not in other.reverse_cache:
-                del self.reverse_cache[k]
-
     def cache_entity(self, identifiers, entity, situation):
         assert hasattr(identifiers, "__iter__")
 
         for identifier in identifiers:
-            self.cache[identifier] = copy.deepcopy(entity)
-
-        self.reverse_cache[entity.key()] = identifiers
+            self.cache[identifier] = entity
 
     def remove_entity(self, entity_or_key):
         if not isinstance(entity_or_key, datastore.Key):
             entity_or_key = entity_or_key.key()
 
-        for identifier in self.reverse_cache[entity_or_key]:
+        for identifier in self.cache.get_reversed(entity_or_key, compare_func=key_or_entity_compare):
             del self.cache[identifier]
-
-        del self.reverse_cache[entity_or_key]
 
     def get_entity(self, identifier):
         return self.cache.get(identifier)
 
     def get_entity_by_key(self, key):
         try:
-            identifier = self.reverse_cache[key][0]
-        except KeyError:
+            identifier = self.cache.get_reversed(key, compare_func=key_or_entity_compare)[0]
+        except IndexError:
             return None
         return self.get_entity(identifier)
 
@@ -141,7 +223,7 @@ class ContextStack(object):
         if apply_staged:
             while self.staged:
                 to_apply = self.staged.pop()
-                keys = to_apply.reverse_cache.keys()
+                keys = [x.key() for x in to_apply.cache.values()]
                 if keys:
                     # This assumes that all keys are in the same namespace, which is almost definitely
                     # going to be the case, but it feels a bit dirty

--- a/djangae/db/backends/appengine/context.py
+++ b/djangae/db/backends/appengine/context.py
@@ -113,9 +113,9 @@ class CacheDict(object):
         while self.total_value_size > self.max_size_in_bytes:
             next_priority_key = self.value_priority[-1]
 
-            # We intentionally copy the result with [:] as this will be manipulated
+            # We intentionally copy the result with list() as this will be manipulated
             # in del self[reference]
-            for reference in self.value_references[next_priority_key][:]:
+            for reference in list(self.value_references[next_priority_key]):
                 del self[reference]
 
     def _set(self, k, v):

--- a/djangae/db/backends/appengine/context.py
+++ b/djangae/db/backends/appengine/context.py
@@ -50,8 +50,10 @@ class CacheDict(object):
             next_key = self.key_priority[-1]
             del self[next_key]
 
-    def __setitem__(self, k, v):
-        v = copy.deepcopy(v)
+    def set(self, k, v, perform_copy=True):
+        if perform_copy:
+            v = copy.deepcopy(v)
+
         self.entries[k] = v
 
         try:
@@ -66,6 +68,14 @@ class CacheDict(object):
 
         self.total_value_size += sys.getsizeof(v)
         self._check_size_and_limit()
+
+    def set_multi(self, keys, value):
+        value = copy.deepcopy(value) # Copy once
+        for k in keys:
+            self.set(k, value, perform_copy=False)
+
+    def __setitem__(self, k, v):
+        self.set(k, v)
 
     def __getitem__(self, k):
         v = self.entries[k] # Find the entry
@@ -174,8 +184,7 @@ class Context(object):
     def cache_entity(self, identifiers, entity, situation):
         assert hasattr(identifiers, "__iter__")
 
-        for identifier in identifiers:
-            self.cache[identifier] = entity
+        self.cache.set_multi(identifiers, entity)
 
     def remove_entity(self, entity_or_key):
         if not isinstance(entity_or_key, datastore.Key):

--- a/djangae/db/backends/appengine/meta_queries.py
+++ b/djangae/db/backends/appengine/meta_queries.py
@@ -260,7 +260,7 @@ class QueryByKeys(object):
         self.query_count = len(self.queries)
         self.queries_by_key = { a: list(b) for a, b in groupby(self.queries, _get_key) }
 
-        self.max_allowable_queries = getattr(settings, "DJANGAE_MAX_QUERY_BRACHES", DEFAULT_MAX_ALLOWABLE_QUERIES)
+        self.max_allowable_queries = getattr(settings, "DJANGAE_MAX_QUERY_BRANCHES", DEFAULT_MAX_ALLOWABLE_QUERIES)
         self.can_multi_query = self.query_count < self.max_allowable_queries
 
         self.ordering = ordering

--- a/djangae/db/backends/appengine/meta_queries.py
+++ b/djangae/db/backends/appengine/meta_queries.py
@@ -237,6 +237,10 @@ def _convert_entity_based_on_query_options(entity, opts):
 
     return entity
 
+# The max number of entities in a resultset that will be cached
+# if a query returns more than this number then only the first ones
+# will be cached
+DEFAULT_MAX_ENTITY_COUNT = 8
 
 class QueryByKeys(object):
     """ Does the most efficient fetching possible for when we have the keys of the entities we want. """
@@ -279,6 +283,8 @@ class QueryByKeys(object):
         key_count = len(self.queries_by_key)
 
         is_projection = False
+
+        max_cache_count = getattr(settings, "DJANGAE_CACHE_MAX_ENTITY_COUNT", DEFAULT_MAX_ENTITY_COUNT)
 
         cache_results = True
         results = None
@@ -334,7 +340,7 @@ class QueryByKeys(object):
             if cache_results and sorted_results:
                 caching.add_entities_to_cache(
                     self.model,
-                    sorted_results,
+                    sorted_results[:max_cache_count],
                     caching.CachingSituation.DATASTORE_GET,
                     self.namespace,
                 )

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -124,7 +124,7 @@ The following settings are available to control the caching:
 
  - `DJANGAE_CACHE_ENABLED` (default `True`). Setting to False it all off, I really wouldn't suggest doing that!
  - `DJANGAE_CACHE_TIMEOUT_SECONDS` (default `60 * 60`). The length of time stuff should be kept in memcache.
- - `DJANGAE_CACHE_MAX_CONTEXT_SIZE` (default `1024 * 1024 * 8). This is (approximately) the max size of a local context cache instance. Each request and each nested transaction gets its own
+ - `DJANGAE_CACHE_MAX_CONTEXT_SIZE` (default `1024 * 1024 * 8`). This is (approximately) the max size of a local context cache instance. Each request and each nested transaction gets its own
     context cache instance so be aware that this total can rapidly add up, especially on F1 instances. If you have an F2 or F4 instance you might want to increase this value. If you hit the limit
     the least used entities will be evicted from the cache.
  - `DJANGAE_CACHE_MAX_ENTITY_COUNT` (default 8). This is the max number of entities returned by a pk__in query which will be cached in the context or memcache upon their return. If more

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -127,6 +127,8 @@ The following settings are available to control the caching:
  - `DJANGAE_CACHE_MAX_CONTEXT_SIZE` (default `1024 * 1024 * 8). This is (approximately) the max size of a local context cache instance. Each request and each nested transaction gets its own
     context cache instance so be aware that this total can rapidly add up, especially on F1 instances. If you have an F2 or F4 instance you might want to increase this value. If you hit the limit
     the least used entities will be evicted from the cache.
+ - `DJANGAE_CACHE_MAX_ENTITY_COUNT` (default 8). This is the max number of entities returned by a pk__in query which will be cached in the context or memcache upon their return. If more
+    results than this number are returned then the remainder won't be cached.
 
 ## Datastore Behaviours
 

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -124,6 +124,9 @@ The following settings are available to control the caching:
 
  - `DJANGAE_CACHE_ENABLED` (default `True`). Setting to False it all off, I really wouldn't suggest doing that!
  - `DJANGAE_CACHE_TIMEOUT_SECONDS` (default `60 * 60`). The length of time stuff should be kept in memcache.
+ - `DJANGAE_CACHE_MAX_CONTEXT_SIZE` (default `1024 * 1024 * 8). This is (approximately) the max size of a local context cache instance. Each request and each nested transaction gets its own
+    context cache instance so be aware that this total can rapidly add up, especially on F1 instances. If you have an F2 or F4 instance you might want to increase this value. If you hit the limit
+    the least used entities will be evicted from the cache.
 
 ## Datastore Behaviours
 


### PR DESCRIPTION
Fixes #886 
Fixes #831 (hopefully)

Summary of changes proposed in this Pull Request:
- Heavily optimise the context cache which was copying wastefully
- Add a memory limit to the context cache (configurable by `DJANGAE_CACHE_MAX_CONTEXT_SIZE`)
- Restrict the number of entities which are cached after a PK query (configurable with `DJANGAE_CACHE_MAX_ENTITY_COUNT`)
- Fix a typo in the `DJANGAE_MAX_QUERY_BRANCHES` setting lookup

This PR needs some tests for the `CacheDict` class (particularly around entity eviction), but I'm going on holiday so feel free to pick this up @adamalton  :)

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
