### PR TITLE
Switching the import order, as in sdk 1.9.54 simply attempting to imp…

### DIFF
--- a/djangae/compat.py
+++ b/djangae/compat.py
@@ -9,7 +9,7 @@ except ImportError:
     from google.appengine.tools.devappserver2.python.runtime import runtime
 
 try:
-    from google.appengine.tools.devappserver2.devappserver2 import _LOG_LEVEL_TO_RUNTIME_CONSTANT
-except ImportError:
     from google.appengine.tools.devappserver2.constants import LOG_LEVEL_TO_RUNTIME_CONSTANT
     _LOG_LEVEL_TO_RUNTIME_CONSTANT = LOG_LEVEL_TO_RUNTIME_CONSTANT
+except ImportError:
+    from google.appengine.tools.devappserver2.devappserver2 import _LOG_LEVEL_TO_RUNTIME_CONSTANT


### PR DESCRIPTION
…ort something from devappserver2 here results in an attribute error when devappserver tries to import mail_stub.

Fixes #964 (again)
