### PR TITLE
SQL representation unicode error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
  - Use '' as default namespace for memcache keys, instead of None.
  - Set a default app_id (`managepy`) so you can use use gcloud compatible app.yaml files (which cannot contain an app_id).  Override with --app_id
  - Restricted access to the `clearsessions` view to tasks and admins only
+ - Fix unicode error when creating a SQL representation
 
 ## v0.9.10
 

--- a/djangae/db/backends/appengine/formatting.py
+++ b/djangae/db/backends/appengine/formatting.py
@@ -39,7 +39,7 @@ def _generate_values_expression(instances, columns):
             needs_quoting = isinstance(value, six.string_types)
 
             if needs_quoting:
-                row.append('"%s"' % value)
+                row.append('"{}"'.format(value))
             else:
                 row.append(six.text_type(value))
 
@@ -170,5 +170,3 @@ def generate_sql_representation(command):
         return _generate_update_sql(command, representation)
 
     raise NotImplementedError("Unrecognized query type")
-
-    

--- a/djangae/tests/test_sql_formatting.py
+++ b/djangae/tests/test_sql_formatting.py
@@ -194,3 +194,11 @@ class UnrecognisedQueryTypeErrorTest(TestCase):
 
         with self.assertRaises(NotImplementedError):
             generate_sql_representation(Command())
+
+
+class GenerateValuesExpressionTest(TestCase):
+    """Tests for `djangae.db.backends.appengine.formatting._generate_values_expression`."""
+
+    def test_unicode_error(self):
+        """Test that _generate_values_expression does not raise a unicode error."""
+        pass

--- a/djangae/tests/test_sql_formatting.py
+++ b/djangae/tests/test_sql_formatting.py
@@ -1,8 +1,11 @@
+# -*- coding: utf8 -*-
 from django.db import connections, models
 
 from djangae.test import TestCase
 
-from djangae.db.backends.appengine.formatting import generate_sql_representation
+from djangae.db.backends.appengine.formatting import (
+    _generate_values_expression, generate_sql_representation
+)
 from djangae.db.backends.appengine.commands import (
     SelectCommand, InsertCommand, DeleteCommand, UpdateCommand
 )
@@ -201,4 +204,9 @@ class GenerateValuesExpressionTest(TestCase):
 
     def test_unicode_error(self):
         """Test that _generate_values_expression does not raise a unicode error."""
-        pass
+        class Mock(object):
+            value1 = u'ûnīçøde hërę'
+
+        m = Mock()
+        output = _generate_values_expression([m], ['value1'])
+        self.assertEqual(output, '("' + m.value1 + '")')


### PR DESCRIPTION
Fixes #1027 

Summary of changes proposed in this Pull Request:
- Test to trigger unicode error.
- Small change to how a unicode value is quoted for the SQL representation.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
