### PR TITLE
Transaction should track created entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Additional option to not start mapper pipeline; and provide outputs to finalize function.
 - `atomic()` (when used as a context manager) now returns an object representing the current transaction
 - Added `djangae.db.transaction.current_transaction()` to return the same thing from inside an `atomic()` decorator
-- Added `Transaction.has_been_read(instance)` and `Transaction.refresh_if_unread(instance)` which allows writing safe transactional code.
+- Added `Transaction.has_been_read(instance)`, `Transaction.has_been_written` and `Transaction.refresh_if_unread(instance)` which allows writing safe transactional code.
 
 ### Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Additional option to not start mapper pipeline; and provide outputs to finalize function.
 - `atomic()` (when used as a context manager) now returns an object representing the current transaction
 - Added `djangae.db.transaction.current_transaction()` to return the same thing from inside an `atomic()` decorator
-- Added `Transaction.has_already_been_read(instance)` and `Transaction.refresh_if_unread(instance)` which allows writing safe transactional code.
+- Added `Transaction.has_been_read(instance)` and `Transaction.refresh_if_unread(instance)` which allows writing safe transactional code.
 
 ### Bug fixes:
 

--- a/djangae/db/backends/appengine/rpc.py
+++ b/djangae/db/backends/appengine/rpc.py
@@ -15,6 +15,7 @@ from google.appengine.api.datastore import Query, RunInTransaction  # noqa
 
 # This signal exists mainly so the atomic decorator can find out what's happened
 datastore_get = django.dispatch.Signal(providing_args=["keys"])
+datastore_post_put = django.dispatch.Signal(providing_args=["keys"])
 
 
 def Get(keys, **kwargs):
@@ -23,6 +24,8 @@ def Get(keys, **kwargs):
 
 
 def Put(*args, **kwargs):
+    result = _Put(*args, **kwargs)
+    datastore_post_put.send(sender=Put, keys=[result] if isinstance(result, Key) else result)
     return _Put(*args, **kwargs)
 
 

--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -22,25 +22,35 @@ def in_atomic_block():
 def _datastore_get_handler(signal, sender, keys, **kwargs):
     txn = current_transaction()
     if txn:
-        txn._seen_keys.update(set(keys))
+        txn._fetched_keys.update(set(keys))
+
+
+def _datastore_post_put_handler(signal, sender, keys, **kwargs):
+    txn = current_transaction()
+    if txn:
+        txn._put_keys.update(set(keys))
 
 
 rpc.datastore_get.connect(_datastore_get_handler, dispatch_uid='_datastore_get_handler')
+rpc.datastore_post_put.connect(_datastore_post_put_handler, dispatch_uid='_datastore_post_put_handler')
 
 
 class Transaction(object):
     def __init__(self, connection):
         self._connection = connection
         self._previous_connection = None
-        self._seen_keys = set()
+        self._fetched_keys = set()
+        self._put_keys = set()
 
     def enter(self):
-        self._seen_keys = set()
+        self._fetched_keys = set()
+        self._put_keys = set()
         self._enter()
 
     def exit(self):
         self._exit()
-        self._seen_keys = set()
+        self._fetched_keys = set()
+        self._put_keys = set()
 
     def _enter(self):
         raise NotImplementedError()
@@ -48,7 +58,8 @@ class Transaction(object):
     def _exit(self):
         raise NotImplementedError()
 
-    def has_been_read(self, instance, connection=None):
+    def _check_instance_actions(self, instance, connection=None, check_fetched=True, check_put=True):
+        """ Return True if the instance has been used in ANY of the given actions. """
         if instance.pk is None:
             return False
 
@@ -62,7 +73,20 @@ class Transaction(object):
             namespace=connection.settings_dict.get('NAMESPACE', '')
         )
 
-        return key in self._seen_keys
+        if check_put and key in self._put_keys:
+            return True
+
+        if check_fetched and key in self._fetched_keys:
+            return True
+
+        return False
+
+
+    def has_been_read(self, instance, connection=None):
+        return self._check_instance_actions(instance, connection, check_fetched=True, check_put=False)
+
+    def has_been_written(self, instance, connection=None):
+        return self._check_instance_actions(instance, connection, check_fetched=False, check_put=True)
 
     def refresh_if_unread(self, instance):
         """
@@ -91,12 +115,12 @@ class Transaction(object):
                     self.save()
         """
 
-        if self.has_already_been_read(instance):
-            # If the instance has already been read this transaction,
-            # then don't refresh it again.
+        # If the instance has already been read or put in this transaction, then don't refresh it
+        # (again)
+        if self._check_instance_actions(instance):
             return
-        else:
-            instance.refresh_from_db()
+
+        instance.refresh_from_db()
 
     def _commit(self):
         if self._connection:

--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -48,7 +48,7 @@ class Transaction(object):
     def _exit(self):
         raise NotImplementedError()
 
-    def has_already_been_read(self, instance, connection=None):
+    def has_been_read(self, instance, connection=None):
         if instance.pk is None:
             return False
 

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -282,8 +282,8 @@ class TransactionStateTests(TestCase):
             self.assertEqual(apple.color, "Pink")
 
     def test_refresh_if_unread_for_created_objects(self):
