### PR TITLE
Fix a caching bug caused by the non_atomic decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add an option to ignore pull tasks in testing
 - Fix occasions where the default value of a field would not be correctly set on save()
 - Simplified the atomic() and non_atomic() decorator/context managers to hopefully eliminate edge-case/threading bugs that have been seen.
+- Fix a bug where the context cache would be incorrectly set after leaving a non_atomic block
 
 ## v0.9.11
 

--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -373,10 +373,10 @@ class NonAtomicDecorator(ContextDecorator):
         _STORAGE.transaction_stack.append(new_transaction)
         _STORAGE.transaction_stack[-1]._enter()
 
-        # Store the current in-context stack
-        state.original_stack = copy.deepcopy(context.stack)
+        # Store the current state of the stack (aside from the first entry)
+        state.original_stack = copy.deepcopy(context.stack.stack[1:])
 
-        # Unwind the in-context stack
+        # Unwind the in-context stack leaving just the first entry
         while len(context.stack.stack) > 1:
             context.stack.pop(discard=True)
 
@@ -385,7 +385,9 @@ class NonAtomicDecorator(ContextDecorator):
         context = caching.get_context()
         transaction = _STORAGE.transaction_stack.pop()
         transaction._exit()
-        context.stack = state.original_stack
+
+        # Restore the context stack as it was
+        context.stack.stack = context.stack.stack + state.original_stack
 
 
 non_atomic = NonAtomicDecorator

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -279,3 +279,17 @@ class TransactionStateTests(TestCase):
             txn.refresh_if_unread(apple)
 
             self.assertEqual(apple.color, "Pink")
+
+    def test_non_atomic_only(self):
+        from .test_connector import TestFruit
+
+        apple = TestFruit.objects.create(name="Apple", color="Red")
+        apple.save()
+
+        apple2 = TestFruit.objects.get(pk=apple.pk)
+
+        with transaction.non_atomic():
+            apple.delete()
+
+        # Apple should no longer be in the cache!
+        self.assertRaises(TestFruit.DoesNotExist, apple2.refresh_from_db)


### PR DESCRIPTION
Fixes a bug that occurs if you have a non_atomic() block, and delete something within it. The cache before the block would be restored and the deleted item would be returned in a subsequent .get()

Summary of changes proposed in this Pull Request:
- Add test to prove issue
- Fix the atomic decorator

PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
