### PR TITLE
Allow customizing the app_id and set a reasonable default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
  - Make `value_from_datadict` in `forms.fields.ListWidget` return None when the value provided is None as the existing comment describes. This prevents an exception when `save()` is called on a `ListWidget` whose value is `None`.
  - Fixed test to remove dependency on mock
  - Use '' as default namespace for memcache keys, instead of None.
+ - Set a default app_id (`managepy`) so you can use use gcloud compatible app.yaml files (which cannot contain an app_id).  Override with --app_id
 
 ## v0.9.10
 

--- a/djangae/core/management/__init__.py
+++ b/djangae/core/management/__init__.py
@@ -13,6 +13,7 @@ DEFAULTS = {
     "api_port": 8002,
     "automatic_restart": "True",
     "allow_skipped_files": "True",
+    "app_id": "managepy",
 }
 
 
@@ -34,7 +35,10 @@ def execute_from_command_line(argv=None, **sandbox_overrides):
     argv = ['manage.py'] + other_args + stashed_args
 
     overrides = DEFAULTS.copy()
-    overrides.update(sandbox_overrides, app_id=djangae_namespace.app_id)
+    overrides.update(sandbox_overrides)
+
+    if djangae_namespace.app_id:
+        overrides.update(app_id=djangae_namespace.app_id)
 
     return _execute_from_command_line(djangae_namespace.sandbox, argv, parser=djangae_parser, **overrides)
 


### PR DESCRIPTION
Priority:
1) "managepy" (default)
2) value from sandbox_overrides
3) --app_id flag

This also fixes the issue where if there was no application: in the app.yaml
(i.e.  using gcloud) the default app_id will be "None", which is not valid
as a datastore namespace because it's not all lowercase.

Fixes #1008.
Helps with #972.
