### PR TITLE
Rename protect_read to prevent_read. Default prevent_further_reads to…

### DIFF
--- a/djangae/tests/test_transactional.py
+++ b/djangae/tests/test_transactional.py
@@ -296,17 +296,17 @@ class TransactionStateTests(TestCase):
                     self.assertFalse(txn2.has_been_read(apple))
                     self.assertFalse(txn2.has_been_read(pear))
 
-    def test_protect_read(self):
+    def test_prevent_read(self):
         from .test_connector import TestFruit
 
         apple = TestFruit.objects.create(name="Apple", color="Red")
 
         # Don't allow reading apple within the transaction
         with transaction.atomic() as txn:
-            txn.protect_read(TestFruit, apple.pk)
+            txn.prevent_read(TestFruit, apple.pk)
 
             self.assertRaises(
-                transaction.ProtectedReadError,
+                transaction.PreventedReadError,
                 TestFruit.objects.get, pk=apple.pk
             )
 

--- a/docs/db_backend.md
+++ b/docs/db_backend.md
@@ -326,19 +326,19 @@ instance.value -> 1  # Oops!
 
 You can write safer code by using `refresh_if_unread(instance)` which will only update the instance if you haven't already done it in the current transaction.
 
-`refresh_if_unread()` also takes an optional keyword argument called `protect_further_reads` which adds additional protection against reading the same instance twice inside a transaction (see below).
+`refresh_if_unread()` also takes an optional keyword argument called `prevent_further_reads` which adds additional protection against reading the same instance twice inside a transaction (see below).
 
 Sometimes when working with transactions you might find you accidentally introduce an additional entity group into the
 transaction unintentionally. This is very easily done by following a ForeignKey relationship inside the transaction and if
 the related instance is shared by a large number of objects you'll rapidly see a large number of `TransactionFailedError`s thrown.
 
-The Djangae `Transaction` object exposes a method to help protect against this situation called `protect_read`.
+The Djangae `Transaction` object exposes a method to help protect against this situation called `prevent_read`.
 
 ```
 with transaction.atomic() as txn:
-    txn.protect_read(MyModel, 1)
+    txn.prevent_read(MyModel, 1)
 
-    MyModel.objects.get(pk=1)  # Raises ProtectedReadError
+    MyModel.objects.get(pk=1)  # Raises PreventedReadError
 ```
 
 


### PR DESCRIPTION
… False

Turns out that because updates do Get + Put, defaulting prevent_further_reads
to True will mean overriding the default on almost every refresh_if_unread.

It's still useful to have though.

Summary of changes proposed in this Pull Request:
- Fix mistakes in previous PR

PR checklist:
- [x] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
