### PR TITLE
Fix key length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
    if an exception occurs in a task
  - Ensure that the order of values in a RelatedListField are respected when updated via a form.
  - Make mapreduce optional again (#926).
+ - We no longer cut truncate keys automatically and the max string key length is now the datastore supported 1500 bytes
 
 ## v0.9.9 (release date: 27th March 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
    if an exception occurs in a task
  - Ensure that the order of values in a RelatedListField are respected when updated via a form.
  - Make mapreduce optional again (#926).
- - We no longer truncate string keys automatically and the max string key length is now the datastore supported 1500 bytes
+ - We no longer truncate string keys automatically and the max string key length is now the Datastore supported 1500 bytes
 
 ## v0.9.9 (release date: 27th March 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
    if an exception occurs in a task
  - Ensure that the order of values in a RelatedListField are respected when updated via a form.
  - Make mapreduce optional again (#926).
- - We no longer cut truncate keys automatically and the max string key length is now the datastore supported 1500 bytes
+ - We no longer truncate string keys automatically and the max string key length is now the datastore supported 1500 bytes
 
 ## v0.9.9 (release date: 27th March 2017)
 

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -10,7 +10,7 @@ from django.apps import apps
 from django.conf import settings
 from django.db.backends.utils import format_number
 from django.db import IntegrityError
-from django.utils import timezone
+from django.utils import timezone, six
 from google.appengine.api import datastore
 from google.appengine.api.datastore import Key, Query
 try:
@@ -250,15 +250,9 @@ def django_instance_to_entities(connection, fields, raw, instance, check_null=Tr
 
     kwargs = {}
     if primary_key:
-        if isinstance(primary_key, (int, long)):
+        if isinstance(primary_key, six.integer_types):
             kwargs["id"] = primary_key
-        elif isinstance(primary_key, basestring):
-            if len(primary_key) > 500:
-                warnings.warn("Truncating primary key that is over 500 characters. "
-                              "THIS IS AN ERROR IN YOUR PROGRAM.",
-                              RuntimeWarning)
-                primary_key = primary_key[:500]
-
+        elif isinstance(primary_key, six.string_types):
             kwargs["name"] = primary_key
         else:
             raise ValueError("Invalid primary key value")

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -57,7 +57,7 @@ That's a hell of an annoying caveat. That's not to say our approach doesn't suff
 ## Caveats
 
 Because our pre-calculated fields are indexed, the combined length of the values (plus the unique ID and joining characters) you are
-ordering on must not exceed 500 characters. This will throw an error, and if that happens, you'll either need to use a slower paginator (e.g. djangae.core.paginator)
+ordering on must not exceed 1500 characters. This will throw an error, and if that happens, you'll either need to use a slower paginator (e.g. djangae.core.paginator)
 or rethink your design.
 
 ## Why didn't you update potatopage?

--- a/docs/release_notes/0_9_10.md
+++ b/docs/release_notes/0_9_10.md
@@ -10,7 +10,7 @@ queries. The previous implementation suffered the following drawbacks:
    performance issues across the site as this index data would be transferred with returned instance.
  - Index data was saved across several fields (due to a misunderstanding of the limits of list properties)
 
-The new backend has none of these drawbacks. The limit for string value is the same as CharField (1500 bytes, 500 bytes for keys) and
+The new backend has none of these drawbacks. The limit for string value is the same as CharField (1500 bytes) and
 index data is stored on a descendent entity meaning data isn't needlessly transferred with instances.
 
 ## Migrating


### PR DESCRIPTION
Fixes #872 

Summary of changes proposed in this Pull Request:
- Fixes outdated assumption of the valid length of a string key (1500 bytes is the actual limit, not 500)
- Doesn't truncate keys automatically, saving will now be an error

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
