### PR TITLE
Test runner does skips import error tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added support for named class-based views to dumpurls.  Also now supports export to either json or csv
 - Added `deferred.defer_iteration_with_finalize`
 - Added `Transaction.protect_read` which prevents a specific instance being read inside a transaction.
+- Fixed bug where when running test suite with a target module, if any of the targetted tests had an import error, they were being skipped / silently failing.
 
 ### Bug fixes:
 

--- a/djangae/test_runner.py
+++ b/djangae/test_runner.py
@@ -212,7 +212,9 @@ class DjangaeTestSuiteRunner(DiscoverRunner):
             if hasattr(test, 'available_apps'):
                 test.available_apps = None
 
-            if args[0] and not any([test.id().startswith(x) for x in args[0]]):
+            # make sure we don't run any of the extra tests if a particular
+            # module target was provided at runtime
+            if args[0] and not any([x in test.id() for x in args[0]]):
                 continue
 
             if test.id() in DJANGO_TESTS_TO_SKIP:


### PR DESCRIPTION
If you run the test suite with a target, and one of the targeted tests fails with an import error, this was not propagating to the test run output (it wasn't actually being run, so essentially failing silently).

This is because the test ID changes to have a prefix of `djangae.test_runner.ModuleImportFailure`.

You can verify this locally with the `testapp` by adding an invalid import to a test module, then running `manage.py test <path.to.the.test.module>`. Notice it will currently fail silently, as the test is ignored by the `DjangaeTestSuiteRunner`. 

PR checklist:
- [ ] Updated relevant documentation
- [X] Updated CHANGELOG.md 
- [ ] Added tests for my change
