### PR TITLE
Changed some logging calls to use a named logger.

### DIFF
--- a/djangae/db/migrations/mapper_library.py
+++ b/djangae/db/migrations/mapper_library.py
@@ -21,6 +21,9 @@ from google.appengine.runtime import DeadlineExceededError
 from djangae.db.backends.appengine import rpc
 
 
+logger = logging.getLogger(__name__)
+
+
 class Redefer(Exception):
     """ Custom exception class to allow triggering of the re-deferring of a processing task. """
     pass
@@ -282,7 +285,7 @@ class ShardedTaskMarker(rpc.Entity):
 
                 marker.put()
             except datastore_errors.EntityNotFoundError:
-                logging.error(
+                logger.error(
                     "Unable to start task %s as marker is missing",
                     self.key().id_or_name()
                 )

--- a/djangae/db/migrations/operations.py
+++ b/djangae/db/migrations/operations.py
@@ -22,6 +22,7 @@ from .constants import TASK_RECHECK_INTERVAL
 from .utils import clone_entity
 
 
+logger = logging.getLogger(__name__)
 TESTING = 'test' in sys.argv
 
 
@@ -118,7 +119,7 @@ class BaseEntityMapperOperation(Operation, DjangaeMigration):
             raise
         except Exception:
             if self.skip_errors:
-                logging.exception(
+                logger.exception(
                     "Error processing operation %s for entity %s.  Skipping.",
                     self.identifier, entity.key()
                 )


### PR DESCRIPTION
This is particularly useful if you use the Django LOGGING setting to
configure the levels for 'djangae.*' loggers. If you use plain
`logging.info(..)` then that uses the root logger, so would ignore
any settings the admin chose for 'djangae.*' loggers.

There's also a bunch of root logging calls in tests, I have ignored
those.

Fixes #[include a number of issue this PR is fixing].

Summary of changes proposed in this Pull Request:
- 
- 
- 

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
