### PR TITLE
Include all namespaces in the backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### New features & improvements:
 
+- Backup all datastore namespaces.
+
 ### Bug fixes:
 
 ## v0.9.12

--- a/djangae/contrib/backup/tasks.py
+++ b/djangae/contrib/backup/tasks.py
@@ -46,7 +46,6 @@ def backup_datastore(bucket=None, kinds=None):
         'outputUrlPrefix': get_backup_path(bucket),
         'entityFilter': {
             'kinds': valid_models,
-            'namespaceIds': [''],
         }
     }
     app_id = app_identity.get_application_id()
@@ -113,4 +112,3 @@ def _get_authentication_credentials():
             service_account_path, scopes=AUTH_SCOPES
         )
     return credentials
-


### PR DESCRIPTION
Fixes #1178 

Summary of changes proposed in this Pull Request:
- remove the (empty) `namespaceIds` option so that all datastore namespaces are included in the backup

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change