### PR TITLE
Add a ComputedNullBooleanField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Improve the approx SQL representation of Datastore commands (update, delete etc.)
 - Default value for failure_behaviour in `process_task_queues` is now `RAISE_ERROR`. Tasks will no longer fail silently when processed using this method in unit tests.
 - Add djangae.compat to handle SDK structural changes
+- Add a ComputedNullBooleanField
 
 ### Bug fixes:
 

--- a/djangae/fields/computed.py
+++ b/djangae/fields/computed.py
@@ -52,3 +52,7 @@ class ComputedPositiveIntegerField(ComputedFieldMixin, models.PositiveIntegerFie
 
 class ComputedBooleanField(ComputedFieldMixin, models.BooleanField):
     pass
+
+
+class ComputedNullBooleanField(ComputedFieldMixin, models.NullBooleanField):
+    pass

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -238,6 +238,7 @@ Computed fields are:
 * `ComputedIntegerField`
 * `ComputedPositiveIntegerField`
 * `ComputedBooleanField`
+* `ComputedNullBooleanField`
 
 
 ## Example Usages


### PR DESCRIPTION
* This is useful when working with apps with existing data sets / schemas, as attempting to add the ComputedBooleanField retrospectively will blow up.

Note - Didn't add a test as the `ComputedFieldMixin` mixin is already used extensively. 

PR checklist:
- [*] Updated relevant documentation
- [*] Updated CHANGELOG.md 
- [ ] Added tests for my change
