### PR TITLE
1055 import error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 -
 
 ### Bug fixes:
--
+
+- Fixed `ImportError` when running `./manage.py runserver` and the SDK is not already on the Python import path.
+
 
 ## v0.9.11
 

--- a/djangae/environment.py
+++ b/djangae/environment.py
@@ -9,6 +9,10 @@ from django.http import HttpResponseForbidden
 from djangae.utils import memoized
 
 
+# No SDK imports allowed in module namespace because `./manage.py runserver`
+# imports this before the SDK is added to sys.path. See bugs #899, #1055.
+
+
 def application_id():
     from google.appengine.api import app_identity
 

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -9,6 +9,8 @@ import warnings
 from socket import socket
 
 
+# No SDK imports allowed in module namespace because `./manage.py runserver`
+# imports this before the SDK is added to sys.path. See bugs #899, #1055.
 logger = logging.getLogger(__name__)
 
 

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -6,10 +6,6 @@ import logging
 import sys
 import time
 import warnings
-
-from google.appengine.api import datastore_errors
-from google.appengine.runtime import apiproxy_errors
-from google.appengine.runtime import DeadlineExceededError
 from socket import socket
 
 
@@ -103,6 +99,10 @@ def retry(func, *args, **kwargs):
     """ Calls a function that may intermittently fail, catching the given error(s) and (re)trying
         for a maximum of `_attempts` times.
     """
+    # Imported here to fix ImportError (see bugs #899, #1055).
+    from google.appengine.api import datastore_errors
+    from google.appengine.runtime import apiproxy_errors
+    from google.appengine.runtime import DeadlineExceededError
     from djangae.db.transaction import TransactionFailedError  # Avoid circular import
     # Slightly weird `.pop(x, None) or default` thing here due to not wanting to repeat the tuple of
     # default things in `retry_on_error` and having to do inline imports


### PR DESCRIPTION
Fixes #1055 .

The current logic allows one to have the SDK tools (dev_appserver.py, etc.)
on one's $PATH, and then Djangae works out where the SDK is installed and
adds it to sys.path, after which it is OK to import things from the SDK
modules.

But that got broke because `./manage.py runserver` indirectly loads this
module, which was pulling in things from the SDK. If you don't have the
SDK already already on sys.path, this would result in ImportError.

This fix moves the SDK imports inside the function (and adds comments which may or may not prevent this bug happening again).