### PR TITLE
Allow passing filters to mapreduce

### DIFF
--- a/djangae/contrib/processing/mapreduce/helpers.py
+++ b/djangae/contrib/processing/mapreduce/helpers.py
@@ -248,7 +248,8 @@ def map_entities(kind_name, namespace, processor_func, *args, **kwargs):
     params = {
         'input_reader': {
             RawDatastoreInputReader.ENTITY_KIND_PARAM: kind_name,
-            RawDatastoreInputReader.NAMESPACE_PARAM: namespace
+            RawDatastoreInputReader.NAMESPACE_PARAM: namespace,
+            RawDatastoreInputReader.FILTERS_PARAM: options.pop("_filters", [])
         },
         'output_writer': options.pop("_output_writer_kwargs", {}) or {}
     }

--- a/djangae/contrib/processing/mapreduce/helpers.py
+++ b/djangae/contrib/processing/mapreduce/helpers.py
@@ -243,7 +243,7 @@ def map_entities(kind_name, namespace, processor_func, *args, **kwargs):
 
         Returns the pipeline
     """
-    options = extract_options(kwargs, additional={"finalize_func"})
+    options = extract_options(kwargs, additional={"finalize_func", "_filters"})
 
     params = {
         'input_reader': {

--- a/djangae/contrib/processing/mapreduce/helpers.py
+++ b/djangae/contrib/processing/mapreduce/helpers.py
@@ -238,8 +238,8 @@ def map_entities(kind_name, namespace, processor_func, *args, **kwargs):
         on each one.
         Calls finalize_func when the iteration completes.
 
-        output_writer is optional, but should be a mapreduce
-        OutputWriter subclass
+        output_writer is optional, but should be a mapreduce OutputWriter subclass
+        _filters is an optional kwarg which will be passed directly to the input reader
 
         Returns the pipeline
     """
