### PR TITLE
Fix os.environ task headers in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - The in-context cache is now reliably wiped when the testbed is initialized for each test.
  - Fixed an ImportError when the SDK is not on sys.path.
  - Updated the documenation to say that DJANGAE_CREATE_UNKNOWN_USER defaults to True.
+ - os.environ is now correctly updated with task headers when using process_task_queues in tests
 
 
 ## v0.9.9 (release date: 27th March 2017)

--- a/djangae/tests/test_environment.py
+++ b/djangae/tests/test_environment.py
@@ -1,4 +1,5 @@
-
+import os
+from google.appengine.ext.deferred import defer
 
 from djangae.environment import task_or_admin_only
 from djangae.test import TestCase
@@ -51,3 +52,24 @@ class TaskOrAdminOnlyTestCase(TestCase):
         with sleuth.fake("google.appengine.api.users.is_current_user_admin", True):
             response = view(None)
         self.assertEqual(response.status_code, 200)
+
+
+def deferred_func():
+    assert("HTTP_X_APPENGINE_TASKNAME" in os.environ)
+    assert("HTTP_X_APPENGINE_QUEUENAME" in os.environ)
+    assert("HTTP_X_APPENGINE_TASKEXECUTIONCOUNT" in os.environ)
+
+    # Deferred tasks aren't cron tasks, so shouldn't have this header
+    assert("HTTP_X_APPENGINE_CRON" not in os.environ)
+
+
+class TaskHeaderTest(TestCase):
+
+    def test_task_headers_are_available_in_tests(self):
+        defer(deferred_func)
+        self.process_task_queues()
+
+        # Check nothing lingers
+        self.assertFalse("HTTP_X_APPENGINE_TASKNAME" in os.environ)
+        self.assertFalse("HTTP_X_APPENGINE_QUEUENAME" in os.environ)
+        self.assertFalse("HTTP_X_APPENGINE_TASKEXECUTIONCOUNT" in os.environ)


### PR DESCRIPTION
Fixes #915 

Summary of changes proposed in this Pull Request:
- Add task headers to os.environ when processing tasks in tests

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
