### PR TITLE
Change ensure_instance_included to ensure_instance_consistent

### DIFF
--- a/docs/consistency.md
+++ b/docs/consistency.md
@@ -3,7 +3,7 @@
 A contrib app which helps to mitigate against eventual consistency issues with the App Engine Datastore.
 
 **Note: If all you want to do is make sure that a newly updated/created object is returned as part of a queryset
-take a look at [djangae.db.consistency.ensure_instance_included](db_backend.md#djangaedbconsistencyensure_instance_included).
+take a look at [djangae.db.consistency.ensure_instance_consistent](db_backend.md#djangaedbconsistencyensure_instance_consistent).
 If you want a powerful solution to general consistency issues then this is the app for you!**
 
 ## In A Nutshell


### PR DESCRIPTION
Per v0.9.4, I've changed references from ensure_instance_included to ensure_instance_consistent and updated the associated deeplink.