### PR TITLE
Calculate buffer time

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 
-max-line-length = 100
+max-line-length = 120

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -30,6 +30,8 @@ the `finalize` callback is called. If a shard gets close to the 10-minute deadli
 
 Each processing task keeps track of its execution time and re-defers itself to avoid hitting App Engine's `DeadlineExceededError`. However, this check is only performed in between the processing of each object and the re-deferring only happens when the task is within `_buffer_time` seconds of hitting the deadline. So if the processing of an individual model instance takes more than `_buffer_time` seconds then the `DeadlineExceededError` may still be hit, which will cause that task to be retried from the beginning, thus re-processing some of the model instances.
 
+If `_buffer_time` is None (default) then the buffer time will be dynamically calculated from the longest iteration time.
+
 If `args` is specified, these arguments are passed as positional arguments to both `callback` (after the instance) and `finalize`.
 
 `_shards` is the number of shards to use for processing. If `_delete_marker` is `True` then the Datastore entity that


### PR DESCRIPTION
Fixes #1139 

Summary of changes proposed in this Pull Request:
- Default the `_buffer_time` arg to `defer_iteration_with_finalize` to None
- If the `_buffer_time` is None, calculate the buffer time from the longest previous iteration

Note: I haven't updated the CHANGELOG as `defer_iteration_with_finalize` is a new function. I also have been unable to think of how to write a good test for this...

PR checklist:
- [x] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
