### PR TITLE
Remove slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The best way to run Django on Google App Engine.
 Djangae (djan-gee) is a Django app that allows you to run Django applications on Google App Engine, including (if you
 want to) using Django's models with the App Engine Datastore as the underlying database.
 
-- Documentation: https://djangae.readthedocs.io/
-- Google Group: https://groups.google.com/forum/#!forum/djangae-users
-- Website: https://djangae.org
-- GitHub: https://github.com/potatolondon/djangae
-- Gitter: https://gitter.im/potatolondon/djangae
+- :closed_book: Documentation: https://djangae.readthedocs.io/
+- :busts_in_silhouette: Google Group: https://groups.google.com/forum/#!forum/djangae-users
+- :earth_africa: Website: https://djangae.org
+- :octocat: GitHub: https://github.com/potatolondon/djangae
+- :speech_balloon: Gitter: https://gitter.im/potatolondon/djangae
 
 **Note: Djangae is under heavy development, stability is not guaranteed. See [1.0 release changes issue](https://github.com/potatolondon/djangae/issues/593) to follow progress on Djangae 1.0 release.**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Djangae
 
-[![Join the chat at https://gitter.im/potatolondon/djangae](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/potatolondon/djangae?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![build-status-image]][travis] [![codecov.io](https://img.shields.io/codecov/c/github/potatolondon/djangae/master.svg)](https://codecov.io/github/potatolondon/djangae?branch=master)
+[![Join the chat at https://gitter.im/potatolondon/djangae](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/potatolondon/djangae?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![build-status-image]][travis]
 
 The best way to run Django on Google App Engine.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Djangae
 
-[![Join the chat at https://gitter.im/potatolondon/djangae](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/potatolondon/djangae?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-[![build-status-image]][travis] [![codecov.io](https://img.shields.io/codecov/c/github/potatolondon/djangae/master.svg)](https://codecov.io/github/potatolondon/djangae?branch=master)
+[![Join the chat at https://gitter.im/potatolondon/djangae](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/potatolondon/djangae?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![build-status-image]][travis] [![codecov.io](https://img.shields.io/codecov/c/github/potatolondon/djangae/master.svg)](https://codecov.io/github/potatolondon/djangae?branch=master)
 
 The best way to run Django on Google App Engine.
 
@@ -11,9 +9,9 @@ want to) using Django's models with the App Engine Datastore as the underlying d
 
 - Documentation: https://djangae.readthedocs.io/
 - Google Group: https://groups.google.com/forum/#!forum/djangae-users
-- Website: https://potatolondon.github.io/djangae/
+- Website: https://djangae.org
 - GitHub: https://github.com/potatolondon/djangae
-- Slack: https://djangae.slack.com
+- Gitter: https://gitter.im/potatolondon/djangae
 
 **Note: Djangae is under heavy development, stability is not guaranteed. See [1.0 release changes issue](https://github.com/potatolondon/djangae/issues/593) to follow progress on Djangae 1.0 release.**
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The best way to run Django on Google App Engine.
 Djangae (djan-gee) is a Django app that allows you to run Django applications on Google App Engine, including (if you
 want to) using Django's models with the App Engine Datastore as the underlying database.
 
-- :closed_book: Documentation: https://djangae.readthedocs.io/
-- :busts_in_silhouette: Google Group: https://groups.google.com/forum/#!forum/djangae-users
-- :earth_africa: Website: https://djangae.org
-- :octocat: GitHub: https://github.com/potatolondon/djangae
-- :speech_balloon: Gitter: https://gitter.im/potatolondon/djangae
+:earth_africa:&nbsp;&nbsp;[Website](https://djangae.org)&nbsp;&nbsp;|&nbsp;&nbsp;
+:octocat:&nbsp;&nbsp;[GitHub](https://github.com/potatolondon/djangae)&nbsp;&nbsp;|&nbsp;&nbsp;
+:closed_book:&nbsp;&nbsp; [Docs](https://djangae.readthedocs.io/)&nbsp;&nbsp;|&nbsp;&nbsp;
+:speech_balloon:&nbsp;&nbsp;[Gitter](https://gitter.im/potatolondon/djangae)&nbsp;&nbsp;|&nbsp;&nbsp;
+:busts_in_silhouette:&nbsp;&nbsp;[Google Group](https://groups.google.com/forum/#!forum/djangae-users)  
 
 **Note: Djangae is under heavy development, stability is not guaranteed. See [1.0 release changes issue](https://github.com/potatolondon/djangae/issues/593) to follow progress on Djangae 1.0 release.**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,9 +7,11 @@ want to) using Django's models with the App Engine Datastore as the underlying d
 
 Google Group: [https://groups.google.com/forum/#!forum/djangae-users](https://groups.google.com/forum/#!forum/djangae-users)
 
-Website: [https://potatolondon.github.io/djangae/](https://potatolondon.github.io/djangae/)
+Website: [https://djangae.org](https://djangae.org)
 
 GitHub: [https://github.com/potatolondon/djangae](https://github.com/potatolondon/djangae)
+
+Gitter: [https://gitter.im/potatolondon/djangae](https://gitter.im/potatolondon/djangae)
 
 **Note: Djangae is under heavy development, stability is not guaranteed. A 1.0 release will happen when it's ready**
 


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Remove the (unmanned) Slack link
- Replace with the (usually manned) Gitter link
- Clean up the link section of the readme

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
