### PR TITLE
Tweak retry time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
  - Use '' as default namespace for memcache keys, instead of None.
  - Set a default app_id (`managepy`) so you can use use gcloud compatible app.yaml files (which cannot contain an app_id).  Override with --app_id
  - Restricted access to the `clearsessions` view to tasks and admins only
+ - Fixed the `sleep()` time in `djangae.utils.retry` which was sleeping in `ns` rather than `ms`
 
 ## v0.9.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Add a ComputedNullBooleanField
 - Updated the `sleuth` library in djangae.contrib
 - Updated the csrf session check to respect Django's `CSRF_USE_SESSIONS` flag
+- `djangae.utils.retry` now waits for 375ms by default before retrying to avoid excerbating contention (previous value of 100ms was far too low).
+- `djangae.utils.retry` now accepts overriding the initial retry time with the `_initial_wait` kwarg.
 
 ### Bug fixes:
 

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -112,7 +112,7 @@ def retry(func, *args, **kwargs):
                 return func(*args, **kwargs)
             except (datastore_errors.Error, apiproxy_errors.Error, TransactionFailedError) as exc:
                 logger.info("Retrying function: %s(%s, %s) - %s", str(func), str(args), str(kwargs), str(exc))
-                time.sleep(timeout_ms / 1000000.0)
+                time.sleep(timeout_ms * 0.001)
                 timeout_ms *= 2
                 if i > retries:
                     raise exc

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -105,7 +105,7 @@ def retry(func, *args, **kwargs):
     retries = kwargs.pop('_retries', 3)
     i = 0
     try:
-        timeout_ms = 100
+        timeout_ms = kwargs.pop('_initial_wait', 375)  # Try 375, 750, 1500
         while True:
             try:
                 i += 1


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- This increases the min wait time for retry from 100ms to 375ms as the previous value caused more problems than it solved (increased contention and likelihood of transaction failure)
- The value is now overridable through the `_initial_wait` kwarg.

This is a stop-gap improvement as `retry()` needs a proper cleanup and tests. I haven't added documentation as the function is currently undocumented and will be undergoing API change soon so it's probably best not to advertise it too much now!

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
