### PR TITLE
Fix a bug with exception catching in the transaction decorator

### DIFF
--- a/djangae/db/transaction.py
+++ b/djangae/db/transaction.py
@@ -249,15 +249,15 @@ class ContextDecorator(object):
 
         def decorated(*_args, **_kwargs):
             decorator_args = self.decorator_args.copy()
-            exception = False
+            exception_type = None
             self.__class__._do_enter(self._push_state(), decorator_args)
             try:
                 return self.func(*_args, **_kwargs)
-            except Exception:
-                exception = True
+            except BaseException as e:
+                exception_type = type(e)
                 raise
             finally:
-                self.__class__._do_exit(self._pop_state(), decorator_args, exception)
+                self.__class__._do_exit(self._pop_state(), decorator_args, exception_type)
 
         if not self.func:
             # We were instantiated with args


### PR DESCRIPTION
This bug meant that if an exception that subclassed BaseException rather than Exception was raised during a transaction, the transaction (as far as it had got) was committed rather than rolled back.

Such exceptions include google.appengine.runtime.DeadlineExceededError.

Fixes #1107.

The commit in which this bug was introduced was `166a82255`.  That commit has not been included in an official release yet, and hence I haven't added a CHANGELOG entry for this fix, because the bug hasn't affected any actual release.

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [x] Added tests for my change
