### PR TITLE
Make value_from_datadict return None if value is None. Fixes #1014

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
  - Add .flake8 file to move towards enforcement code standard
  - Add missing `djangae/fields/allkeys-5.2.0.zip` file to `MANIFEST.in`
  - It was possible a `TypeError` would throw when calculating the ComputedCollationField value if the source value was unicode
+ - Make `value_from_datadict` in `forms.fields.ListWidget` return None when the value provided is None as the existing comment describes. This prevents an exception when `save()` is called on a `ListWidget` whose value is `None`.
 
 ## v0.9.10
 

--- a/djangae/forms/fields.py
+++ b/djangae/forms/fields.py
@@ -34,6 +34,10 @@ class ListWidget(forms.TextInput):
             of this widget. Returns None if it's not provided.
         """
         value = data.get(name, '')
+
+        if value is None:
+            return None
+
         if isinstance(value, six.string_types):
             value = value.split(',')
         return [v.strip() for v in value if v.strip()]

--- a/djangae/tests/test_form_fields.py
+++ b/djangae/tests/test_form_fields.py
@@ -107,6 +107,12 @@ class ListFieldFormsTest(TestCase):
         obj = form.save()
         self.assertEqual(obj.list_field, [])
 
+    def test_none_value_in_dict(self):
+        """ Check that value_from_datadict returns None if value provided is None """
+        data = dict(list_field=None)
+        form = ListFieldForm(data)
+        self.assertTrue(form.is_valid())
+
 
 class OrderedModelMultipleChoiceField(TestCase):
 


### PR DESCRIPTION
Fixes #1014.

Summary of changes proposed in this Pull Request:
- Make `value_from_datadict` in `forms.fields.ListWidget` return None when the value provided is `None` as the existing comment describes. This prevents an exception when `save()` is called on a `ListWidget` whose value is `None`.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
