### PR TITLE
do not emit logging output when running tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  - Fixed performance issues and bugs in the Djangae core paginator
  - Fix several issues with the test sandbox
  - Initialize the app_identity stub in the test sandbox
+ - Logging output silenced during `manage.py test` execution
 
 ## v0.9.10
 

--- a/testapp/manage.py
+++ b/testapp/manage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import logging
 import os
 import sys
 
@@ -11,6 +12,7 @@ if __name__ == "__main__":
     from djangae.core.management import execute_from_command_line, test_execute_from_command_line
 
     if "test" in sys.argv:
+        logging.disable(logging.CRITICAL)
         test_execute_from_command_line(sys.argv)
     else:
         execute_from_command_line(sys.argv)


### PR DESCRIPTION
Fixes #974.

Summary of changes proposed in this Pull Request:
- Do not emit logging output when running `manage.py test`

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [N/A] Added tests for my change
