### PR TITLE
Fix broken `--help` in management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
  - Fix several issues with the test sandbox
  - Initialize the app_identity stub in the test sandbox
  - Logging output silenced during `manage.py test` execution
+ - Fix management command `--help` output
 
 ## v0.9.10
 

--- a/djangae/core/management/__init__.py
+++ b/djangae/core/management/__init__.py
@@ -6,8 +6,7 @@ import argparse
 import djangae.sandbox as sandbox
 from djangae import environment
 
-# Set some Django-y defaults
-DJANGO_DEFAULTS = {
+DEFAULTS = {
     "storage_path": os.path.join(environment.get_application_root(), ".storage"),
     "port": 8000,
     "admin_port": 8001,
@@ -17,23 +16,42 @@ DJANGO_DEFAULTS = {
 }
 
 
-def _execute_from_command_line(sandbox_name, argv, **sandbox_overrides):
-    # Parses for a settings flag, adding it as an environment variable to
-    # the sandbox if found.
-    parser = argparse.ArgumentParser(prog='manage.py')
-    parser.add_argument('--settings', nargs='?')
-    parsed = parser.parse_known_args(argv)
-    settings = parsed[0].settings
-    env_vars = {}
-    if settings:
-        env_vars['DJANGO_SETTINGS_MODULE'] = settings
+def execute_from_command_line(argv=None, **sandbox_overrides):
+    """Wraps Django's `execute_from_command_line` to initialize a djangae
+    sandbox before running a management command.
+    """
+    argv = argv or sys.argv[:]
 
+    djangae_parser = argparse.ArgumentParser(description='Djangae arguments', add_help=False)
+    djangae_parser.add_argument('--sandbox', default=sandbox.LOCAL, choices=sandbox.SANDBOXES.keys())
+    djangae_parser.add_argument('--app_id', default=None, help='GAE APPLICATION ID')
+
+    ignored_args = ('-v', '--version')
+    stashed_args = [arg for arg in argv[1:] if arg in ignored_args]
+
+    djangae_namespace, other_args = djangae_parser.parse_known_args([arg for arg in argv[1:] if arg not in ignored_args])
+
+    argv = ['manage.py'] + other_args + stashed_args
+
+    overrides = DEFAULTS.copy()
+    overrides.update(sandbox_overrides, app_id=djangae_namespace.app_id)
+
+    return _execute_from_command_line(djangae_namespace.sandbox, argv, parser=djangae_parser, **overrides)
+
+
+def _execute_from_command_line(sandbox_name, argv, parser=None, **sandbox_overrides):
+    # Parses for a settings flag, adding it as an environment variable to
     # retrieve additional overridden module settings
-    for arg in parsed[1]:
+    env_vars = {}
+    for arg in argv:
         m = re.match(r'--(?P<module_name>.+)-settings=(?P<settings_path>.+)', arg)
         if m:
             argv.remove(arg)
             env_vars['%s_DJANGO_SETTINGS_MODULE' % m.group('module_name')] = m.group('settings_path')
+
+        m = re.match(r'--settings=(?P<settings_path>.+)', arg)
+        if m:
+            env_vars['DJANGO_SETTINGS_MODULE'] = m.group('settings_path')
 
     with sandbox.activate(
         sandbox_name,
@@ -41,25 +59,16 @@ def _execute_from_command_line(sandbox_name, argv, **sandbox_overrides):
         new_env_vars=env_vars,
         **sandbox_overrides
     ):
-        import django.core.management as django_management  # Now on the path
-        return django_management.execute_from_command_line(argv)
-
-
-def execute_from_command_line(argv=None, **sandbox_overrides):
-    """Wraps Django's `execute_from_command_line` to initialize a djangae
-    sandbox before running a management command.
-    """
-    argv = argv or sys.argv
-    parser = argparse.ArgumentParser(prog='manage.py')
-    parser.add_argument(
-        '--sandbox', default=sandbox.LOCAL, choices=sandbox.SANDBOXES.keys())
-    parser.add_argument('--app_id', default=None, help='GAE APPLICATION ID')
-    namespace, other_args = parser.parse_known_args(argv[1:])
-
-    overrides = DJANGO_DEFAULTS
-    overrides.update(sandbox_overrides, app_id=namespace.app_id)
-
-    return _execute_from_command_line(namespace.sandbox, ['manage.py'] + other_args, **overrides)
+        try:
+            import django.core.management as django_management  # Now on the path
+            return django_management.execute_from_command_line(argv)
+        except SystemExit as e:
+            # print Djangae parser options help message
+            print_help = any([arg in ('-h', '--help') for arg in argv])
+            if e.code == 0 and print_help:
+                parser.print_help()
+                sys.stdout.write('\n')
+            raise
 
 
 def remote_execute_from_command_line(argv=None, **sandbox_overrides):


### PR DESCRIPTION
Fixes #981

Summary of changes proposed in this Pull Request:
- Help text for all management commands is now working

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
