### PR TITLE
Djangae urls and mapreduce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
  - Fix issue where serialization of IterableFields resulted in invalid JSON
  - Updated the documenation to say that DJANGAE_CREATE_UNKNOWN_USER defaults to True.
  - Ensure that the order of values in a RelatedListField are respected when updated via a form.
+ - Make mapreduce optional again (#926).
 
 ## v0.9.9 (release date: 27th March 2017)
 

--- a/djangae/tests/test_urls.py
+++ b/djangae/tests/test_urls.py
@@ -1,0 +1,54 @@
+import importlib
+import sys
+
+import mock
+from django.test import SimpleTestCase
+
+
+class ImportingUrlsTestCase(SimpleTestCase):
+    def setUp(self):
+        super(ImportingUrlsTestCase, self).setUp()
+        self.patcher = mock.patch.dict('sys.modules', {})
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        super(ImportingUrlsTestCase, self).tearDown()
+
+    def test_importing_djangae_urls_should_not_import_mapreduce(self):
+        # If you include 'djangae.urls', that should NOT trigger an import of
+        # the mapreduce and pipeline when 'djangae.contrib.processing.mapreduce'
+        # is not in INSTALLED_APPS.
+        #
+        # https://github.com/potatolondon/djangae/issues/926
+
+        # There are lots of individual modules that are imported as part of the
+        # mapreduce and pipeline packages, but we'll use the main ones for this.
+        module_names = [
+            'pipeline',
+            'mapreduce',
+        ]
+        for name in module_names:
+            if name in sys.modules:
+                del sys.modules[name]
+
+        djangae_urls_name = 'djangae.urls'
+
+        if djangae_urls_name in sys.modules:
+            del sys.modules[djangae_urls_name]
+
+        # OK. The main mapreduce modules should not be present now.
+        for name in module_names:
+            self.assertNotIn(name, sys.modules)
+
+        self.assertNotIn(djangae_urls_name, sys.modules)
+
+        # Now see if this imports mapreduce libs as a side-effect.
+        with self.settings(INSTALLED_APPS=[]):
+            importlib.import_module(djangae_urls_name)
+
+        # And finally check that urls was imported, but not the mapreduce libs.
+        for name in module_names:
+            self.assertNotIn(name, sys.modules)
+
+        self.assertIn(djangae_urls_name, sys.modules)

--- a/djangae/urls.py
+++ b/djangae/urls.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.conf.urls import url, include
 
-import djangae.contrib.processing.mapreduce.urls
 from . import views
 
 
@@ -16,6 +15,8 @@ urlpatterns = [
 
 # Set up the mapreduce URLs if the mapreduce processing module is installed
 if 'djangae.contrib.processing.mapreduce' in settings.INSTALLED_APPS:
+    import djangae.contrib.processing.mapreduce.urls
+
     urlpatterns.append(
        url(r'^mapreduce/', include(djangae.contrib.processing.mapreduce.urls)),
     )

--- a/testapp/requirements.txt
+++ b/testapp/requirements.txt
@@ -8,3 +8,4 @@ beautifulsoup4
 pytz
 django-session-csrf
 pyuca
+mock


### PR DESCRIPTION
Fixes #926 

This change allows projects to import djangae.urls without the side-effect of importing the mapreduce and pipeline packages.

The test for the change is a separate commit, cos I figured it would be controversial. It adds mock as a test dependency because the test messes with sys.modules, and I couldn't see a way to use sleuth to save/restore the state of sys.modules. Without that, a bunch of unrelated tests started failing.