### PR TITLE
System check errors should have an ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for querying JSONFields in a similar way to the PostgreSQL JSONField
 - Allow special indexers to index `None` as well as remove unused index properties from the entity
+- Added IDs to system check errors, allowing them to be silenced
 
 ### Bug fixes:
 

--- a/djangae/checks.py
+++ b/djangae/checks.py
@@ -25,7 +25,7 @@ CSP_SOURCE_NAMES = [
 
 
 @register(Tags.security)
-def check_session_csrf_enabled(app_configs, **kwargs):
+def check_session_csrf_enabled(app_configs=None, **kwargs):
     errors = []
 
     # Django >= 1.10 has a MIDDLEWARE setting, which is None by default. Convert
@@ -43,7 +43,7 @@ def check_session_csrf_enabled(app_configs, **kwargs):
 
 
 @register(Tags.security)
-def check_csp_is_not_report_only(app_configs, **kwargs):
+def check_csp_is_not_report_only(app_configs=None, **kwargs):
     errors = []
     if getattr(settings, "CSP_REPORT_ONLY", False):
         errors.append(Error(
@@ -55,7 +55,7 @@ def check_csp_is_not_report_only(app_configs, **kwargs):
 
 
 @register(Tags.security, deploy=True)
-def check_csp_sources_not_unsafe(app_configs, **kwargs):
+def check_csp_sources_not_unsafe(app_configs=None, **kwargs):
     errors = []
     for csp_src_name in CSP_SOURCE_NAMES:
         csp_src_values = getattr(settings, csp_src_name, [])
@@ -63,13 +63,13 @@ def check_csp_sources_not_unsafe(app_configs, **kwargs):
             errors.append(Error(
                 csp_src_name + "_UNSAFE",
                 hint="Please remove 'unsafe-inline'/'unsafe-eval' from your CSP policies",
-                id='djangae.E01%s' % CSP_SOURCE_NAMES.index(csp_src_name),
+                id='djangae.E1%02d' % CSP_SOURCE_NAMES.index(csp_src_name),
             ))
     return errors
 
 
 @register(Tags.caches, deploy=True)
-def check_cached_template_loader_used(app_configs, **kwargs):
+def check_cached_template_loader_used(app_configs=None, **kwargs):
     """ Ensure that the cached template loader is used for Django's template system. """
     for template in settings.TEMPLATES:
         if template['BACKEND'] != "django.template.backends.django.DjangoTemplates":
@@ -84,6 +84,7 @@ def check_cached_template_loader_used(app_configs, **kwargs):
             id='djangae.E003',
         )
         return [error]
+    return []
 
 
 @register(Tags.urls)

--- a/djangae/checks.py
+++ b/djangae/checks.py
@@ -37,6 +37,7 @@ def check_session_csrf_enabled(app_configs, **kwargs):
         errors.append(Error(
             "SESSION_CSRF_DISABLED",
             hint="Please add 'session_csrf.CsrfMiddleware' to MIDDLEWARE_CLASSES",
+            id='djangae.E001',
         ))
     return errors
 
@@ -48,6 +49,7 @@ def check_csp_is_not_report_only(app_configs, **kwargs):
         errors.append(Error(
             "CSP_REPORT_ONLY_ENABLED",
             hint="Please set 'CSP_REPORT_ONLY' to False",
+            id='djangae.E002',
         ))
     return errors
 
@@ -61,6 +63,7 @@ def check_csp_sources_not_unsafe(app_configs, **kwargs):
             errors.append(Error(
                 csp_src_name + "_UNSAFE",
                 hint="Please remove 'unsafe-inline'/'unsafe-eval' from your CSP policies",
+                id='djangae.E01%s' % CSP_SOURCE_NAMES.index(csp_src_name),
             ))
     return errors
 
@@ -77,7 +80,8 @@ def check_cached_template_loader_used(app_configs, **kwargs):
                 return []
         error = Error(
             "CACHED_TEMPLATE_LOADER_NOT_USED",
-            hint="Please use 'django.template.loaders.cached.Loader' for Django templates"
+            hint="Please use 'django.template.loaders.cached.Loader' for Django templates",
+            id='djangae.E003',
         )
         return [error]
 

--- a/djangae/tests/test_checks.py
+++ b/djangae/tests/test_checks.py
@@ -64,6 +64,11 @@ class ChecksTestCase(TestCase):
             errors = checks.check_csp_sources_not_unsafe()
             self.assertEqual(len(errors), 9)
 
+            # this assumes that errors come through in the same order as
+            # checks.CSP_SOURCE_NAMES
+            for idx, err in enumerate(errors):
+                self.assertEqual(err.id, 'djangae.E1%02d' % idx)
+
     def test_template_loader_present(self):
         template_setting = [{
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -74,8 +79,6 @@ class ChecksTestCase(TestCase):
         with override_settings(TEMPLATES=template_setting):
             errors = checks.check_cached_template_loader_used()
             self.assertEqual(len(errors), 0)
-            for idx, err in enumerate(errors):
-                self.assertTrue(err.idi, 'djangae.E1%02d' % idx)
 
     def test_template_loader_missing(self):
         template_setting = [{
@@ -90,7 +93,7 @@ class ChecksTestCase(TestCase):
     def test_template_loader_skips_non_django_backends(self):
         template_setting = [{
             'BACKEND': 'nondjango.templates',
-            'OPTIONS': {'loaders': [('nondjango.templates.Loaders',)]},
+            'OPTIONS': {'loaders': [('nondjango.templates.Loader',)]},
         }]
         with override_settings(TEMPLATES=template_setting):
             errors = checks.check_cached_template_loader_used()

--- a/djangae/tests/test_checks.py
+++ b/djangae/tests/test_checks.py
@@ -3,10 +3,11 @@ import tempfile
 
 import yaml
 
+from djangae import checks
 from djangae.contrib import sleuth
-from djangae.checks import check_deferred_builtin
 from djangae.environment import get_application_root
 from djangae.test import TestCase
+from django.test.utils import override_settings
 
 
 class ChecksTestCase(TestCase):
@@ -28,11 +29,69 @@ class ChecksTestCase(TestCase):
         yaml.dump(app_yaml, temp_app_yaml)
 
         with sleuth.switch('djangae.checks.get_application_root', lambda : temp_app_yaml_dir) as mock_app_root:
-            warnings = check_deferred_builtin()
+            warnings = checks.check_deferred_builtin()
             self.assertEqual(len(warnings), 1)
             self.assertEqual(warnings[0].id, 'djangae.W001')
 
     def test_deferred_builtin_off(self):
-        warnings = check_deferred_builtin()
+        warnings = checks.check_deferred_builtin()
         self.assertEqual(len(warnings), 0)
 
+    def test_csrf_check(self):
+        errors = checks.check_session_csrf_enabled()
+        self.assertEqual(len(errors), 0)
+
+        with override_settings(MIDDLEWARE=[], MIDDLEWARE_CLASSES=[]):
+            errors = checks.check_session_csrf_enabled()
+            self.assertEqual(len(errors), 1)
+            self.assertEqual(errors[0].id, 'djangae.E001')
+
+    def test_csp_report_check(self):
+        errors = checks.check_csp_is_not_report_only()
+        self.assertEqual(len(errors), 0)
+
+        with override_settings(CSP_REPORT_ONLY=True):
+            errors = checks.check_csp_is_not_report_only()
+            self.assertEqual(len(errors), 1)
+            self.assertEqual(errors[0].id, 'djangae.E002')
+
+    def test_csp_unsafe_check(self):
+        errors = checks.check_csp_sources_not_unsafe()
+        self.assertEqual(len(errors), 0)
+
+        csp_settings = {k: ["'unsafe-inline'"] for k in checks.CSP_SOURCE_NAMES}
+        with override_settings(**csp_settings):
+            errors = checks.check_csp_sources_not_unsafe()
+            self.assertEqual(len(errors), 9)
+
+    def test_template_loader_present(self):
+        template_setting = [{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'OPTIONS': {'loaders': [
+                ('django.template.loaders.cached.Loader', ('django.template.loaders.filesystem.Loader',)),
+            ]},
+        }]
+        with override_settings(TEMPLATES=template_setting):
+            errors = checks.check_cached_template_loader_used()
+            self.assertEqual(len(errors), 0)
+            for idx, err in enumerate(errors):
+                self.assertTrue(err.idi, 'djangae.E1%02d' % idx)
+
+    def test_template_loader_missing(self):
+        template_setting = [{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'OPTIONS': {'loaders': [('django.template.loaders.filesystem.Loader',)]},
+        }]
+        with override_settings(TEMPLATES=template_setting):
+            errors = checks.check_cached_template_loader_used()
+            self.assertEqual(len(errors), 1)
+            self.assertEqual(errors[0].id, 'djangae.E003')
+
+    def test_template_loader_skips_non_django_backends(self):
+        template_setting = [{
+            'BACKEND': 'nondjango.templates',
+            'OPTIONS': {'loaders': [('nondjango.templates.Loaders',)]},
+        }]
+        with override_settings(TEMPLATES=template_setting):
+            errors = checks.check_cached_template_loader_used()
+            self.assertEqual(len(errors), 0)


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Add IDs to system check errors
- Add tests for checks
- Fixed check that didn't always return a list

Without IDs on errors raised by Djangae checks there is no way to silence them. A few examples:

* The check for django-sessions-csrf is not required with Django 1.11 as the same functionality is now built-in
* The check for unsafe-* CSP directives should be silenced if you want to use CSP nonces, but also want to support IE 11
  * To do this you need both nonces and `'unsafe-inline'` in your CSP directives, the latter being ignored by Firefox and Chrome when there is a nonce present

PR checklist:
- _n/a_ Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
