### PR TITLE
Lock down the backup view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
  - Fixed the `sleep()` time in `djangae.utils.retry` which was sleeping in `ns` rather than `ms`
  - Fix unicode error when creating a SQL representation
  - Fix cross-database relationship support for `RelatedSetField` and `RelatedListField`.
+ - Locked down the backup creation view in `djangae.contrib.backups`
+ - Fixed the backup creation URL to have a trailing slash (optional, to prevent breaking apps)
 
 ## v0.9.10
 

--- a/djangae/contrib/backup/tests/test_views.py
+++ b/djangae/contrib/backup/tests/test_views.py
@@ -1,3 +1,5 @@
+import os
+
 from djangae.contrib import sleuth
 from djangae.test import TestCase
 
@@ -36,7 +38,12 @@ class DataStoreBackupTest(TestCase):
                         DJANGAE_BACKUP_EXCLUDE_MODELS=[
                             'gauth_datastore.Group'
                         ]):
-                    create_datastore_backup(None)
+
+                    try:
+                        os.environ["HTTP_X_APPENGINE_CRON"] = "1"
+                        create_datastore_backup(None)
+                    finally:
+                        del os.environ["HTTP_X_APPENGINE_CRON"]
 
         # assert task was triggered
         tasks = self.taskqueue_stub.get_filtered_tasks()

--- a/djangae/contrib/backup/urls.py
+++ b/djangae/contrib/backup/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
 
 from . import views
 
 urlpatterns = (
     url(
-        '^create-datastore-backup$',
+        '^create-datastore-backup/?$',
         views.create_datastore_backup,
         name="create_datastore_backup"
     ),

--- a/djangae/contrib/backup/views.py
+++ b/djangae/contrib/backup/views.py
@@ -3,7 +3,7 @@ import urllib
 
 from django.apps import apps
 from django.http import HttpResponse
-from djangae.environment import application_id
+from djangae.environment import task_or_admin_only
 from google.appengine.api import taskqueue
 
 from .utils import get_backup_setting, get_backup_path
@@ -15,6 +15,7 @@ GAE_BUILTIN_MODULE = "ah-builtin-python-bundle"
 BACKUP_HANDLER = "/_ah/datastore_admin/backup.create"
 
 
+@task_or_admin_only
 def create_datastore_backup(request):
     """Creates a datastore backup based on the DJANGAE_BACKUP_X settings."""
     enabled = get_backup_setting("ENABLED")


### PR DESCRIPTION
Fixes #1038 

Summary of changes proposed in this Pull Request:
- Locks down the backup creation view to admins and tasks
- Fixes the URL to match the documentation

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
