### PR TITLE
Moved import of Users API inside the view decorator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 
  - When running the local sandbox, if a port clash is detected then the next port will be used (this was broken before)
  - Accessing the Datastore from outside tests will no longer throw an error when using the test sandbox
- - The in-context cache is now reliably wiped when the testbed is initialized for each test
+ - The in-context cache is now reliably wiped when the testbed is initialized for each test.
+ - Fixed an ImportError when the SDK is not on sys.path.
+
 
 ## v0.9.9 (release date: 27th March 2017)
 

--- a/djangae/environment.py
+++ b/djangae/environment.py
@@ -4,7 +4,6 @@ import os
 
 # THIRD PARTY
 from django.http import HttpResponseForbidden
-from google.appengine.api import users
 
 # DJANGAE
 from djangae.utils import memoized
@@ -118,6 +117,9 @@ def task_or_admin_only(view_function):
     """ View decorator for restricting access to tasks (and crons) and admins of the application
         only.
     """
+    # Avoiding an ImportError when the SDK is not already on sys.path.
+    from google.appengine.api import users
+
     @wraps(view_function)
     def replacement(*args, **kwargs):
         if not any((

--- a/djangae/tests/test_environment.py
+++ b/djangae/tests/test_environment.py
@@ -48,6 +48,6 @@ class TaskOrAdminOnlyTestCase(TestCase):
         def view(request):
             return HttpResponse("Hello")
 
-        with sleuth.fake("djangae.environment.users.is_current_user_admin", True):
+        with sleuth.fake("google.appengine.api.users.is_current_user_admin", True):
             response = view(None)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This avoids an ImportError exception at startup. The sandbox pulls in
djangae.environment, and that was importing google.appengine.api before
the sandbox had a chance to put the SDK on the path (for those cases
where a project is using the location of dev_appserver.py to have the
SDK added to sys.path).

Fixes #899 .


PR checklist:
- [ ] Updated relevant documentation
- [* ] Updated CHANGELOG.md 
- [ ] Added tests for my change
