### PR TITLE
add new option remove_duplicates to ListField and RelatedListField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Updated `djangae.contrib.backup` to use the new export API (the existing API was deprecated in Feb 2018). This adds a dependency of `google-auth` and `google-api-python-client`,
   and also requires some manual permissions to be configured for the app service account. Existing djangae settings will be respected. Read https://cloud.google.com/datastore/docs/schedule-export for details on the new permissions required, and https://cloud.google.com/datastore/docs/export-import-entities
   for an overview including differences between the two APIs.
+- Added new option `remove_duplicates` to ListField and RelatedListField which removes duplicated elements and retain order while saving.
 
 ### Bug fixes:
 

--- a/djangae/db/utils.py
+++ b/djangae/db/utils.py
@@ -473,3 +473,12 @@ def ensure_datetime(value):
     if isinstance(value, long):
         return datetime.fromtimestamp(value / 1e6)
     return value
+
+
+def remove_duplicates_form_list(list_to_scan):
+    remove_duplicates = []
+    for idx in xrange(len(list_to_scan)):
+        el = list_to_scan[idx]
+        if el not in remove_duplicates:
+            remove_duplicates.append(el)
+    return remove_duplicates

--- a/djangae/tests/test_form_fields.py
+++ b/djangae/tests/test_form_fields.py
@@ -1,4 +1,5 @@
 # LIBRARIES
+from decimal import Decimal
 from bs4 import BeautifulSoup
 from django import forms
 from django.db import models
@@ -26,10 +27,43 @@ class BlankableListFieldModel(models.Model):
     list_field = ListField(models.CharField(max_length=1), blank=True)
 
 
+class RemoveDuplicatesListFieldModel(models.Model):
+    char_list_field = ListField(models.CharField(max_length=20), remove_duplicates=True)
+    int_list_field = ListField(models.IntegerField(max_length=20), remove_duplicates=True)
+    dec_list_field = ListField(models.DecimalField(max_digits=6, decimal_places=2), remove_duplicates=True)
+
+
+class NoneRemoveDuplicatesListFieldModel(models.Model):
+    char_list_field = ListField(models.CharField(max_length=20))
+    int_list_field = ListField(models.IntegerField(max_length=20))
+    dec_list_field = ListField(models.DecimalField(max_digits=6, decimal_places=2))
+
+
 class ListFieldForm(forms.ModelForm):
     class Meta:
         model = BlankableListFieldModel
         fields = ['list_field']
+
+
+class RemoveDuplicatesListFieldForm(forms.ModelForm):
+    class Meta:
+        model = RemoveDuplicatesListFieldModel
+        fields = [
+            'char_list_field',
+            'int_list_field',
+            'dec_list_field',
+        ]
+
+
+class NoneRemoveDuplicatesFieldForm(forms.ModelForm):
+    class Meta:
+        model = NoneRemoveDuplicatesListFieldModel
+        fields = [
+            'char_list_field',
+            'int_list_field',
+            'dec_list_field'
+        ]
+
 
 class RelatedListFieldModel(models.Model):
     related_list_field = RelatedListField(CharFieldModel)
@@ -108,6 +142,56 @@ class ListFieldFormsTest(TestCase):
         form = ListFieldForm(data)
         self.assertTrue(form.is_valid())
 
