### PR TITLE
Control task handling behaviour in process_task_queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - The in-context cache is now reliably wiped when the testbed is initialized for each test.
  - Fixed an ImportError when the SDK is not on sys.path.
  - Updated the documenation to say that DJANGAE_CREATE_UNKNOWN_USER defaults to True.
+ - os.environ is now correctly updated with task headers when using process_task_queues in tests
 
 
 ## v0.9.9 (release date: 27th March 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
  - Fixed an ImportError when the SDK is not on sys.path.
  - Updated the documenation to say that DJANGAE_CREATE_UNKNOWN_USER defaults to True.
  - os.environ is now correctly updated with task headers when using process_task_queues in tests
+ - process_task_queues can now be controlled by passing the `failure_behaviour` argument as appropriate
+ - process_task_queues will no longer propagate exceptions from tasks, instead use the `failure_behaviour` to control what happens
+   if an exception occurs in a task
 
 
 ## v0.9.9 (release date: 27th March 2017)

--- a/djangae/tests/test_environment.py
+++ b/djangae/tests/test_environment.py
@@ -1,4 +1,5 @@
-
+import os
+from google.appengine.ext.deferred import defer
 
 from djangae.environment import task_or_admin_only
 from djangae.test import TestCase
@@ -51,3 +52,24 @@ class TaskOrAdminOnlyTestCase(TestCase):
         with sleuth.fake("google.appengine.api.users.is_current_user_admin", True):
             response = view(None)
         self.assertEqual(response.status_code, 200)
+
+
+def deferred_func():
+    assert("HTTP_X_APPENGINE_TASKNAME" in os.environ)
+    assert("HTTP_X_APPENGINE_QUEUENAME" in os.environ)
+    assert("HTTP_X_APPENGINE_TASKEXECUTIONCOUNT" in os.environ)
+
+    # Deferred tasks aren't cron tasks, so shouldn't have this header
+    assert("HTTP_X_APPENGINE_CRON" not in os.environ)
+
+
+class TaskHeaderTest(TestCase):
+
+    def test_task_headers_are_available_in_tests(self):
+        defer(deferred_func)
+        self.process_task_queues()
+
+        # Check nothing lingers
+        self.assertFalse("HTTP_X_APPENGINE_TASKNAME" in os.environ)
+        self.assertFalse("HTTP_X_APPENGINE_QUEUENAME" in os.environ)
+        self.assertFalse("HTTP_X_APPENGINE_TASKEXECUTIONCOUNT" in os.environ)

--- a/djangae/tests/test_test.py
+++ b/djangae/tests/test_test.py
@@ -1,6 +1,6 @@
 from google.appengine.ext import deferred
 
-from djangae.test import TestCase, _get_queued_tasks
+from djangae.test import TestCase, _get_queued_tasks, TaskFailedBehaviour, TaskFailedError
 
 
 def my_task():
@@ -9,6 +9,14 @@ def my_task():
     """
     pass
 
+
+def throw_once():
+    throw_once.counter += 1
+    if throw_once.counter == 1:
+        raise Exception("First call")
+
+
+throw_once.counter = 0
 
 class TaskQueueTests(TestCase):
 
@@ -25,3 +33,23 @@ class TaskQueueTests(TestCase):
 
         tasks = _get_queued_tasks(self.taskqueue_stub)
         self.assertEqual(0, len(tasks))
+
+    def test_task_queue_processing_control(self):
+
+        deferred.defer(throw_once)
+
+        self.process_task_queues(failure_behaviour=TaskFailedBehaviour.RETRY_TASK)
+
+        # Should've retried
+        self.assertEqual(throw_once.counter, 2)
+
+        throw_once.counter = 0
+
+        deferred.defer(throw_once)
+
+        self.assertRaises(
+            TaskFailedError,
+            self.process_task_queues,
+            failure_behaviour=TaskFailedBehaviour.RAISE_ERROR
+        )
+        self.assertEqual(throw_once.counter, 1)


### PR DESCRIPTION
Fixes #914 

**NOTE: Contains #916**

Summary of changes proposed in this Pull Request:
- Allow controlling the error handling behaviour of process_task_queues
- Handle exceptions thrown by tasks as if they were thrown from inside Django (return an error response rather than propagating)

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
