### PR TITLE
fix a couple sql unicode bugs; and fix quoting of sql value literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Fixed Djangae's project description on pypi.org.
 - Fixed installing dependencies when running tests with pip version 10.
 - Replace binary values in sql value generation with `<binary>` identifier.
+- Fix a couple sql unicode bugs.
+- Use single quotes for sql string literals, and do not quote integers.
 
 ## v0.9.11
 

--- a/djangae/db/backends/appengine/base.py
+++ b/djangae/db/backends/appengine/base.py
@@ -18,6 +18,7 @@ from django.db.backends.base.features import BaseDatabaseFeatures
 from django.db.backends.base.validation import BaseDatabaseValidation
 from django.db.backends.base.creation import BaseDatabaseCreation
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.utils.encoding import smart_text
 
 from google.appengine.api.datastore_types import Blob, Text
 from google.appengine.api import datastore, datastore_errors
@@ -351,7 +352,7 @@ class DatabaseOperations(BaseDatabaseOperations):
             in your SQL. Technically this is a bug in Django for assuming that sql is ASCII but
             it's only our backend that will ever trigger the problem
         """
-        return u"QUERY = {}".format(sql)
+        return u"QUERY = {}".format(smart_text(sql))
 
     def fetch_returned_insert_id(self, cursor):
         return cursor.lastrowid

--- a/djangae/db/backends/appengine/commands.py
+++ b/djangae/db/backends/appengine/commands.py
@@ -13,7 +13,7 @@ import django
 from django.db import DatabaseError
 from django.db import IntegrityError
 from django.utils import six
-from django.utils.encoding import python_2_unicode_compatible
+from django.utils.encoding import python_2_unicode_compatible, force_str
 
 from google.appengine.api import datastore, datastore_errors, memcache
 from google.appengine.datastore import datastore_stub_util
@@ -542,7 +542,7 @@ class SelectCommand(object):
         return self.results_returned
 
     def __repr__(self):
-        return generate_sql_representation(self)
+        return force_str(generate_sql_representation(self))
 
     def __mod__(self, params):
         return repr(self)

--- a/djangae/db/backends/appengine/query.py
+++ b/djangae/db/backends/appengine/query.py
@@ -665,9 +665,10 @@ class Query(object):
 
                 if node.children:
                     for lookup in node.children:
-                        query[''.join([lookup.column, lookup.operator])] = six.text_type("NULL" if lookup.value is None else lookup.value)
+
+                        query[''.join([lookup.column, lookup.operator])] = _serialize_sql_value(lookup.value)
                 else:
-                    query[''.join([node.column, node.operator])] = six.text_type("NULL" if node.value is None else node.value)
+                    query[''.join([node.column, node.operator])] = _serialize_sql_value(node.value)
 
                 where.append(query)
 
@@ -683,6 +684,11 @@ INVALID_ORDERING_FIELD_MESSAGE = (
     "field and instead order on that."
 )
 
+def _serialize_sql_value(value):
+    if isinstance(value, six.integer_types):
+        return value
+    else:
+        return six.text_type("NULL" if value is None else value)
 
 def _get_parser(query, connection=None):
     version = django.VERSION[:2]

--- a/djangae/tests/test_form_fields.py
+++ b/djangae/tests/test_form_fields.py
@@ -7,7 +7,7 @@ from django.utils.six.moves import range
 # DJANGAE
 from djangae.fields import ListField, RelatedListField
 from djangae.test import TestCase
-from djangae.tests.test_db_fields import JSONFieldModel, NullableJSONFieldModel
+from djangae.tests.test_db_fields import CharFieldModel, JSONFieldModel, NullableJSONFieldModel
 
 
 class JSONModelForm(forms.ModelForm):
@@ -30,12 +30,6 @@ class ListFieldForm(forms.ModelForm):
     class Meta:
         model = BlankableListFieldModel
         fields = ['list_field']
-
-
-class CharFieldModel(models.Model):
-    """Simple model we can reference as the related model in RelatedListField."""
-    string_field = models.CharField(max_length=2)
-
 
 class RelatedListFieldModel(models.Model):
     related_list_field = RelatedListField(CharFieldModel)
@@ -123,7 +117,7 @@ class OrderedModelMultipleChoiceField(TestCase):
         """
         instance_one, instance_two, instance_three = [
             CharFieldModel.objects.create(
-                string_field=str(x)
+                char_field=str(x)
             ) for x in range(3)
         ]
         data = dict(related_list_field=[

--- a/djangae/tests/test_sql_formatting.py
+++ b/djangae/tests/test_sql_formatting.py
@@ -100,6 +100,19 @@ SELECT (*) FROM {} ORDER BY field1, field2 DESC
 
         self.assertEqual(expected, sql)
 
+    def test_unicode_error(self):
+        command = SelectCommand(
+            connections['default'],
+            FormattingTestModel.objects.filter(field2=u"Jacqu\xe9s").query
+        )
+        sql = generate_sql_representation(command)
+
+        expected = u"""
+SELECT (*) FROM {} WHERE (field2='Jacqu\xe9s')
+""".format(FormattingTestModel._meta.db_table).strip()
+
+        self.assertEqual(expected, sql)
+
 
 class InsertFormattingTest(TestCase):
     def test_single_insert(self):
@@ -118,7 +131,7 @@ class InsertFormattingTest(TestCase):
         sql = generate_sql_representation(command)
 
         expected = """
-INSERT INTO {} (field1, field2, field3, field4) VALUES (1, "Two", "Three", "<binary>")
+INSERT INTO {} (field1, field2, field3, field4) VALUES (1, 'Two', 'Three', '<binary>')
 """.format(FormattingTestModel._meta.db_table).strip()
 
         self.assertEqual(expected, sql)
@@ -210,4 +223,4 @@ class GenerateValuesExpressionTest(TestCase):
 
         m = Mock()
         output = _generate_values_expression([m], ['value1'])
-        self.assertEqual(output, '("' + m.value1 + '")')
+        self.assertEqual(output, '(\'' + m.value1 + '\')')


### PR DESCRIPTION
Fixes #1075.

Summary of changes proposed in this Pull Request:
- Need to properly encode/decode utf8 in a couple places when generating sql
- Sql string literals should be single quoted (not double), and ints shouldn't be quoted at all

PR checklist:
- [N/A] Updated relevant documentation
- [X] Updated CHANGELOG.md 
- [X] Added tests for my change