-        """ refresh_if_unread should account for objects which have been *created* within the
-            transaction, as well as ones that have been read.
+        """ refresh_if_unread should not refresh objects which have been *created* within the
+            transaction, as at the DB level they will not exist.
         """
         from .test_connector import TestFruit
 
@@ -292,7 +292,7 @@ class TransactionStateTests(TestCase):
             apple = TestFruit.objects.create(name="Apple", color="Red")
             apple.color = "Pink"  # Deliberately don't save
             txn.refresh_if_unread(apple)
-            self.assertEqual(apple.color, "Red")
+            self.assertEqual(apple.color, "Pink")
 
         # Without caching
         with DisableCache():
@@ -300,7 +300,7 @@ class TransactionStateTests(TestCase):
                 apple = TestFruit.objects.create(name="Radish", color="Red")
                 apple.color = "Pink"  # Deliberately don't save
                 txn.refresh_if_unread(apple)
-                self.assertEqual(apple.color, "Red")
+                self.assertEqual(apple.color, "Pink")
 
     def test_non_atomic_only(self):
         from .test_connector import TestFruit

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -244,23 +244,23 @@ class TransactionStateTests(TestCase):
         pear = TestFruit.objects.create(name="Pear", color="Green")
 
         with transaction.atomic(xg=True) as txn:
-            self.assertFalse(txn.has_already_been_read(apple))
-            self.assertFalse(txn.has_already_been_read(pear))
+            self.assertFalse(txn.has_been_read(apple))
+            self.assertFalse(txn.has_been_read(pear))
 
             apple.refresh_from_db()
 
-            self.assertTrue(txn.has_already_been_read(apple))
-            self.assertFalse(txn.has_already_been_read(pear))
+            self.assertTrue(txn.has_been_read(apple))
+            self.assertFalse(txn.has_been_read(pear))
 
             with transaction.atomic(xg=True) as txn:
-                self.assertTrue(txn.has_already_been_read(apple))
-                self.assertFalse(txn.has_already_been_read(pear))
+                self.assertTrue(txn.has_been_read(apple))
+                self.assertFalse(txn.has_been_read(pear))
                 pear.refresh_from_db()
-                self.assertTrue(txn.has_already_been_read(pear))
+                self.assertTrue(txn.has_been_read(pear))
 
                 with transaction.atomic(independent=True) as txn2:
-                    self.assertFalse(txn2.has_already_been_read(apple))
-                    self.assertFalse(txn2.has_already_been_read(pear))
+                    self.assertFalse(txn2.has_been_read(apple))
+                    self.assertFalse(txn2.has_been_read(pear))
 
     def test_refresh_if_unread(self):
         from .test_connector import TestFruit

--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -302,6 +302,29 @@ class TransactionStateTests(TestCase):
                 txn.refresh_if_unread(apple)
                 self.assertEqual(apple.color, "Pink")
 
+    def test_refresh_if_unread_for_resaved_objects(self):
+        """ refresh_if_unread should not refresh objects which have been re-saved within the
+            transaction.
+        """
+        from .test_connector import TestFruit
+
+        # With caching
+        apple = TestFruit.objects.create(name="Apple", color="Red")
+        with transaction.atomic() as txn:
+            apple.save()
+            apple.color = "Pink"  # Deliberately don't save
+            txn.refresh_if_unread(apple)
+            self.assertEqual(apple.color, "Pink")
+
+        # Without caching
+        radish = TestFruit.objects.create(name="Radish", color="Red")
+        with DisableCache():
+            with transaction.atomic() as txn:
+                radish.save()
+                radish.color = "Pink"  # Deliberately don't save
+                txn.refresh_if_unread(radish)
+                self.assertEqual(radish.color, "Pink")
+
     def test_non_atomic_only(self):
         from .test_connector import TestFruit
 

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -281,18 +281,18 @@ actually read from the Datastore.
 
 There are times when it's necessary to read from the Datastore directly, and you can use `djangae.db.caching.disable_cache()` for that.
 
-The other feature that Djangae provides are `Transaction` objects, and in particular, `Transaction.has_already_been_read(instance)` and
+The other feature that Djangae provides are `Transaction` objects, and in particular, `Transaction.has_been_read(instance)` and
 `Transaction.refresh_if_unread(instance)`:
 
 ```python
 
 instance = MyModel.objects.create(pk=1, value=0)
 with atomic() as txn:
-    assert(not txn.has_already_been_read(instance))
+    assert(not txn.has_been_read(instance))
 
     txn.refresh_if_unread(instance)
 
-    assert(txn.has_already_been_read(instance))
+    assert(txn.has_been_read(instance))
 
     instance.value = 1
     instance.save()

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -281,7 +281,7 @@ actually read from the Datastore.
 
 There are times when it's necessary to read from the Datastore directly, and you can use `djangae.db.caching.disable_cache()` for that.
 
-The other feature that Djangae provides are `Transaction` objects, and in particular, `Transaction.has_been_read(instance)` and
+The other feature that Djangae provides are `Transaction` objects, and in particular, `Transaction.has_been_read(instance)`, `Transaction.has_been_written(instance)` and
 `Transaction.refresh_if_unread(instance)`:
 
 ```python


### PR DESCRIPTION
Fixes #1098

Changed the behaviour of `transaction.refresh_if_unread` to:

* Not refresh objects which have been created within the transaction (because they won't exist at the DB level until the transaction is committed).
* Not refresh existing objects which have been re-saved within the transaction... because... that's the easiest thing to do!  But I don't know if it's the _right_ thing to do?!

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
