### PR TITLE
Changed djangae.contrib.backup to be easier to use.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New features & improvements:
 
+- Backups made with `djangae.contrib.backup` are created in a new, time-stamped directory to make managing backups easier. Only `DJANGAE_BACKUP_ENABLED` is required, all other backup settings are optional and the default is to create backups in the default cloud storage bucket. See the backup docs for details.
 - Add support for querying JSONFields in a similar way to the PostgreSQL JSONField
 - Allow special indexers to index `None` as well as remove unused index properties from the entity
 - Added IDs to system check errors, allowing them to be silenced

--- a/djangae/contrib/backup/tests/test_views.py
+++ b/djangae/contrib/backup/tests/test_views.py
@@ -23,17 +23,20 @@ class DataStoreBackupTest(TestCase):
             Site
         ]
         with sleuth.fake('django.apps.apps.get_models', models):
-            with self.settings(
-                    DJANGAE_BACKUP_ENABLED=True,
-                    DJANGAE_BACKUP_GCS_BUCKET='testapp',
-                    DJANGAE_BACKUP_NAME='testapp-bk',
-                    DJANGAE_BACKUP_EXCLUDE_APPS=[
-                        'sites'
-                    ],
-                    DJANGAE_BACKUP_EXCLUDE_MODELS=[
-                        'gauth_datastore.Group'
-                    ]):
-                create_datastore_backup(None)
+            bucket = 'testapp/19991231-235900'
+
+            with sleuth.fake('djangae.contrib.backup.views.get_backup_path', bucket):
+                with self.settings(
+                        DJANGAE_BACKUP_ENABLED=True,
+                        DJANGAE_BACKUP_GCS_BUCKET='testapp',
+                        DJANGAE_BACKUP_NAME='testapp-bk',
+                        DJANGAE_BACKUP_EXCLUDE_APPS=[
+                            'sites'
+                        ],
+                        DJANGAE_BACKUP_EXCLUDE_MODELS=[
+                            'gauth_datastore.Group'
+                        ]):
+                    create_datastore_backup(None)
 
         # assert task was triggered
         tasks = self.taskqueue_stub.get_filtered_tasks()
@@ -42,8 +45,8 @@ class DataStoreBackupTest(TestCase):
         self.assertEqual(tasks[0].url,
             '/_ah/datastore_admin/backup.create?'
             'name=testapp-bk'
-            '&amp;gs_bucket_name=testapp'
-            '&amp;filesystem=gs'
-            '&amp;kind=django_admin_log'
-            '&amp;kind=djangae_gaedatastoreuser'
+            '&gs_bucket_name=testapp%2F19991231-235900'
+            '&filesystem=gs'
+            '&kind=django_admin_log'
+            '&kind=djangae_gaedatastoreuser'
         )

--- a/djangae/contrib/backup/utils.py
+++ b/djangae/contrib/backup/utils.py
@@ -1,4 +1,8 @@
+import datetime
+
 from django.conf import settings
+from google.appengine.api import app_identity
+
 
 SETTINGS_PREFIX = "DJANGAE_BACKUP_"
 
@@ -10,3 +14,35 @@ def get_backup_setting(name, required=True, default=None):
 
     return getattr(settings, settings_name, default)
 
+
+def get_gcs_bucket():
+    """Get a bucket from DJANGAE_BACKUP_GCS_BUCKET setting. Defaults to the
+    default application bucket with 'djangae-backups' appended.
+
+    Raises an exception if DJANGAE_BACKUP_GCS_BUCKET is missing and there is
+    no default bucket.
+    """
+    try:
+        bucket = settings.DJANGAE_BACKUP_GCS_BUCKET
+    except AttributeError:
+        bucket = app_identity.get_default_gcs_bucket_name()
+
+        if bucket:
+            bucket = '{}/djangae-backups'.format(bucket)
+
+    if not bucket:
+        raise Exception('No DJANGAE_BACKUP_GCS_BUCKET or default bucket')
+
+    return bucket
+
+
+def get_backup_path():
+    bucket = get_gcs_bucket()
+
+    # And then we create a new, time-stamped directory for every backup run.
+    # This will give us UTC even if USE_TZ=False and we aren't running on
+    # App Engine (local development?).
+    dt = datetime.datetime.utcnow()
+    bucket_path = '{}/{:%Y%m%d-%H%M%S}'.format(bucket, dt)
+
+    return bucket_path

