### PR TITLE
Json set field serialization fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  - When running the local sandbox, if a port clash is detected then the next port will be used (this was broken before)
  - Accessing the Datastore from outside tests will no longer throw an error when using the test sandbox
  - The in-context cache is now reliably wiped when the testbed is initialized for each test
+ - The iterable set and list fields and their related fk variations didn't properly serialize / deserialize.
 
 ## v0.9.9 (release date: 27th March 2017)
 

--- a/djangae/fields/iterable.py
+++ b/djangae/fields/iterable.py
@@ -201,9 +201,15 @@ class IterableField(models.Field):
         # If possible, parse the string into the iterable
         if not hasattr(value, "__iter__"): # Allows list/set, not string
             if isinstance(value, basestring):
-                if (self._iterable_type == set and value.startswith("{") and value.endswith("}")) or \
-                   (self._iterable_type == list and value.startswith("[") and value.endswith("]")):
-                    value = [x.strip() for x in value[1:-1].split(",") ]
+                if self._iterable_type in (list, set) and (
+                    (value.startswith("[") and value.endswith("]")) or
+                    (value.startswith("{") and value.endswith("}"))):
+                    value = value[1:-1]
+
+                    if not value:
+                        value = []  # a split on an empty string returns ['']
+                    else:
+                        value = [x.strip(" '\"") for x in value.split(",")]
                 else:
                     raise ValueError("Unable to parse string into iterable field")
             else:

--- a/djangae/patches/json.py
+++ b/djangae/patches/json.py
@@ -4,8 +4,8 @@ def additional_type_handler(func):
     @wraps(func)
     def _wrapper(self, o):
         if isinstance(o, set):
-            # Return a string representing a set
-            return "{" + ",".join([str(x) for x in o]) + "}"
+            # Treat sets as lists.
+            return list(o)
         else:
             return func(self, o)
 

--- a/djangae/tests/test_serializers.py
+++ b/djangae/tests/test_serializers.py
@@ -1,0 +1,17 @@
+import json
+
+from djangae.test import TestCase
+
+
+class JSONEncoderTestCase(TestCase):
+    def test_encodes_sets_as_lists(self):
+        # Django's built-in encoder does lists, but not sets. Djangae patches
+        # it to make lists from sets, which is needed for SetField.
+        from django.core.serializers.json import DjangoJSONEncoder
+
+        encoder = DjangoJSONEncoder()
+        obj = {'test': set(['foo', 'bar', 'baz'])}
+        data = encoder.encode(obj)
+        result = json.loads(data)
+
+        self.assertIsInstance(result['test'], list)


### PR DESCRIPTION
Builds upon David's 555 branch - fixing up some code and changing the tests which were failing in his branch. Fixes #881 and #555.

Summary of changes proposed in this Pull Request:
- Ensure set's are encoded as lists
- Fixup to_string on the iterable fields to explicitly convert ints instead of relying on `str(list(...))`to avoid the trailing L's 
- Retain list order when deserializing list fields
- Change serialization tests to perform an end to end serialize+deserialize.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
