### PR TITLE
Improve locking transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bug fixes:
 
--
+- Handle transaction errors when trying to acquire a lock. Improved the retry countdown.
 
 ## v1.0.0
 

--- a/djangae/contrib/locking/models.py
+++ b/djangae/contrib/locking/models.py
@@ -1,6 +1,7 @@
 # STANDARD LIB
 from datetime import timedelta
 import hashlib
+import random
 import time
 
 # THRID PARTY
@@ -27,28 +28,34 @@ class LockQuerySet(models.query.QuerySet):
         """
         identifier_hash = hashlib.md5(identifier).hexdigest()
 
-        @transaction.atomic()
         def trans():
-            lock = self.filter(identifier_hash=identifier_hash).first()
-            if lock:
-                # Lock already exists, so check if it's old enough to ignore/steal
-                if (
-                    steal_after_ms and
-                    timezone.now() - lock.timestamp > timedelta(microseconds=steal_after_ms * 1000)
-                ):
-                    # We can steal it.  Update timestamp to now and return it
-                    lock.timestamp = timezone.now()
-                    lock.save()
-                    return lock
-            else:
-                return DatastoreLock.objects.create(
-                    identifier_hash=identifier_hash,
-                    identifier=identifier
-                )
+            """ Wrapper for the atomic transaction that handles transaction errors """
+            @transaction.atomic()
+            def _trans():
+                lock = self.filter(identifier_hash=identifier_hash).first()
+                if lock:
+                    # Lock already exists, so check if it's old enough to ignore/steal
+                    if (
+                        steal_after_ms and
+                        timezone.now() - lock.timestamp > timedelta(microseconds=steal_after_ms * 1000)
+                    ):
+                        # We can steal it.  Update timestamp to now and return it
+                        lock.timestamp = timezone.now()
+                        lock.save()
+                        return lock
+                else:
+                    return DatastoreLock.objects.create(
+                        identifier_hash=identifier_hash,
+                        identifier=identifier
+                    )
+            try:
+                return _trans()
+            except transaction.TransactionFailedError:
+                return None
 
         lock = trans()
         while wait and lock is None:
-            time.sleep(0.1)  # Sleep for a bit between retries
+            time.sleep(random.uniform(0, 1))  # Sleep for a random bit between retries
             lock = trans()
         return lock
 

--- a/djangae/contrib/locking/models.py
+++ b/djangae/contrib/locking/models.py
@@ -30,7 +30,7 @@ class LockQuerySet(models.query.QuerySet):
 
         def trans():
             """ Wrapper for the atomic transaction that handles transaction errors """
-            @transaction.atomic()
+            @transaction.atomic(independent=True)
             def _trans():
                 lock = self.filter(identifier_hash=identifier_hash).first()
                 if lock:

--- a/djangae/contrib/locking/tests.py
+++ b/djangae/contrib/locking/tests.py
@@ -100,7 +100,7 @@ class DatastoreLocksTestCase(TestCase):
         with sleuth.detonate(
             'djangae.contrib.locking.models.LockQuerySet.filter', TransactionFailedError
         ):
-            lock = Lock.acquire("my_lock")
+            lock = Lock.acquire("my_lock", wait=False)
             self.assertIsNone(lock)
 
 


### PR DESCRIPTION
Fixes #1187.

Summary of changes proposed in this Pull Request:
- Handle transaction errors when trying to acquire a lock
- Improved the locking retry countdown.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change

@Kazade re #1187, not sure where you meant the independent arg should be added? `transaction.atomic` doesn't support that specific one as far as I know.