### PR TITLE
Improve retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added support for named class-based views to dumpurls.  Also now supports export to either json or csv
 - Added `deferred.defer_iteration_with_finalize`
 - Added `Transaction.protect_read` which prevents a specific instance being read inside a transaction.
+- Improved `djangae.utils.retry` to catch the Datastore's `InternalError`, and to better select wait times between attempts. Also improved the logging and prevented losing the source of the final exception when retrying fails.
 
 ### Bug fixes:
 

--- a/djangae/tests/test_utils.py
+++ b/djangae/tests/test_utils.py
@@ -220,7 +220,7 @@ class RetryTestCase(TestCase):
             should be doubled for each subsequent retry.
         """
 
-        @retry_on_error(_initial_wait=5, _attempts=3, _catch=Exception)
+        @retry_on_error(_initial_wait=5, _attempts=3, _catch=Exception, _avoid_clashes=False)
         def flakey():
             raise Exception("Oops")
 
@@ -231,8 +231,8 @@ class RetryTestCase(TestCase):
                 pass
 
             self.assertEqual(len(sleep_watch.calls), 2)  # It doesn't sleep after the final attempt
-            self.assertEqual(sleep_watch.calls[0].args[0], 0.005) # initial wait in milliseconds
-            self.assertEqual(sleep_watch.calls[1].args[0], 0.01) # initial wait doubled during backoff
+            self.assertEqual(sleep_watch.calls[0].args[0], 0.005)  # initial wait in milliseconds
+            self.assertEqual(sleep_watch.calls[1].args[0], 0.01)  # initial wait doubled
 
     def test_max_wait_param(self):
         """ The _max_wait parameter should limit the backoff time for retries, otherwise they will

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -118,6 +118,9 @@ def retry(func, *args, **kwargs):
     timeout_ms = kwargs.pop('_initial_wait', 750)  # Try 750, 1500, 3000 etc.
     max_wait = kwargs.pop('_max_wait', 30000)
 
+    # Whether or not to add a random element to the sleep times
+    randomize = kwargs.pop('_avoid_clashes', True)
+
     i = 0
     try:
         while True:
@@ -136,10 +139,15 @@ def retry(func, *args, **kwargs):
                 logger.info("Retrying function: %s(%s, %s) - %s", func, args, kwargs, exc)
 
                 # Add a slight bit of randomness (up to a second) to avoid competing tasks
-                # repeatedly clashing with each other on retries.
-                random_factor = random.randint(0, 1000)
+                # repeatedly clashing with each other on retries. We still cap at max_wait,
+                # because that's what the user requested, we also respect initial wait so don't
+                # add a random factor on the first sleep
+                if randomize:
+                    random_factor = random.randint(0, 1000) if i > 1 else 0
+                else:
+                    random_factor = 0
 
-                time.sleep((timeout_ms + random_factor) * 0.001)
+                time.sleep(min((timeout_ms + random_factor), max_wait) * 0.001)
                 timeout_ms *= 2
                 timeout_ms = min(timeout_ms, max_wait)
 
@@ -148,7 +156,9 @@ def retry(func, *args, **kwargs):
         raise
 
 
-def retry_on_error(_catch=None, _attempts=3, _initial_wait=375, _max_wait=30000):
+def retry_on_error(
+    _catch=None, _attempts=3, _initial_wait=375, _max_wait=30000, _avoid_clashes=True
+):
     """ Decorator for wrapping a function with `retry`. """
 
     def decorator(func):
@@ -158,6 +168,7 @@ def retry_on_error(_catch=None, _attempts=3, _initial_wait=375, _max_wait=30000)
                 func,
                 _catch=_catch, _attempts=_attempts,
                 _initial_wait=_initial_wait, _max_wait=_max_wait,
+                _avoid_clashes=_avoid_clashes,
                 *args, **kwargs
             )
         return replacement

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -125,6 +125,10 @@ def retry(func, *args, **kwargs):
                     logger.error("Ran out of attempts while retrying function")
                     raise  # Re-raise original exception
 
+                # The location of the errors on each attempt may change, so we log
+                # each one
+                logger.exception("Exception during retry attempt. Will retry.")
+
                 logger.info("Retrying function: %s(%s, %s) - %s", func, args, kwargs, exc)
                 time.sleep(timeout_ms * 0.001)
                 timeout_ms *= 2

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -122,7 +122,9 @@ def retry(func, *args, **kwargs):
                 return func(*args, **kwargs)
             except catch as exc:
                 if i >= attempts:
-                    raise exc
+                    logger.error("Ran out of attempts while retrying function")
+                    raise  # Re-raise original exception
+
                 logger.info("Retrying function: %s(%s, %s) - %s", func, args, kwargs, exc)
                 time.sleep(timeout_ms * 0.001)
                 timeout_ms *= 2

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -111,7 +111,7 @@ def retry(func, *args, **kwargs):
         datastore_errors.Error, apiproxy_errors.Error, TransactionFailedError
     )
     attempts = kwargs.pop('_attempts', 3)
