### PR TITLE
Fix issue where serialization of IterableFields resulted in invalid JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
  - Accessing the Datastore from outside tests will no longer throw an error when using the test sandbox
  - The in-context cache is now reliably wiped when the testbed is initialized for each test.
  - Fixed an ImportError when the SDK is not on sys.path.
-
+ - Fix issue where serialization of IterableFields resulted in invalid JSON
 
 ## v0.9.9 (release date: 27th March 2017)
 

--- a/djangae/fields/iterable.py
+++ b/djangae/fields/iterable.py
@@ -206,9 +206,14 @@ class IterableField(models.Field):
         # If possible, parse the string into the iterable
         if not hasattr(value, "__iter__"): # Allows list/set, not string
             if isinstance(value, basestring):
-                if (self._iterable_type == set and value.startswith("{") and value.endswith("}")) or \
-                   (self._iterable_type == list and value.startswith("[") and value.endswith("]")):
-                    value = [x.strip() for x in value[1:-1].split(",") ]
+                if value.startswith("[") and value.endswith("]"):
+                    value = value[1:-1].strip()
+
+                    value = [
+                        x.strip("'").strip("\"")
+                        for x in value.split(",")
+                        if len(value) > 2
+                    ]
                 else:
                     raise ValueError("Unable to parse string into iterable field")
             else:

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -17,7 +17,7 @@ import django
 
 # DJANGAE
 from djangae.core.validators import MinItemsValidator, MaxItemsValidator
-from djangae.fields.iterable import IsEmptyLookup, ContainsLookup, OverlapLookup
+from djangae.fields.iterable import IsEmptyLookup, ContainsLookup, OverlapLookup, _serialize_value
 
 
 class RelatedIteratorRel(ForeignObjectRel):
@@ -514,12 +514,9 @@ class RelatedIteratorField(ForeignObject):
         return ret
 
     def value_to_string(self, obj):
-        """
-        Custom method for serialization, as JSON doesn't support
-        serializing sets.
-        """
-        return str(list(self._get_val_from_obj(obj)))
-
+        return "[" + ",".join(
+            _serialize_value(o) for o in self._get_val_from_obj(obj)
+        ) + "]"
 
     def formfield(self, **kwargs):
         db = kwargs.pop('using', None)

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -514,7 +514,7 @@ class RelatedIteratorField(ForeignObject):
         return ret
 
     def value_to_string(self, obj):
-        return "[" + ",".join(
+        return u"[" + ",".join(
             _serialize_value(o) for o in self._get_val_from_obj(obj)
         ) + "]"
 
@@ -546,6 +546,34 @@ class RelatedIteratorField(ForeignObject):
 
         return super(RelatedIteratorField, self).get_lookup(lookup_name)
 
+    def to_python(self, value):
+        if value is None:
+            return list()
+
+        # Deal with deserialization from a string
+        if isinstance(value, basestring):
+            if not (value.startswith("[") and value.endswith("]")):
+                raise ValidationError("Invalid input for {} instance", type(self).__name__)
+
+            value = value[1:-1].strip()
+
+            if not value:
+                return list()
+
+            ids = [
+                self.rel.to._meta.pk.to_python(x.strip("'").strip("\""))
+                for x in value.split(",")
+                if len(value) > 2
+            ]
+            # Annoyingly Django special cases FK and M2M in the Python deserialization code,
+            # to assign to the attname, whereas all other fields (including this one) are required to
+            # populate field.name instead. So we have to query here... we have no choice :(
+            objs = self.rel.to._default_manager.db_manager('default').in_bulk(ids)
+
+            # retain order
+            return [objs.get(_id) for _id in ids if _id in objs]
+
+        return list(value)
 
 RelatedIteratorField.register_lookup(RelatedContainsLookup)
 RelatedIteratorField.register_lookup(RelatedOverlapLookup)
@@ -573,27 +601,7 @@ class RelatedSetField(RelatedIteratorField):
         return name, path, args, kwargs
 
     def to_python(self, value):
-        if value is None:
-            return set()
-
-        # Deal with deserialization from a string
-        if isinstance(value, basestring):
-            if not (value.startswith("[") and value.endswith("]")) and \
-               not (value.startswith("{") and value.endswith("}")):
-                raise ValidationError("Invalid input for RelatedSetField instance")
-
-            value = value[1:-1].strip()
-
-            if not value:
-                return set()
-
-            ids = [self.rel.to._meta.pk.to_python(x) for x in value.split(",")]
-            # Annoyingly Django special cases FK and M2M in the Python deserialization code,
-            # to assign to the attname, whereas all other fields (including this one) are required to
-            # populate field.name instead. So we have to query here... we have no choice :(
-            return set(self.rel.to._default_manager.db_manager('default').filter(pk__in=ids))
-
-        return set(value)
+        return set(super(RelatedSetField, self).to_python(value))
 
     def save_form_data(self, instance, data):
         setattr(instance, self.attname, set()) #Wipe out existing things
@@ -626,28 +634,6 @@ class RelatedListField(RelatedIteratorField):
             del kwargs[hardcoded_kwarg]
 
         return name, path, args, kwargs
-
-    def to_python(self, value):
-        if value is None:
-            return list()
-
-        # Deal with deserialization from a string
-        if isinstance(value, basestring):
-            if not (value.startswith("[") and value.endswith("]")):
-                raise ValidationError("Invalid input for RelatedListField instance")
-
-            value = value[1:-1].strip()
-
-            if not value:
-                return list()
-
-            ids = [self.rel.to._meta.pk.to_python(x) for x in value.split(",")]
-            # Annoyingly Django special cases FK and M2M in the Python deserialization code,
-            # to assign to the attname, whereas all other fields (including this one) are required to
-            # populate field.name instead. So we have to query here... we have no choice :(
-            return list(self.rel.to._default_manager.db_manager('default').filter(pk__in=ids))
-
-        return list(value)
 
     def save_form_data(self, instance, data):
         setattr(instance, self.attname, []) #Wipe out existing things

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -578,6 +578,20 @@ class IterableFieldTests(TestCase):
             instance.full_clean,
         )
 
