### PR TITLE
Use `--no-binary :all:` when installing Django for tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Bug fixes:
 
 - Fixed `ImportError` when running `./manage.py runserver` and the SDK is not already on the Python import path.
-- Fix a ValueError when sharding string keys in the migrations mapper library
+- Fix a ValueError when sharding string keys in the migrations mapper library.
+- Fixed installing dependencies when running tests with pip version 10.
 
 ## v0.9.11
 

--- a/testapp/install_deps.py
+++ b/testapp/install_deps.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     p.wait()
 
     print("Installing Django {}".format(DJANGO_VERSION))
-    args = ["pip", "install", "--no-deps", DJANGO_FOR_PIP, "-t", TARGET_DIR, "-I", "--no-use-wheel"]
+    args = ["pip", "install", "--no-deps", DJANGO_FOR_PIP, "-t", TARGET_DIR, "-I", "--no-binary", ":all:"]
     p = subprocess.Popen(args)
     p.wait()
 


### PR DESCRIPTION
Pip version 10 dropped support for the `--no-use-wheel` flag, which
meant that the test dependencies wouldn't install properly. This
change is compatiblie with pip versions 8 and 9 too (I didn't test
earlier versions).

Fixes #1063 .
