### PR TITLE
Security tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added custom `FileField` and `ImageField` which accept an optional `url_field` argument to allow you to specify the name of another field on the model on which the URL to the file or image is cached.
 - Add a ComputedNullBooleanField
 - Updated the `sleuth` library in djangae.contrib
+- Updated the csrf session check to respect Django's `CSRF_USE_SESSIONS` flag
 
 ### Bug fixes:
 
@@ -36,6 +37,7 @@
  - Fixed test to remove dependency on mock
  - Use '' as default namespace for memcache keys, instead of None.
  - Set a default app_id (`managepy`) so you can use use gcloud compatible app.yaml files (which cannot contain an app_id).  Override with --app_id
+ - Restricted access to the `clearsessions` view to tasks and admins only
 
 ## v0.9.10
 

--- a/djangae/checks.py
+++ b/djangae/checks.py
@@ -1,5 +1,5 @@
 import os
-
+from django import VERSION
 from django.conf import settings
 from django.core.checks import register, Tags, Error, Warning
 
@@ -30,7 +30,7 @@ def check_session_csrf_enabled(app_configs=None, **kwargs):
 
     # Django 1.11 has built-in session-based CSRF tokens, so if that's enabled
     # we don't need to check for the mozilla version
-    if getattr(settings, "CSRF_USE_SESSIONS", False):
+    if VERSION > (1, 11) and getattr(settings, "CSRF_USE_SESSIONS", False):
         return []
 
     # Django >= 1.10 has a MIDDLEWARE setting, which is None by default. Convert

--- a/djangae/checks.py
+++ b/djangae/checks.py
@@ -28,6 +28,11 @@ CSP_SOURCE_NAMES = [
 def check_session_csrf_enabled(app_configs=None, **kwargs):
     errors = []
 
+    # Django 1.11 has built-in session-based CSRF tokens, so if that's enabled
+    # we don't need to check for the mozilla version
+    if getattr(settings, "CSRF_USE_SESSIONS", False):
+        return []
+
     # Django >= 1.10 has a MIDDLEWARE setting, which is None by default. Convert
     # it to a list, it might be a tuple.
     middleware = list(getattr(settings, 'MIDDLEWARE', []) or [])

--- a/djangae/views.py
+++ b/djangae/views.py
@@ -86,8 +86,6 @@ def internalupload(request):
 
 @environment.task_or_admin_only
 def clearsessions(request):
-    if not environment.is_in_cron():
-        return HttpResponse(status=403)
     engine = import_module(settings.SESSION_ENGINE)
     try:
         engine.SessionStore.clear_expired()

--- a/djangae/views.py
+++ b/djangae/views.py
@@ -84,6 +84,7 @@ def internalupload(request):
         return HttpResponseServerError()
 
 
+@environment.task_or_admin_only
 def clearsessions(request):
     if not environment.is_in_cron():
         return HttpResponse(status=403)

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,3 +24,8 @@ This middleware applies the patches and then raises `django.core.exceptions.Midd
 Use the `dumpurls` management command to generate a report listing all the configured URL patterns in your project.
 
 For each pattern, the report shows the regular expression for the full path, the Python dotted module name for the view that handles requests, and the names of decorators that may have been applied to the view.
+
+# CSRF session check
+
+The built in Djangae checks enforce the use of session-based (rather than cookie-based) CSRF tokens. To satisfy this check
+either the `CSRF_USE_SESSIONS` setting must be True, or Mozilla's `session-csrf` app must be installed and configured.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -7,3 +7,5 @@ You cannot run a management command to clear django sessions on appengine, djang
     - description: clear sessions
       url: /_ah/clearsessions
       schedule: every 24 hours
+
+The clearsessions view is restricted to tasks and admins only


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Makes the CSRF session check respect the newish `CSRF_USE_SESSIONS` setting in Django
- Locks down the clearsessions view to tasks or admins only

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
