### PR TITLE
Fix cross-database support for RelatedSetField and RelatedListField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
  - Restricted access to the `clearsessions` view to tasks and admins only
  - Fixed the `sleep()` time in `djangae.utils.retry` which was sleeping in `ns` rather than `ms`
  - Fix unicode error when creating a SQL representation
+ - Fix cross-database relationship support for `RelatedSetField` and `RelatedListField`.
 
 ## v0.9.10
 

--- a/djangae/fields/related.py
+++ b/djangae/fields/related.py
@@ -260,7 +260,7 @@ class RelatedIteratorManagerBase(object):
         )
 
     def get_queryset(self):
-        db = self._db or router.db_for_read(self.instance.__class__, instance=self.instance)
+        db = self._db or router.db_for_read(self.model, instance=self.instance)
 
         if (hasattr(self.instance, "_prefetched_objects_cache") and
             self.field.name in self.instance._prefetched_objects_cache):

--- a/testapp/testapp/routers.py
+++ b/testapp/testapp/routers.py
@@ -1,0 +1,11 @@
+class TestRouter(object):
+    """A router for tests that allows setting a model's database explicitly."""
+
+    def _get_db(self, model, **hints):
+        return getattr(model, 'test_database', None)
+
+    def db_for_read(self, model, **hints):
+        return self._get_db(model, **hints)
+
+    def db_for_write(self, model, **hints):
+        return self._get_db(model, **hints)

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -141,6 +141,8 @@ DATABASES = {
     },
 }
 
+DATABASE_ROUTERS = ['testapp.routers.TestRouter']
+
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 


### PR DESCRIPTION
Fixes #1034.

Summary of changes proposed in this Pull Request:
- Fix cross-database support for `RelatedSetField` and `RelatedListField`.
- Introduce `testapp.routers.TestRouter` so that models in tests can explicitly choose a database.

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