@@ -313,6 +313,7 @@ def map_reduce_entities(kind_name, namespace, map_func, reduce_func, output_writ
         Does a complete map-shuffle-reduce over the entities
 
         output_writer should be a mapreduce OutputWriter subclass
+        _filters is an optional kwarg which will be passed directly to the input reader
 
         Returns the pipeline
     """

--- a/djangae/contrib/processing/mapreduce/helpers.py
+++ b/djangae/contrib/processing/mapreduce/helpers.py
@@ -308,7 +308,7 @@ def map_reduce_queryset(queryset, map_func, reduce_func, output_writer, *args, *
     return pipeline
 
 
-def map_reduce_entities(kind_name, map_func, reduce_func, output_writer, *args, **kwargs):
+def map_reduce_entities(kind_name, namespace, map_func, reduce_func, output_writer, *args, **kwargs):
     """
         Does a complete map-shuffle-reduce over the entities
 
@@ -320,7 +320,7 @@ def map_reduce_entities(kind_name, map_func, reduce_func, output_writer, *args, 
     reduce_func = qualname(reduce_func)
     output_writer = qualname(output_writer)
 
-    options = extract_options(kwargs)
+    options = extract_options(kwargs, additional={"_filters"})
 
     _shards = options.pop("_shards", None)
     _job_name = options.pop("_job_name", "Map reduce task over {}".format(kind_name))
@@ -334,7 +334,9 @@ def map_reduce_entities(kind_name, map_func, reduce_func, output_writer, *args, 
         output_writer,
         mapper_params={
             'input_reader': {
-                RawDatastoreInputReader.ENTITY_KIND_PARAM: kind_name
+                RawDatastoreInputReader.ENTITY_KIND_PARAM: kind_name,
+                RawDatastoreInputReader.NAMESPACE_PARAM: namespace,
+                RawDatastoreInputReader.FILTERS_PARAM: options.pop("_filters", [])
             },
         },
         reducer_params={

--- a/djangae/contrib/processing/mapreduce/helpers.py
+++ b/djangae/contrib/processing/mapreduce/helpers.py
@@ -1,5 +1,6 @@
 import cPickle
 import pipeline
+
 from importlib import import_module
 from mapreduce import context
 from mapreduce.mapper_pipeline import MapperPipeline
@@ -7,6 +8,8 @@ from mapreduce.mapreduce_pipeline import MapreducePipeline
 from mapreduce import pipeline_base
 from mapreduce.model import MapreduceState
 from mapreduce.input_readers import RawDatastoreInputReader, GoogleCloudStorageInputReader
+
+from django.utils import six
 from djangae.contrib.processing.mapreduce.input_readers import DjangoInputReader
 
 from utils import qualname
@@ -22,7 +25,7 @@ class DynamicPipeline(pipeline_base.PipelineBase):
     def __init__(self, pipelines, *args, **kwargs):
         # This gets reinstantiated somewhere with the already-pickled pipelines argument
         # so we prevent double pickling by checking it's not a string
-        if not isinstance(pipelines, basestring):
+        if not isinstance(pipelines, six.string_types):
             pipelines = str(cPickle.dumps(pipelines))
         super(DynamicPipeline, self).__init__(pipelines, *args, **kwargs)
 

--- a/djangae/contrib/processing/mapreduce/tests/helper_tests.py
+++ b/djangae/contrib/processing/mapreduce/tests/helper_tests.py
@@ -69,9 +69,27 @@ class MapReduceEntityTests(TestCase):
                 text="abcc"
             )
 
+    def test_filters(self):
+        pipeline = map_reduce_entities(
+            TestModel._meta.db_table,
+            connection.settings_dict["NAMESPACE"],
+            yield_letters,
+            reduce_count,
+            output_writers.GoogleCloudStorageKeyValueOutputWriter,
+            _output_writer_kwargs={
+                'bucket_name': 'test-bucket'
+            },
+            _filters=[("text", "=", "abcc")]
+        )
+        self.process_task_queues()
+        # Refetch the pipeline record
+        pipeline = get_pipeline_by_id(pipeline.pipeline_id)
+        self.assertTrue(pipeline.has_finalized)
+
     def test_mapreduce_over_entities(self):
         pipeline = map_reduce_entities(
             TestModel._meta.db_table,
+            connection.settings_dict["NAMESPACE"],
             yield_letters,
             reduce_count,
             output_writers.GoogleCloudStorageKeyValueOutputWriter,

--- a/djangae/contrib/processing/mapreduce/tests/helper_tests.py
+++ b/djangae/contrib/processing/mapreduce/tests/helper_tests.py
@@ -24,7 +24,7 @@ class TestModel(models.Model):
         app_label = "mapreduce"
 
     is_true = models.BooleanField(default=False)
-    text = models.CharField(null=True)
+    text = models.CharField(null=True, max_length=50)
 
 
 class Counter(models.Model):
@@ -212,7 +212,7 @@ class MapEntitiesTests(TestCase):
             count_entity,
             finalize_func=delete,
             counter_id=counter.pk,
-            _filters=[("text", "<", "3")]
+            _filters=[("text", "=", "3")]
         )
 
         self.process_task_queues()
@@ -220,7 +220,7 @@ class MapEntitiesTests(TestCase):
         self.assertTrue(pipeline.has_finalized)
         counter.refresh_from_db()
 
-        self.assertEqual(3, counter.count)
+        self.assertEqual(1, counter.count)
         self.assertFalse(TestModel.objects.count())
 
     def test_mapping_over_entities(self):

--- a/djangae/contrib/processing/mapreduce/tests/helpers.py
+++ b/djangae/contrib/processing/mapreduce/tests/helpers.py
@@ -63,7 +63,7 @@ def delete(*args, **kwargs):
 class MapReduceEntityTests(TestCase):
 
     def setUp(self):
-        for i in xrange(5):
+        for i in range(5):
             TestModel.objects.create(
                 id=i+1,
                 text="abcc"
@@ -88,7 +88,7 @@ class MapReduceEntityTests(TestCase):
 class MapReduceQuerysetTests(TestCase):
 
     def setUp(self):
-        for i in xrange(5):
+        for i in range(5):
             TestModel.objects.create(
                 id=i+1,
                 text="abcc"
@@ -111,7 +111,7 @@ class MapReduceQuerysetTests(TestCase):
 
 class MapQuerysetTests(TestCase):
     def setUp(self):
-        for i in xrange(5):
+        for i in range(5):
             TestModel.objects.create(id=i+1)
 
     def test_filtering(self):
@@ -200,7 +200,7 @@ def count_entity(entity, counter_id):
 
 class MapEntitiesTests(TestCase):
     def setUp(self):
-        for i in xrange(5):
+        for i in range(5):
             TestModel.objects.create(id=i+1)
 
     def test_mapping_over_entities(self):

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,19 +1,21 @@
 # Pipelines and MapReduce
 
-Djangae now contains functionality to run Google's native Pipelines and MapReduce
+Djangae contains functionality to run Google's native Pipelines and MapReduce, as well as running MapReduce processes over Django querysets on the Datastore.
 
 ## MapReduce
 
 1. Add the MapReduce library to your project, e.g. `$ pip install GoogleAppEngineMapReduce` or from
 [https://github.com/GoogleCloudPlatform/appengine-mapreduce](https://github.com/GoogleCloudPlatform/appengine-mapreduce).
-2. Add `djangae.contrib.processing.mapreduce` to INSTALLED_APPS
+2. Add `"djangae.contrib.processing.mapreduce"` to INSTALLED_APPS
 3. Add the following rule to the top of your url patterns:
 
 ```
     url(r'^_ah/mapreduce/', include(djangae.contrib.processing.mapreduce.urls)),
 ```
 
-Now you can create native MapReduce tasks from inside your Django application, the requests will be handled and forwarded to correct handlers
+And ensure that the `/_ah/mapreduce` path is routed through to the normal WSGI handler (the same as your other Django views) in app.yaml, protected with `login: admin`.
+
+Now you can create native MapReduce tasks from inside your Django application, the requests will be handled and forwarded to correct handlers.
 
 Documentation for the MapReduce api functionality
 [https://github.com/GoogleCloudPlatform/appengine-mapreduce/wiki](https://github.com/GoogleCloudPlatform/appengine-mapreduce/wiki)
@@ -29,10 +31,12 @@ it uses a basic clustering algorithm similar to the `DatastoreInputReader` bundl
 map and mapreduce jobs. These functions are:
 
  - `map_queryset(qs, func, finalize_func=None)`: Call `func` on all instances in a queryset
- - `map_entities(kind, namespace, func, finalize_func=None)`: Call `func` entities in a kind + namespace
+ - `map_entities(kind, namespace, func, finalize_func=None, _filters=None)`: Call `func` entities in a kind + namespace
+    * `_filters` is a list of tuples in the format, `(field, operator, value)` e.g. `_filters=[("name", "=", "Lucy")]`.
  - `map_files(bucket, func, finalize_func=None, filenames=None)`: Call `func` on all files in a CloudStorage bucket
  - `map_reduce_queryset(queryset, map_func, reduce_func, output_writer)`
- - `map_reduce_entities(kind, namespace, map_func, reduce_func, output_writer)`
+ - `map_reduce_entities(kind, namespace, map_func, reduce_func, output_writer, _filters=None)`.
+    * `_filters` is a list of tuples in the format, `(field, operator, value)` e.g. `_filters=[("name", "=", "Lucy")]`.
 
 Each of these functions allows the following optional kwargs:
 


### PR DESCRIPTION
Fixes #920 

Summary of changes proposed in this Pull Request:
- Allows _filters as an optional argument to map_entities which is passed down to mapreduce
- Adds namespace to `map_reduce_entities` which was documented, but didn't exist!

I haven't updated the changelog as this entire module is new.

PR checklist:
- [x] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [x] Added tests for my change
