### PR TITLE
Add `djangae.compat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  in migrations.
 - Improve the approx SQL representation of Datastore commands (update, delete etc.)
 - Default value for failure_behaviour in `process_task_queues` is now `RAISE_ERROR`. Tasks will no longer fail silently when processed using this method in unit tests.
+- Add djangae.compat to handle SDK structural changes
 
 ### Bug fixes:
 
@@ -21,6 +22,7 @@
  - Logging output silenced during `manage.py test` execution
  - Fix management command `--help` output
  - Create .editorconfig to ensure basic editor settings are consistent between users
+ - Fix import error in SDK 1.9.60 
 
 ## v0.9.10
 

--- a/djangae/compat.py
+++ b/djangae/compat.py
@@ -1,0 +1,15 @@
+try:
+    from google.appengine.tools.devappserver2.python import sandbox
+except ImportError:
+    from google.appengine.tools.devappserver2.python.runtime import sandbox
+
+try:
+    from google.appengine.tools.devappserver2.python import runtime
+except ImportError:
+    from google.appengine.tools.devappserver2.python.runtime import runtime
+
+try:
+    from google.appengine.tools.devappserver2.devappserver2 import _LOG_LEVEL_TO_RUNTIME_CONSTANT
+except ImportError:
+    from google.appengine.tools.devappserver2.constants import LOG_LEVEL_TO_RUNTIME_CONSTANT
+    _LOG_LEVEL_TO_RUNTIME_CONSTANT = LOG_LEVEL_TO_RUNTIME_CONSTANT

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -113,11 +113,7 @@ def _create_dispatcher(configuration, options):
     from google.appengine.tools.devappserver2 import dispatcher
     from google.appengine.tools.devappserver2.devappserver2 import DevelopmentServer
 
-    try:
-        from google.appengine.tools.devappserver2.devappserver2 import _LOG_LEVEL_TO_RUNTIME_CONSTANT
-    except ImportError:
-        from google.appengine.tools.devappserver2.constants import LOG_LEVEL_TO_RUNTIME_CONSTANT
-        _LOG_LEVEL_TO_RUNTIME_CONSTANT = LOG_LEVEL_TO_RUNTIME_CONSTANT
+    from djangae.compat import _LOG_LEVEL_TO_RUNTIME_CONSTANT
 
     from google.appengine.tools.sdk_update_checker import GetVersionObject, \
                                                           _VersionList
@@ -498,11 +494,11 @@ def activate(sandbox_name, add_sdk_to_path=False, new_env_vars=None, **overrides
     # Initialize as though `dev_appserver.py` is about to run our app, using all the
     # configuration provided in app.yaml.
     import google.appengine.tools.devappserver2.application_configuration as application_configuration
-    import google.appengine.tools.devappserver2.python.sandbox as sandbox
     import google.appengine.tools.devappserver2.devappserver2 as devappserver2
     import google.appengine.tools.devappserver2.wsgi_request_info as wsgi_request_info
     import google.appengine.ext.remote_api.remote_api_stub as remote_api_stub
     import google.appengine.api.apiproxy_stub_map as apiproxy_stub_map
+    from djangae.compat import sandbox
 
     gae_args = [
         s for s in sys.argv

--- a/djangae/wsgi.py
+++ b/djangae/wsgi.py
@@ -2,7 +2,7 @@ from djangae import environment
 
 
 def fix_c_whitelist():
-    from google.appengine.tools.devappserver2.python import sandbox
+    from djangae.compat import sandbox
     if '_sqlite3' not in sandbox._WHITE_LIST_C_MODULES:
         sandbox._WHITE_LIST_C_MODULES.extend([
             '_sqlite3',
@@ -34,7 +34,7 @@ def fix_sandbox():
     if environment.is_production_environment():
         return
 
-    from google.appengine.tools.devappserver2.python import sandbox
+    from djangae.compat import sandbox
 
     if '_sqlite3' not in sandbox._WHITE_LIST_C_MODULES:
         fix_c_whitelist()


### PR DESCRIPTION
Fixes #964

Summary of changes proposed in this Pull Request:
- Add `djangae.compat` as a central place to handle module/package changes in SDK versions 
- Supporting caching of downloaded SDK versions

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
