### PR TITLE
Updated docs and comments for DJANGAE_CREATE_UNKNOWN_USER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
  - Accessing the Datastore from outside tests will no longer throw an error when using the test sandbox
  - The in-context cache is now reliably wiped when the testbed is initialized for each test.
  - Fixed an ImportError when the SDK is not on sys.path.
+ - Updated the documenation to say that DJANGAE_CREATE_UNKNOWN_USER defaults to True.
 
 
 ## v0.9.9 (release date: 27th March 2017)

--- a/djangae/contrib/gauth/settings.py
+++ b/djangae/contrib/gauth/settings.py
@@ -7,5 +7,5 @@ AUTH_USER_MODEL = 'gauth_datastore.GaeDatastoreUser'
 LOGIN_URL = 'djangae_login_redirect'
 
 # Set this to True to allow unknown Google users to sign in. Matching is done
-# by email. Defaults to False.
-# DJANGAE_CREATE_UNKNOWN_USER = False
+# by email.
+# DJANGAE_CREATE_UNKNOWN_USER = True

--- a/docs/gauth.md
+++ b/docs/gauth.md
@@ -56,9 +56,9 @@ If you want to write your own permissions system, but you still want to take adv
 
 ## Authentication for unknown users
 
-By default Djangae will deny access for unknown users (unless the user is an administrator for the App Engine application).
+By default Djangae will grant access for unknown users who are signed in with a Google account.
 
-Add `DJANGAE_CREATE_UNKNOWN_USER=True` to your settings and Djangae will always grant access (for authenticated Google Accounts users), creating a Django user if one does not exist.
+Add `DJANGAE_CREATE_UNKNOWN_USER=True` (the default) to your settings and Djangae will always grant access (for authenticated Google Accounts users), creating a Django user if one does not exist. If `DJANGAE_CREATE_UNKNOWN_USER=False` then Djangae will deny access for unknown users (unless the user is an administrator for the App Engine application).
 
 If there is a Django user with a matching email address and username set to `None` then Djangae will update the Django user, setting the username to the Google user ID. If there is a user with a matching email address and username set to another user ID then Djangae will set the existing user's email address to `None` and create a new Django user.
 


### PR DESCRIPTION
[The docs say DJANGAE_CREATE_UNKNOWN_USER defaults to False][1]. This is not true.

[1]: https://djangae.readthedocs.io/en/latest/gauth/#authentication-for-unknown-users

Summary of changes proposed in this Pull Request:
- Updated docs for DJANGAE_CREATE_UNKNOWN_USER.
- Updated comments in Djangae's settings module for DJANGAE_CREATE_UNKNOWN_USER.


PR checklist:
- [*] Updated relevant documentation
- [*] Updated CHANGELOG.md 
- [ ] Added tests for my change
