### PR TITLE
gauth backend fails to authenticate

### DIFF
--- a/djangae/contrib/gauth/backends.py
+++ b/djangae/contrib/gauth/backends.py
@@ -1,4 +1,5 @@
 import warnings
+from functools import partial
 
 from django.db.models.query_utils import Q
 from django.db.utils import IntegrityError
@@ -62,7 +63,7 @@ def should_create_unknown_user():
 
 
 class BaseAppEngineUserAPIBackend(ModelBackend):
-    atomic = transaction.atomic
+    atomic = partial(transaction.atomic)
     atomic_kwargs = {}
 
     def authenticate(self, google_user=None):

--- a/djangae/contrib/gauth_datastore/backends.py
+++ b/djangae/contrib/gauth_datastore/backends.py
@@ -1,5 +1,6 @@
 # STANDARD LIB
 from itertools import chain
+from functools import partial
 
 # DJANGAE
 from djangae.db import transaction
@@ -8,7 +9,7 @@ from djangae.contrib.gauth_datastore.permissions import get_permission_choices
 
 
 class AppEngineUserAPIBackend(BaseAppEngineUserAPIBackend):
-    atomic = transaction.atomic
+    atomic = partial(transaction.atomic)
     atomic_kwargs = {'xg': True}
 
     def get_group_permissions(self, user_obj, obj=None):

--- a/djangae/contrib/gauth_sql/backends.py
+++ b/djangae/contrib/gauth_sql/backends.py
@@ -1,4 +1,4 @@
-from djangae.contrib.gauth.common.backends import BaseAppEngineUserAPIBackend
+from djangae.contrib.gauth.backends import BaseAppEngineUserAPIBackend
 
 
 class AppEngineUserAPIBackend(BaseAppEngineUserAPIBackend):


### PR DESCRIPTION
Within the auth backends, the atomic function/decorator/context manager is stored as a class property (to abstract it for use with Django/Djangae implementation), which when called [here](https://github.com/potatolondon/djangae/blob/master/djangae/contrib/gauth/backends.py#L139) , is treated as a class method, and a class instance is passed as the first argument.

This causes it to fail, as the first argument is expected to be the db alias (`using`), to fix this, we could either return the atomic function from another function, or, as i have done here, wrapped it in `partial`, so it is treated as a standalone function, not a classmethod.

Also included @TysonRV 's import fix 