### PR TITLE
Revert "check google cloud sdk version on local server start"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - `atomic()` (when used as a context manager) now returns an object representing the current transaction
 - Added `djangae.db.transaction.current_transaction()` to return the same thing from inside an `atomic()` decorator
 - Added `Transaction.has_already_been_read(instance)` and `Transaction.refresh_if_unread(instance)` which allows writing safe transactional code.
-- Added App Engine SDK version check on project startup.
 
 ### Bug fixes:
 

--- a/djangae/checks.py
+++ b/djangae/checks.py
@@ -5,16 +5,11 @@ from django.core.checks import register, Tags, Error, Warning
 
 from djangae.environment import get_application_root
 
-from google.appengine.tools.sdk_update_checker import GetVersionObject, _VersionList
-
-
 # django 1.8 didn't declare a "caches" tag
 if not hasattr(Tags, "caches"):
     Tags.caches = "caches"
     Tags.urls = "urls"
 
-
-MAX_APP_ENGINE_SDK_VERSION = (1, 9, 57)
 
 CSP_SOURCE_NAMES = [
     'CSP_DEFAULT_SRC',
@@ -27,19 +22,6 @@ CSP_SOURCE_NAMES = [
     'CSP_STYLE_SRC',
     'CSP_CONNECT_SRC',
 ]
-
-
-@register
-def check_app_engine_sdk_version(app_configs=None, **kwargs):
-    errors = []
-    sdk_version = tuple(_VersionList(GetVersionObject()['release']))
-    if sdk_version > MAX_APP_ENGINE_SDK_VERSION:
-            errors.append(Warning(
-                "MAX_APP_ENGINE_SDK_VERSION",
-                hint="You are using a version of the App Engine SDK that is not yet supported",
-                id='djangae.W002',
-            ))
-    return errors
 
 
 @register(Tags.security)

--- a/djangae/tests/test_checks.py
+++ b/djangae/tests/test_checks.py
@@ -98,14 +98,3 @@ class ChecksTestCase(TestCase):
         with override_settings(TEMPLATES=template_setting):
             errors = checks.check_cached_template_loader_used()
             self.assertEqual(len(errors), 0)
-
-    def test_app_engine_sdk_version_check_supported(self):
-        with sleuth.switch('djangae.checks._VersionList', lambda x: [1, 0, 0]):
-            errors = checks.check_app_engine_sdk_version()
-            self.assertEqual(len(errors), 0)
-
-    def test_app_engine_sdk_version_check_unsupported(self):
-        with sleuth.switch('djangae.checks._VersionList', lambda x: [100, 0, 0]):
-            errors = checks.check_app_engine_sdk_version()
-            self.assertEqual(len(errors), 1)
-            self.assertEqual(errors[0].id, 'djangae.W002')


### PR DESCRIPTION
Reverts potatolondon/djangae#1101

This change breaks startup when deployed to App Engine. Reverting for now.