### PR TITLE
break after removing add_branch

### DIFF
--- a/djangae/db/backends/appengine/dnf.py
+++ b/djangae/db/backends/appengine/dnf.py
@@ -260,6 +260,7 @@ def normalize_query(query):
                     if pk_equality_found and pk_equality_found != child.value:
                         # Remove this AND branch as it's impossible to return anything
                         node.children.remove(and_branch)
+                        break
                     else:
                         pk_equality_found = child.value
             if not node.children:


### PR DESCRIPTION
After determining the add_branch should be removed while resolving detect_conflicting_key_filter, we should stop trying to remove the add_branch. It doesn't matter how many times we confirm it should be removed, we should just remove it once to avoid the ValueError that occurs from trying to remove it again.

Fixes #1174.

Summary of changes proposed in this Pull Request:
- Add a `break` after removing the and_branch.
- It is possible that this doesn't address a deeper issue, in that maybe the issue is that more than 2 key lookup children were being added to the `and_branch`es that caused my problems. But objectively, looking at the bit of code in this for loop, the loop should be terminated after removing the `and_branch` from `node.children`. There is no reason to continue it.

PR checklist:
- [-] Updated relevant documentation  # change is very small, there wasn't specific documentation to update
- [-] Updated CHANGELOG.md  # change is very small
- [-] Added tests for my change  # i'm not sure how to reproduce, unfortunately, possibly due to lack of understanding on how the giant OR/AND queries are created in my project...