--- a/djangae/contrib/backup/views.py
+++ b/djangae/contrib/backup/views.py
@@ -1,12 +1,13 @@
 import logging
-from google.appengine.api import taskqueue
+import urllib
 
 from django.apps import apps
-from django.conf import settings
 from django.http import HttpResponse
 from djangae.environment import application_id
+from google.appengine.api import taskqueue
 
-from .utils import get_backup_setting
+from .utils import get_backup_setting, get_backup_path
+
 
 logger = logging.getLogger(__name__)
 
@@ -15,22 +16,15 @@ BACKUP_HANDLER = "/_ah/datastore_admin/backup.create"
 
 
 def create_datastore_backup(request):
-    """Creates a datastore backup based on the DS_BACKUP_X settings
-    """
-    base_url = "http://{module}-dot-{app_id}.appspot.com{backup_handler}".format(
-        module=GAE_BUILTIN_MODULE,
-        app_id=application_id(),
-        backup_handler=BACKUP_HANDLER
-    )
-
+    """Creates a datastore backup based on the DJANGAE_BACKUP_X settings."""
     enabled = get_backup_setting("ENABLED")
     if not enabled:
-        msg = "DS_BACKUP_ENABLED is False. Not backing up"
+        msg = "DJANGAE_BACKUP_ENABLED is False. Not backing up"
         logger.info(msg)
         return HttpResponse(msg)
 
-    gcs_bucket = get_backup_setting("GCS_BUCKET")
-    backup_name = get_backup_setting("NAME")
+    gcs_bucket = get_backup_path()
+    backup_name = get_backup_setting("NAME", required=False, default='djangae-backups')
     queue = get_backup_setting("QUEUE", required=False)
     exclude_models = get_backup_setting("EXCLUDE_MODELS", required=False, default=[])
     exclude_apps = get_backup_setting("EXCLUDE_APPS", required=False, default=[])
