### PR TITLE
Ensure that the ordering of values in a RelatedListField is respected…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - The in-context cache is now reliably wiped when the testbed is initialized for each test.
  - Fixed an ImportError when the SDK is not on sys.path.
  - Updated the documenation to say that DJANGAE_CREATE_UNKNOWN_USER defaults to True.
+ - Ensure that the order of values in a RelatedListField are respected when updated via a form.
 
 
 ## v0.9.9 (release date: 27th March 2017)

--- a/djangae/forms/fields.py
+++ b/djangae/forms/fields.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import base64
 
@@ -94,6 +95,34 @@ class JSONFormField(forms.CharField):
             except ValueError:
                 raise forms.ValidationError("Could not parse value as JSON")
         return value
+
+
+class OrderedModelMultipleChoiceField(forms.ModelMultipleChoiceField):
+
+    def clean(self, value):
+        """
+        Maintain the order of the values passed in. Without this special casing,
+        _check_values() runs a pk__in query which under the hood gets
+        ordered by Djangae via its default model ordering (which has a PK
+        fallback if no ordering is explicit), and thus the original order of the
+        values passed in is lost.
+        """
+        if self.required and not value:
+            raise ValidationError(self.error_messages['required'], code='required')
+        elif not self.required and not value:
+            return self.queryset.none()
+        if not isinstance(value, (list, tuple)):
+            raise ValidationError(self.error_messages['list'], code='list')
+
+        # now make a copy of the value - we still run it via the clean
+        # and validators so ValidationErrors can be raised - but we don't
+        # return the queryset like the vanilla OrderedModelMultipleChoiceField
+        # as the ordering will be lost by this point
+        value_copy = copy.deepcopy(value)
+        self._check_values(value_copy)
+        self.run_validators(value_copy)
+
+        return [self.queryset.model._meta.pk.to_python(v) for v in value]
 
 
 #Basic obfuscation, just so that the db_table doesn't

--- a/djangae/forms/fields.py
+++ b/djangae/forms/fields.py
@@ -108,11 +108,11 @@ class OrderedModelMultipleChoiceField(forms.ModelMultipleChoiceField):
         values passed in is lost.
         """
         if self.required and not value:
-            raise ValidationError(self.error_messages['required'], code='required')
+            raise forms.ValidationError(self.error_messages['required'], code='required')
         elif not self.required and not value:
             return self.queryset.none()
         if not isinstance(value, (list, tuple)):
-            raise ValidationError(self.error_messages['list'], code='list')
+            raise forms.ValidationError(self.error_messages['list'], code='list')
 
         # now make a copy of the value - we still run it via the clean
         # and validators so ValidationErrors can be raised - but we don't

--- a/djangae/tests/test_form_fields.py
+++ b/djangae/tests/test_form_fields.py
@@ -46,6 +46,17 @@ class RelatedListFieldForm(forms.ModelForm):
         fields = ['related_list_field']
 
 
+class RequiredRelatedListFieldForm(forms.ModelForm):
+
+    class Meta:
+        model = RelatedListFieldModel
+        fields = ['related_list_field']
+
+    def __init__(self, *args, **kwargs):
+        super(RequiredRelatedListFieldForm, self).__init__(*args, **kwargs)
+        self.fields['related_list_field'].required = True
+
+
 class JSONFieldFormsTest(TestCase):
 
     def test_empty_string_submission(self):
@@ -120,3 +131,12 @@ class OrderedModelMultipleChoiceField(TestCase):
             [instance_two.pk, instance_three.pk, instance_one.pk]
         )
 
+    def test_validation_still_performed(self):
+        """
+        Assert the normal validation of the field value occurs despite
+        adding extra logic to the clean method.
+        """
+        data = dict(related_list_field=[])
+        form = RelatedListFieldForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('related_list_field', form.errors)


### PR DESCRIPTION
… via form update

Fixes #[include a number of issue this PR is fixing].

Summary of changes proposed in this Pull Request:
- Previously if you were to try and set some values in the `RelatedSetField` via a form save, the ordering would not always be retained (if it were, this was by chance due to the underlying internals).

PR checklist:
- [X] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [X] Added tests for my change
