### PR TITLE
Replace print with logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
  - Fixed performance issues and bugs in the Djangae core paginator
  - Fix several issues with the test sandbox
  - Initialize the app_identity stub in the test sandbox
+ - Replace `print()` statements with `logging.debug()` in all unittests
+ - Silence stdout output during testing
 
 ## v0.9.10
 

--- a/djangae/contrib/security/tests.py
+++ b/djangae/contrib/security/tests.py
@@ -1,10 +1,12 @@
+import logging
+
 from djangae.test import TestCase
 from djangae.contrib.security.management.commands import dumpurls
 
 
 class DumpUrlsTests(TestCase):
     def test_dumpurls(self):
-        print ("*" * 50) + "\n\n\n"
         """ Test that the `dumpurls` command runs without dying. """
+        logging.debug('%s', "*" * 50)
         command = dumpurls.Command()
         command.handle()

--- a/djangae/tests/test_indexing.py
+++ b/djangae/tests/test_indexing.py
@@ -1,6 +1,8 @@
 """
     Tests for "special indexing" (E.g. __contains, __startswith etc.)
 """
+import logging
+
 from djangae.contrib import sleuth
 from djangae.db.caching import disable_cache
 from djangae.test import TestCase
@@ -44,10 +46,10 @@ class ContainsIndexerTests(TestCase):
                 queryset = ContainsModel.objects.filter(field1__contains="Ad")
                 self.assertFalse(datastore_query.called)
                 self.assertFalse(datastore_get.called)
-                print len(datastore_query.calls)
+                logging.debug('datastore_query.calls count: %d', len(datastore_query.calls))
                 list(queryset)
                 self.assertTrue(datastore_query.called)
-                print len(datastore_query.calls)
+                logging.debug('datastore_query.called count: %d', datastore_query.called)
                 self.assertTrue(datastore_get.called)
 
     def test_flush_wipes_descendent_kinds(self):


### PR DESCRIPTION
Fixes #976 .

Summary of changes proposed in this Pull Request:
- turn all `print()` calls in unit tests to `logging.debug()` calls
- silence all `print()` statements in command and other output when `test` is in `sys.argv`

PR checklist:
- [N/A] Updated relevant documentation
- [X] Updated CHANGELOG.md 
- [N/A] Added tests for my change