@@ -43,13 +37,13 @@ def create_datastore_backup(request):
 
         if app_label in exclude_apps:
             logger.info(
-                "Not backing up {} due to {} being in DS_BACKUP_EXCLUDE_APPS".format(
+                "Not backing up {} due to {} being in DJANGAE_BACKUP_EXCLUDE_APPS".format(
                     model_def, app_label))
             continue
 
         if model_def in exclude_models:
             logger.info(
-                "Not backing up {} as it is present in DS_BACKUP_EXCLUDE_MODELS".format(
+                "Not backing up {} as it is present in DJANGAE_BACKUP_EXCLUDE_MODELS".format(
                     model_def))
             continue
 
@@ -59,23 +53,19 @@ def create_datastore_backup(request):
     if not models:
         raise Exception("No models to back up")
 
-    kinds = "&amp;kind=".join(m._meta.db_table for m in models)
-
-    backup_url = (
-        "{backup_handler}"
-        "?name={backup_name}"
-        "&amp;gs_bucket_name={gcs_bucket}"
-        "&amp;filesystem=gs"
-        "&amp;kind={kinds}"
-    ).format(
-        backup_handler=BACKUP_HANDLER,
-        backup_name=backup_name,
-        gcs_bucket=gcs_bucket,
-        kinds=kinds
-    )
+    # Build the target path and query for the task.
+    params = [
+        ('name', backup_name),
+        ('gs_bucket_name', gcs_bucket),
+        ('filesystem', 'gs'),
+    ]
+    params.extend(('kind', m._meta.db_table) for m in models)
 
     if queue:
-        backup_url += "&amp;queue={}".format(queue)
+        params.append(('queue', queue))
+
+    query = urllib.urlencode(params, doseq=True)
+    backup_url = '{}?{}'.format(BACKUP_HANDLER, query)
 
     # Backups must be started via task queue or cron.
     taskqueue.add(

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -4,9 +4,9 @@ An app to help manage datastore backups.
 
 ## Basic usage
 
-By default all registered models are backed up.
+By default all registered models are backed up to a bucket in Google Cloud Storage. Each backup is created with an enclosing directory named for the start time of the backup (this helps keep your backups organised).
 
-* Enable datastore admin in the Cloud Console for your application
+* Enable datastore admin in the Cloud Console for your application.
 * Add backup url to main urls.py file:
 ```python
     url(r'^tasks/', include('djangae.contrib.backup.urls'))
@@ -18,20 +18,37 @@ cron:
   url: /tasks/create-datastore-backup/
   schedule: every day 07:00
 ```
-* Add backup queue to queue.yaml:
+* Define a backup queue in queue.yaml (optional, see `DJANGAE_BACKUP_QUEUE` below):
 ```yaml
 - name: backups
   rate: 50/s
 ```
-* Add required settings to settings.py"
+* Add required settings to settings.py.
 ```python
 DJANGAE_BACKUP_ENABLED = True
-DJANGAE_BACKUP_GCS_BUCKET = "my-application-bucket"
-DJANGAE_BACKUP_QUEUE = "backups"
 ```
-* Add `'djangae.contrib.backup'` to `settings.INSTALLED_APPS` (if you want the tests to run)
+* Add `'djangae.contrib.backup'` to `settings.INSTALLED_APPS` (if you want the tests to run).
 
 ## Other optional settings
+
+### DJANGAE_BACKUP_GCS_BUCKET
+
+By default backups will be created using the application's default cloud storage bucket, in a directory named "djangae-backups". If your application is named "foo-bar-baz", then the default cloud storage bucket is "foo-bar-baz.appspot.com" and backups will be created in "foo-bar-baz.appspot.com/djangae-backups".
+
+Add `DJANGAE_BACKUP_GCS_BUCKET` to settings to change the target bucket, or to change the destination directory.
+
+For example `DJANGAE_BACKUP_GCS_BUCKET="my-first-bucket"` would use the "my-first-bucket" cloud storage bucket for backups, and the backups would be created in the root of the bucket.
+
+
+### DJANGAE_BACKUP_NAME
+
+Set `DJANGAE_BACKUP_NAME` to a string to change the name used by the backup service to identify backups. Defaults to "djangae-backups".
+
+
+### DJANGAE_BACKUP_QUEUE
+
+Set `DJANGAE_BACKUP_QUEUE` to a string naming a queue that will be used to schedule backup tasks. The queue must be defined in your project's `queue.yaml` file. Defaults to the default App Engine queue.
+
 
 ### Exclude all models from certain applications:
 
@@ -45,6 +62,7 @@ DJANGAE_BACKUP_EXCLUDE_APPS = [
     "sessions",
 ]
 ```
+
 
 ### Exclude specific models
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,13 +12,14 @@ pages:
 - Environment: environment.md
 - Storage backends: storage.md
 - Contrib apps:
-  - Pagination: pagination.md
+  - Datastore eventual consistency: consistency.md
   - Gauth authentication: gauth.md
   - Map Reduce: mappers.md
-  - Unique constraint tool: uniquetool.md
+  - Pagination: pagination.md
+  - Scheduled backups: backup.md
   - Security: security.md
-  - Datastore eventual consistency: consistency.md
   - Thread locking: locking.md
+  - Unique constraint tool: uniquetool.md
 - Contributing & Testing: contributing.md
 - Release notes:
   - Overview: release_notes/index.md


### PR DESCRIPTION
Fixes #1004.

Summary of changes proposed in this Pull Request:
    
- The DJANGAE_BACKUP_GCS_BUCKET setting is optional. It defaults to
    the project's default bucket with a suffix of 'djangae-backups',
    e.g. 'myapp.appspot.com/djangae-backups'.
- The DJANGAE_BACKUP_NAME setting is optional. It defaults to
    'djangae-backups'.
- Backups are created with a timestamp in the object name, e.g.
    'myapp.appspot.com/djangae-backups/20171128-235900'.
- Updated docs (and fixed the docs config to include the backup docs).