### PR TITLE
Don't initialize the images stub if PIL isn't available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
  - Fixed an ImportError when the SDK is not on sys.path.
  - Fix issue where serialization of IterableFields resulted in invalid JSON
  - Updated the documenation to say that DJANGAE_CREATE_UNKNOWN_USER defaults to True.
+ - Fixed a hard requirement on PIL/Pillow when running the tests. Now, the images stub will not be available if Pillow isn't installed.
 
 ## v0.9.9 (release date: 27th March 2017)
 

--- a/djangae/test_runner.py
+++ b/djangae/test_runner.py
@@ -4,6 +4,8 @@
 
 import unittest
 import os
+import logging
+
 from unittest import TextTestResult
 
 from django.test.runner import DiscoverRunner
@@ -90,8 +92,17 @@ DJANGO_TESTS_TO_SKIP = DJANGO_TESTS_WHICH_REQUIRE_ZERO_PKS.union(
     DJANGO_TESTS_WHICH_EXPECT_SEQUENTIAL_IDS
 )
 
+logger = logging.getLogger(__file__)
+
 def init_testbed():
-    IGNORED_STUBS = []
+    try:
+        import PIL
+        IGNORED_STUBS = []
+    except ImportError:
+        logger.warning("Unable to initialize the images stub as Pillow is unavailable")
+        IGNORED_STUBS = [
+            "init_images_stub"
+        ]
 
     # We allow users to disable scattered IDs in tests. This primarily for running Django tests that
     # assume implicit ordering (yeah, annoying)


### PR DESCRIPTION
Fixes #906 

Summary of changes proposed in this Pull Request:
- Don't initialize the images stub in tests if PIL isn't available

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
