### PR TITLE
Update TestCaseMixin to reflect change made to process_task_queues failure behaviour

### DIFF
--- a/djangae/test.py
+++ b/djangae/test.py
@@ -203,7 +203,7 @@ class TestCaseMixin(object):
         if self.taskqueue_stub:
             _flush_tasks(self.taskqueue_stub, queue_name)
 
-    def process_task_queues(self, queue_name=None, failure_behaviour=TaskFailedBehaviour.DO_NOTHING):
+    def process_task_queues(self, queue_name=None, failure_behaviour=TaskFailedBehaviour.RAISE_ERROR):
         process_task_queues(queue_name, failure_behaviour)
 
     def get_task_count(self, queue_name=None):


### PR DESCRIPTION
The recent change to `failure_behaviour` didn't change the default behaviour in TestCaseMixin so DO_NOTHING was overriding RAISE_ERROR when calling `process_task_queues` with no failure behaviour passed in.