### PR TITLE
Use '' instead of None for an unset namespace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
  - It was possible a `TypeError` would throw when calculating the ComputedCollationField value if the source value was unicode
  - Make `value_from_datadict` in `forms.fields.ListWidget` return None when the value provided is None as the existing comment describes. This prevents an exception when `save()` is called on a `ListWidget` whose value is `None`.
  - Fixed test to remove dependency on mock
+ - Use '' as default namespace for memcache keys, instead of None.
 
 ## v0.9.10
 

--- a/djangae/db/backends/appengine/caching.py
+++ b/djangae/db/backends/appengine/caching.py
@@ -210,7 +210,7 @@ def _get_entity_from_memcache(cache_key):
 def _get_entity_from_memcache_by_key(key):
     # We build the cache key for the ID of the instance
     cache_key, _ = _get_cache_key_and_model_from_datastore_key(key)
-    namespace = key.namespace() or None
+    namespace = key.namespace() or ''
     return _get_entity_from_memcache(_apply_namespace(cache_key, namespace))
 
 
@@ -289,7 +289,7 @@ def get_from_cache_by_key(key):
         return None
 
     context = get_context()
-    namespace = key.namespace() or None
+    namespace = key.namespace() or ''
     ret = None
     if context.context_enabled:
         # It's safe to hit the context cache, because a new one was pushed on the stack at the start of the transaction


### PR DESCRIPTION
Fixes broken memcache caching if the default DATABASE namespace is set to ''.

This matches the default namespace returned by App Engine.  Otherwise, you
end up in a situation where the getter code uses a (memcache) key with a stringified
None, but the setter code is using a stringified ''.  i.e.  You can't
retrieve anything from the cache.

An alternate fix would be to fix the add_... code to do the same or None check

Summary of changes proposed in this Pull Request:
- Changes default namespace used by memcache to '' instead of None

This change takes our cache hit rate from ~8% up to >90% in testing.  I don't have historical cache hit data, but I suspect this was made worse by the [workaround](https://github.com/potatolondon/djangae/issues/789#issuecomment-264225096) for issue #789 

