### PR TITLE
Fix collation TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@
  - Logging output silenced during `manage.py test` execution
  - Fix management command `--help` output
  - Create .editorconfig to ensure basic editor settings are consistent between users
- - Fix import error in SDK 1.9.60 
+ - Fix import error in SDK 1.9.60
  - Add .flake8 file to move towards enforcement code standard
  - Add missing `djangae/fields/allkeys-5.2.0.zip` file to `MANIFEST.in`
+ - It was possible a `TypeError` would throw when calculating the ComputedCollationField value if the source value was unicode
 
 ## v0.9.10
 

--- a/djangae/fields/language.py
+++ b/djangae/fields/language.py
@@ -76,7 +76,9 @@ class ComputedCollationField(ComputedFieldMixin, CharField):
 
         def computer(instance):
             source_value = getattr(instance, source_field_name, u"")
-            return self.collator.sort_key(unicode(source_value, "utf-8"))
+            if not isinstance(source_value, unicode):
+                source_value = unicode(source_value, "utf-8")
+            return self.collator.sort_key(source_value)
 
         super(ComputedCollationField, self).__init__(computer)
 

--- a/djangae/tests/test_computed_collation_field.py
+++ b/djangae/tests/test_computed_collation_field.py
@@ -12,6 +12,13 @@ class CCollationModel(models.Model):
 
 class ComputedCollationFieldTests(TestCase):
 
+    def test_unicode(self):
+        instance = CCollationModel(field1=u"A unicode string")
+        try:
+            instance.save()
+        except TypeError:
+            self.fail("Error saving unicode value")
+
     def test_basic_usage(self):
         instance1 = CCollationModel.objects.create(field1="Đavid")
         instance2 = CCollationModel.objects.create(field1="Łukasz")
@@ -24,4 +31,4 @@ class ComputedCollationFieldTests(TestCase):
         self.assertEqual(results[1], instance1)
         self.assertEqual(results[2], instance2)
         self.assertEqual(results[3], instance4)
-    
+


### PR DESCRIPTION
Fixes a TypeError exception when generating the value for ComputedCollationField

Summary of changes proposed in this Pull Request:
- Only conditionally convert a source value to unicode if it's not already

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
