### PR TITLE
Allow computed fields to take the name of a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for querying JSONFields in a similar way to the PostgreSQL JSONField
 - Allow special indexers to index `None` as well as remove unused index properties from the entity
 - Added IDs to system check errors, allowing them to be silenced
+- Computed fields now allow the computing function to be passed as a string containing the name of a method, rather than the function object itself.
 
 ### Bug fixes:
 

--- a/djangae/fields/computed.py
+++ b/djangae/fields/computed.py
@@ -10,7 +10,7 @@ class ComputedFieldMixin(object):
         super(ComputedFieldMixin, self).__init__(*args, **kwargs)
 
     def pre_save(self, model_instance, add):
-        value = self.computer(model_instance)
+        value = self.get_computed_value(model_instance)
         setattr(model_instance, self.attname, value)
         return value
 
@@ -24,6 +24,14 @@ class ComputedFieldMixin(object):
         if value is None:
             return value
         return self.to_python(value)
+
+    def get_computed_value(self, model_instance):
+        # self.computer is either a function or a string containing the name of a method
+        if callable(self.computer):
+            return self.computer(model_instance)
+        else:
+            computer = getattr(model_instance, self.computer)
+            return computer()
 
 
 class ComputedCharField(ComputedFieldMixin, models.CharField):

--- a/djangae/tests/test_db_fields.py
+++ b/djangae/tests/test_db_fields.py
@@ -16,6 +16,7 @@ from djangae.contrib import sleuth
 from djangae.db import transaction
 from djangae.fields import (
     ComputedCharField,
+    ComputedPositiveIntegerField,
     GenericRelationField,
     JSONField,
     ListField,
@@ -40,6 +41,7 @@ class ComputedFieldModel(models.Model):
     int_field = models.IntegerField()
     char_field = models.CharField(max_length=50)
     test_field = ComputedCharField(computer, max_length=50)
+    method_calc_field = ComputedCharField("computer", max_length=50)
 
     class Meta:
         app_label = "djangae"
@@ -54,6 +56,14 @@ class ComputedFieldTests(TestCase):
         # Try getting and saving the instance again
         instance = ComputedFieldModel.objects.get(test_field="1_test")
         instance.save()
+
+    def test_computed_by_method_name_field(self):
+        """ Test that a computed field which specifies its "computer" function as a string of
+            the name of a method on the model.
+        """
+        instance = ComputedFieldModel(int_field=2, char_field="test")
+        instance.save()
+        self.assertEqual(instance.method_calc_field, "2_test")
 
 
 class ModelWithCounter(models.Model):

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -228,7 +228,7 @@ This can be particularly useful with the Datastore where there are limitations t
 For example, you can't do `.filter(a__gte=x, b__gte=y)`, but if `x` and `y` are constant then you could add a computed field which stores a boolean value to indicate whether or not an object meets these criteria.
 So you could then do `.filter(a_is_gte_x_and_b_is_gte_y=True)`.
 
-Each computed field takes a single argument of a "computer" function. This function is called each time the model instance is saved with the model instance passed as a single argument.
+Each computed field takes a single argument of a "computer" function.  This can be passed either as a callable object, or as a string containing the name of a method on the model. This "computer" function or method is called each time the model instance is saved, with the model instance passed as a single argument (this is just the normal `self` in the case of a method).
 The value which the function returns is what is stored in the computed field.
 
 Computed fields are:


### PR DESCRIPTION
This allows computed fields to take the name of a method instead of a function object as the "computer" function.

The main benefit of this is that it allows the field to be pickled, even when using a method on the model class as the computer function.  Unbound methods on the class can't be pickled, so if you pass in a method directly into the field, you then can't pickle the field.

Fixes #968.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