+    def test_remove_duplicates_true(self):
+        """ Check if remove_duplicates option works for random list of elements"""
+        int_list_field = ['1', '2', '3', '2', '4', '5', '6', '6', '3', '2', '22']
+        char_list_field = ['a', 'b', 'a', 'c', 'd', 'e', 'ee', 'e']
+        dec_list_field = ['1.11', '2.00', '3.14', '2.00', '4.44', '5.55', '6.67', '6.67', '3.14', '2.0', '22', '2.00']
+
+        form = RemoveDuplicatesListFieldForm(
+            {
+                'int_list_field': int_list_field,
+                'char_list_field': char_list_field,
+                'dec_list_field': dec_list_field
+            }
+        )
+        self.assertTrue(form.is_valid())
+        obj = form.save()
+        self.assertEqual(obj.int_list_field, [1, 2, 3, 4, 5, 6, 22])
+        self.assertEqual(obj.char_list_field, ['a', 'b', 'c', 'd', 'e', 'ee'])
+        self.assertEqual(
+            obj.dec_list_field,
+            [
+                Decimal('1.11'), Decimal('2.00'), Decimal('3.14'),
+                Decimal('4.44'), Decimal('5.55'), Decimal('6.67'), Decimal('22')
+            ]
+        )
+
+    def test_remove_duplicates_false(self):
+        """ Check if remove_duplicates option does not affect existing code"""
+        int_list_field = ['1', '2', '3', '2', '4', '5', '6', '6', '3', '2', '22']
+        char_list_field = ['a', 'b', 'a', 'c', 'd', 'e', 'ee', 'e']
+        dec_list_field = ['1.11', '2.00', '3.14', '2.00', '4.44', '5.55', '6.67', '6.67', '3.14', '2.0', '22', '2.00']
+
+        form = NoneRemoveDuplicatesFieldForm(
+            {
+                'int_list_field': int_list_field,
+                'char_list_field': char_list_field,
+                'dec_list_field': dec_list_field
+            }
+        )
+        self.assertTrue(form.is_valid())
+        obj = form.save()
+        self.assertEqual(obj.int_list_field, [1, 2, 3, 2, 4, 5, 6, 6, 3, 2, 22])
+        self.assertEqual(obj.char_list_field, ['a', 'b', 'a', 'c', 'd', 'e', 'ee', 'e'])
+        self.assertEqual(
+            obj.dec_list_field,
+            [
+                Decimal('1.11'), Decimal('2.00'), Decimal('3.14'), Decimal('2.00'), Decimal('4.44'), Decimal('5.55'),
+                Decimal('6.67'), Decimal('6.67'), Decimal('3.14'), Decimal('2.0'), Decimal('22'), Decimal('2.00')
+            ]
+        )
+
 
 class OrderedModelMultipleChoiceField(TestCase):
 
@@ -121,7 +205,7 @@ class OrderedModelMultipleChoiceField(TestCase):
             ) for x in range(3)
         ]
         data = dict(related_list_field=[
-            instance_two.pk, instance_three.pk, instance_one.pk]
+            instance_two.pk, instance_three.pk, instance_one.pk, instance_two.pk]
         )
         form = RelatedListFieldForm(data)
         self.assertTrue(form.is_valid())
@@ -129,7 +213,7 @@ class OrderedModelMultipleChoiceField(TestCase):
 
         self.assertEqual(
             obj.related_list_field_ids,
-            [instance_two.pk, instance_three.pk, instance_one.pk]
+            [instance_two.pk, instance_three.pk, instance_one.pk, instance_two.pk]
         )
 
     def test_validation_still_performed(self):

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -10,6 +10,7 @@ This is often useful when structuring data for a non-relational database. [See e
 
 * `item_field`: An instance of a Django model field which defines the data type and validation for each item in the list.
 * `ordering`: A callable which allows the items in the list to be automatically sorted.
+* `remove_duplicates`: False by default, while saving will remove any duplicated elements and retain order. 
 
 ### `SetField(item_field, **kwargs)`
 
@@ -112,6 +113,8 @@ The value of a `RelatedSetField` also has all of the methods of a normal `QueryS
 * Because the `RelatedSetField` stores the IDs of objects, its queryset is immediately consistent, i.e. is unaffected by the Datastore's eventual consistency.  For example, `my_obj.my_related_set_field.filter(colour="blue")` will always return the latest versions of those objects.
 
 ## RelatedListField
+
+* `remove_duplicates`: False by default, while saving will remove any duplicated elements and retain order. 
 
 RelatedListField shares the same behavior as RelatedSetField but has the qualities of a list; it maintains the ordering of related objects and allows duplicates.
 


### PR DESCRIPTION
Fixes #1017

Summary of changes proposed in this Pull Request:
- add new kwargs option "remove_duplicates" to ListField and RelatedListField
- fix some PEP-8 warnings 

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
