### PR TITLE
Update sleuth to the latest version, remove mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Default value for failure_behaviour in `process_task_queues` is now `RAISE_ERROR`. Tasks will no longer fail silently when processed using this method in unit tests.
 - Add djangae.compat to handle SDK structural changes
 - Add a ComputedNullBooleanField
+- Updated the `sleuth` library in djangae.contrib
 
 ### Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
  - Add missing `djangae/fields/allkeys-5.2.0.zip` file to `MANIFEST.in`
  - It was possible a `TypeError` would throw when calculating the ComputedCollationField value if the source value was unicode
  - Make `value_from_datadict` in `forms.fields.ListWidget` return None when the value provided is None as the existing comment describes. This prevents an exception when `save()` is called on a `ListWidget` whose value is `None`.
+ - Fixed test to remove dependency on mock
 
 ## v0.9.10
 

--- a/djangae/contrib/sleuth.py
+++ b/djangae/contrib/sleuth.py
@@ -41,6 +41,7 @@ def _patch(path, replacement):
     thing = _evaluate_path(
         ".".join(path.split(".")[:-1])
     )
+
     setattr(thing, path.split(".")[-1], replacement)
 
 
@@ -110,6 +111,12 @@ class Switch(ContextDecorator):
         self._original_func = _evaluate_path(func_path)
         self._func_path = func_path
         self._replacement = replacement
+
+        # If the original thing we're replacing is a property, make sure
+        # we make the replacement thing a property too
+        if isinstance(self._original_func, property):
+            self._replacement = property(self._replacement)
+
         self._watch = None
 
     def __enter__(self):

--- a/djangae/tests/test_sql_formatting.py
+++ b/djangae/tests/test_sql_formatting.py
@@ -1,5 +1,3 @@
-import mock
-
 from django.db import connections, models
 
 from djangae.test import TestCase
@@ -188,8 +186,11 @@ REPLACE INTO {} (field1) VALUES (2) WHERE (field1=1)
 class UnrecognisedQueryTypeErrorTest(TestCase):
 
     def test_unrecognised_type_raises_not_implemented_error(self):
-        command = mock.Mock()
-        command.query.serialize.return_value = '{}'
+        class Command(object):
+            class Query(object):
+                def serialize(self, *args, **kwargs):
+                    return '{}'
+            query = Query()
 
         with self.assertRaises(NotImplementedError):
-            generate_sql_representation(command)
+            generate_sql_representation(Command())


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Updates the bundled sleuth.py to latest
- Removes a reference to the "mock" library which was used in a single test (?)

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
