### PR TITLE
Altering the default file pattern of our DiscoverTestRunner

### DIFF
--- a/djangae/test_runner.py
+++ b/djangae/test_runner.py
@@ -149,6 +149,10 @@ class SkipUnsupportedTestResult(TextTestResult):
 
 
 class DjangaeTestSuiteRunner(DiscoverRunner):
+    def __init__(self, *a, **kw):
+        kw['pattern'] = '*tests.py'
+        super(DjangaeTestSuiteRunner, self).__init__(*a, **kw)
+
     def _discover_additional_tests(self):
         """
             Django's DiscoverRunner only detects apps that are below


### PR DESCRIPTION
Some pr's are adding tests modules with `tests/something_tests` files. and this change is the easiest way we can include them while also matching our existing tests (which are mostly `tests.py` files)
