### PR TITLE
Add a `break` statement into `current_transaction`

### DIFF
--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -186,10 +186,9 @@ def current_transaction():
             break
         elif isinstance(txn, NormalTransaction):
             active_transaction = txn
-            # Keep searching... there may be an independent or further transaction
+            break
         elif isinstance(txn, NoTransaction):
             # Bail immediately for non_atomic blocks. There is no transaction there.
-            active_transaction = None
             break
 
     return active_transaction


### PR DESCRIPTION
This doesn't actually affect the behaviour because no other transaction will exist, we were just pointlessly continuing to loop.

Also removed `active_transaction = None` because all cases where we set this variable are now followed by a `break`, so if we get to this line then it will always be `None` anyway.

PR checklist:
- [ ] ~Updated relevant documentation~ - N/A
- [ ] ~Updated CHANGELOG.md~ - N/A
- [ ] ~Added tests for my change~ - Nope, but the existing already cover this code, and they still pass!
