### PR TITLE
Update Django requirement to >=1.11.19

### DIFF
--- a/testprodapp/requirements.txt
+++ b/testprodapp/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.8,<1.9
+django>=1.11.19,<2.0
 django-session-csrf==0.7.1


### PR DESCRIPTION
This is just updating the Django version used in the testapp.

1.11.19 contains a security fix, so that should now be the minimum.