-    timeout_ms = kwargs.pop('_initial_wait', 375)  # Try 375, 750, 1500
+    timeout_ms = kwargs.pop('_initial_wait', 750)  # Try 375, 750, 1500
     max_wait = kwargs.pop('_max_wait', 30000)
 
     i = 0

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -108,10 +108,13 @@ def retry(func, *args, **kwargs):
     # Slightly weird `.pop(x, None) or default` thing here due to not wanting to repeat the tuple of
     # default things in `retry_on_error` and having to do inline imports
     catch = kwargs.pop('_catch', None) or (
-        datastore_errors.Error, apiproxy_errors.Error, TransactionFailedError
+        datastore_errors.Error,
+        apiproxy_errors.Error,
+        TransactionFailedError,
+        datastore_errors.InternalError
     )
     attempts = kwargs.pop('_attempts', 3)
-    timeout_ms = kwargs.pop('_initial_wait', 750)  # Try 375, 750, 1500
+    timeout_ms = kwargs.pop('_initial_wait', 750)  # Try 750, 1500, 3000 etc.
     max_wait = kwargs.pop('_max_wait', 30000)
 
     i = 0

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import collections
 import functools
 import logging
+import random
 import sys
 import time
 import warnings
@@ -133,7 +134,12 @@ def retry(func, *args, **kwargs):
                 logger.exception("Exception during retry attempt. Will retry.")
 
                 logger.info("Retrying function: %s(%s, %s) - %s", func, args, kwargs, exc)
-                time.sleep(timeout_ms * 0.001)
+
+                # Add a slight bit of randomness (up to a second) to avoid competing tasks repeatedly
+                # clashing with each other on retries.
+                random_factor = random.randint(0, 1000)
+
+                time.sleep((timeout_ms + random_factor) * 0.001)
                 timeout_ms *= 2
                 timeout_ms = min(timeout_ms, max_wait)
 

--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -135,8 +135,8 @@ def retry(func, *args, **kwargs):
 
                 logger.info("Retrying function: %s(%s, %s) - %s", func, args, kwargs, exc)
 
-                # Add a slight bit of randomness (up to a second) to avoid competing tasks repeatedly
-                # clashing with each other on retries.
+                # Add a slight bit of randomness (up to a second) to avoid competing tasks
+                # repeatedly clashing with each other on retries.
                 random_factor = random.randint(0, 1000)
 
                 time.sleep((timeout_ms + random_factor) * 0.001)
@@ -156,7 +156,8 @@ def retry_on_error(_catch=None, _attempts=3, _initial_wait=375, _max_wait=30000)
         def replacement(*args, **kwargs):
             return retry(
                 func,
-                _catch=_catch, _attempts=_attempts, _initial_wait=_initial_wait, _max_wait=_max_wait,
+                _catch=_catch, _attempts=_attempts,
+                _initial_wait=_initial_wait, _max_wait=_max_wait,
                 *args, **kwargs
             )
         return replacement
@@ -183,7 +184,9 @@ def djangae_webapp(request_handler):
         view_func = request_handler(req, response)
         view_func.dispatch()
 
-        django_response = HttpResponse(response.body, status=int(str(response.status).split(" ")[0]))
+        django_response = HttpResponse(
+            response.body, status=int(str(response.status).split(" ")[0])
+        )
         for header, value in response.headers.items():
             django_response[header] = value
 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -10,7 +10,7 @@ It is useful for things such as performing Datastore transactions which may coll
 ### `djangae.utils.retry`
 
 ```python
-retry(function, _catch=None, _attempts=3, _initial_wait=375, _max_wait=30000)
+retry(function, _catch=None, _attempts=3, _initial_wait=375, _max_wait=30000, _avoid_clashes=True)
 ```
 
 Calls the given function, catching the given exception(s), and (re)trying up to a maximum of `_attempts` times.
@@ -26,6 +26,10 @@ The wait will double on each subsequent retry, up to a maximum of `_max_wait` mi
 	google.appengine.runtime.apiproxy_errors.Error
 )
 ```
+
+If `_avoid_clashes` is True (default) then a random time up to a second will be added after the first
+retry (the retry time is still capped at `_max_wait`). This is to help avoid situations where several
+tasks collide, and then all back off for the same amount of time before clashing again.
 
 ### `djangae.utils.retry_on_error`
 


### PR DESCRIPTION
Fixes #1149 

Summary of changes proposed in this Pull Request:
- Catch InternalError by default
- Re-raise original exception when retrying fails
- Log each error otherwise only the final error source will be shown
- Add an element of randomness to the retry time
- Increase the default initial wait time to 750 ms

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