+    def test_list_field_serializes_and_deserializes(self):
+        obj = IterableFieldModel(list_field=['foo', 'bar'])
+        data = serializers.serialize('json', [obj])
+
+        new_obj = serializers.deserialize('json', data).next().object
+        self.assertEqual(new_obj.list_field, ['foo', 'bar'])
+
+    def test_set_field_serializes_and_deserializes(self):
+        obj = IterableFieldModel(set_field=set(['foo', 'bar']))
+        data = serializers.serialize('json', [obj])
+
+        new_obj = serializers.deserialize('json', data).next().object
+        self.assertEqual(new_obj.set_field, set(['foo', 'bar']))
+
 
 class RelatedIterableFieldTests(TestCase):
     """ Combined tests for common RelatedListField and RelatedSetField tests. """
@@ -981,6 +995,21 @@ class InstanceListFieldTests(TestCase):
         main.related_list.add(other, other1, other2, other1, other2,)
         main.save()
         self.assertItemsEqual([other, other2, other2], main.related_list.filter(name="one"))
+
+    def test_related_list_field_serializes_and_deserializes(self):
+        obj = ISModel.objects.create()
+        foo = ISOther.objects.create(name='foo')
+        bar = ISOther.objects.create(name='bar')
+        obj.related_list.add(foo, bar)
+        obj.save()
+
+        data = serializers.serialize('json', [obj])
+
+        new_obj = serializers.deserialize('json', data).next().object
+        self.assertEqual(
+            list(new_obj.related_things.all()),
+            [foo, bar],
+        )
 
 
 class InstanceSetFieldTests(TestCase):

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -431,7 +431,7 @@ class IterableFieldTests(TestCase):
         instance = IterableFieldModel.objects.get(pk=instance.pk)
         self.assertEqual(set(["One"]), instance.set_field)
 
-        self.assertEqual({1, 2}, SetField(models.IntegerField).to_python("{1, 2}"))
+        self.assertEqual({1, 2}, SetField(models.IntegerField).to_python("[1, 2]"))
 
     def test_empty_list_queryable_with_is_null(self):
         instance = IterableFieldModel.objects.create()

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -1004,10 +1004,9 @@ class InstanceListFieldTests(TestCase):
         obj.save()
 
         data = serializers.serialize('json', [obj])
-
         new_obj = serializers.deserialize('json', data).next().object
         self.assertEqual(
-            list(new_obj.related_things.all()),
+            list(new_obj.related_list.all()),
             [foo, bar],
         )
 


### PR DESCRIPTION
Fixes #881.

This may get superseded if #555 gets completed but it seemed worth fixing the short term problem.

Summary of changes proposed in this Pull Request:
- Fix issue where serialization of IterableFields resulted in invalid JSON

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
