### PR TITLE
Add a shard index in the environment when running tasks via defer_ite…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - cd testapp
 - python install_deps.py
 script:
-- python manage.py test
+- travis_wait 30 python manage.py test
 after_script:
 - cd ..
 - rm django_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New features & improvements:
 
 - Backup all datastore namespaces.
+- Add a `"DEFERRED_ITERATION_SHARD_INDEX"` key to os.environ for callbacks running from `defer_iteration_with_finalize`
 
 ### Bug fixes:
 

--- a/djangae/tests/test_defer_iteration.py
+++ b/djangae/tests/test_defer_iteration.py
@@ -1,7 +1,10 @@
 from django.db import models
 
-from djangae.deferred import defer_iteration_with_finalize
+from djangae.deferred import defer_iteration_with_finalize, DEFERRED_ITERATION_SHARD_INDEX_KEY
 from djangae.test import TestCase
+
+
+_SHARD_COUNT = 5
 
 
 class DeferIterationTestModel(models.Model):
@@ -11,6 +14,11 @@ class DeferIterationTestModel(models.Model):
 
 
 def callback(instance, touch=True):
+    shard_index = int(os.environ[DEFERRED_ITERATION_SHARD_INDEX_KEY])
+
+    assert(shard_index >= 0)
+    assert(shard_index < 5)
+
     if touch:
         instance.touched = True
     instance.save()
@@ -45,7 +53,8 @@ class DeferIterationTestCase(TestCase):
             DeferIterationTestModel.objects.all(),
             callback,
             finalize,
-            touch=False  # kwarg to not touch the objects at all
+            touch=False,  # kwarg to not touch the objects at all
+            _shards=_SHARD_COUNT
         )
 
         self.process_task_queues()
@@ -58,7 +67,8 @@ class DeferIterationTestCase(TestCase):
         defer_iteration_with_finalize(
             DeferIterationTestModel.objects.all(),
             callback,
-            finalize
+            finalize,
+            _shards=_SHARD_COUNT
         )
 
         self.process_task_queues()
@@ -72,7 +82,8 @@ class DeferIterationTestCase(TestCase):
         defer_iteration_with_finalize(
             DeferIterationTestModel.objects.filter(ignored=False),
             callback,
-            finalize
+            finalize,
+            _shards=_SHARD_COUNT
         )
 
         self.process_task_queues()
@@ -90,7 +101,8 @@ class DeferIterationTestCase(TestCase):
         defer_iteration_with_finalize(
             DeferIterationTestModel.objects.all(),
             sporadic_error,
-            finalize
+            finalize,
+            _shards=_SHARD_COUNT
         )
 
         self.process_task_queues()

--- a/djangae/tests/test_defer_iteration.py
+++ b/djangae/tests/test_defer_iteration.py
@@ -1,3 +1,4 @@
+import os
 from django.db import models
 
 from djangae.deferred import defer_iteration_with_finalize, DEFERRED_ITERATION_SHARD_INDEX_KEY

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -38,3 +38,13 @@ If `args` is specified, these arguments are passed as positional arguments to bo
 tracks complete shards is deleted. If you want to keep these (as a log of sorts) then set this to `False`.
 
 `_transactional` and `_queue` work in the same way as `defer()`
+
+## Identifying a task shard
+
+From a shard callback, you can identify the current shard by accessing `os.environ["DEFERRED_ITERATION_SHARD_INDEX"]` there is a constant defined for this key:
+
+```
+from djangae.deferred import DEFERRED_ITERATION_SHARD_INDEX_KEY
+shard_index = int(os.environ[DEFERRED_ITERATION_SHARD_INDEX_KEY])
+```
+


### PR DESCRIPTION
…ration_with_finalize

Summary of changes proposed in this Pull Request:
- Adds a value to os.environ to identify a shard in defer_iteration_with_finalize

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
