### PR TITLE
Fix backup ignoring models that override table name using db_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bug fixes:
 
--
+- Fixes bug where `djangae.contrib.backups` would not backup models who explictly set table name with `db_table`.
 
 ## v1.0.0
 

--- a/djangae/contrib/backup/tests/test_tasks.py
+++ b/djangae/contrib/backup/tests/test_tasks.py
@@ -1,22 +1,18 @@
-import json
-
 from django.test import override_settings
 from django.contrib.admin.models import LogEntry
 
 from djangae.contrib.gauth_datastore.models import GaeDatastoreUser
 from djangae.contrib import sleuth
-from djangae.environment import application_id
 from djangae.test import TestCase
 
 from djangae.contrib.backup.tasks import (
     _get_valid_export_kinds,
     backup_datastore,
-    SERVICE_URL,
     AUTH_SCOPES,
 )
 
-from google.appengine.api import app_identity
 from google.auth import app_engine
+
 
 def mock_get_app_models(**kwargs):
     return [

--- a/djangae/contrib/backup/tests/test_tasks.py
+++ b/djangae/contrib/backup/tests/test_tasks.py
@@ -9,7 +9,7 @@ from djangae.environment import application_id
 from djangae.test import TestCase
 
 from djangae.contrib.backup.tasks import (
-    _get_valid_export_models,
+    _get_valid_export_kinds,
     backup_datastore,
     SERVICE_URL,
     AUTH_SCOPES,
@@ -25,25 +25,34 @@ def mock_get_app_models(**kwargs):
     ]
 
 
-class GetValidExportModelsTestCase(TestCase):
-    """Tests focused on djangae.contrib.backup.tasks._get_valid_export_models"""
+class GetValidExportKindsTestCase(TestCase):
+    """Tests focused on djangae.contrib.backup.tasks._get_valid_export_kinds"""
 
     @override_settings(DJANGAE_BACKUP_EXCLUDE_MODELS=['django_admin_log'])
     @sleuth.switch('django.apps.apps.get_models', mock_get_app_models)
-    def test_models_filtered(self):
-        valid_models = _get_valid_export_models(
+    def test_models_filtered_by_model(self):
+        valid_models = _get_valid_export_kinds(
             ['django_admin_log', 'gauth_datastore_gaedatastoreuser']
         )
         self.assertNotIn('django_admin_log', valid_models)
-        self.assertIn('gauth_datastore_gaedatastoreuser', valid_models)
+        self.assertIn('djangae_gaedatastoreuser', valid_models)
 
-    @override_settings(DJANGAE_BACKUP_EXCLUDE_APPS=['django'])
+    @override_settings(DJANGAE_BACKUP_EXCLUDE_MODELS=['django_admin_log'])
+    @sleuth.switch('django.apps.apps.get_models', mock_get_app_models)
+    def test_models_filtered_by_kind(self):
+        valid_models = _get_valid_export_kinds(
+            ['django_admin_log', 'djangae_gaedatastoreuser']
+        )
+        self.assertNotIn('django_admin_log', valid_models)
+        self.assertIn('djangae_gaedatastoreuser', valid_models)
+
+    @override_settings(DJANGAE_BACKUP_EXCLUDE_APPS=['admin'])
     @sleuth.switch('django.apps.apps.get_models', mock_get_app_models)
     def test_apps_filtered(self):
-        valid_models = _get_valid_export_models(
+        valid_models = _get_valid_export_kinds(
             ['django_admin_log', 'gauth_datastore_gaedatastoreuser']
         )
-        self.assertIn('gauth_datastore_gaedatastoreuser', valid_models)
+        self.assertIn('djangae_gaedatastoreuser', valid_models)
         self.assertNotIn('django_admin_log', valid_models)
 
 

--- a/djangae/contrib/backup/tests/test_views.py
+++ b/djangae/contrib/backup/tests/test_views.py
@@ -21,7 +21,7 @@ class DatastoreBackupViewTestCase(TestCase):
     @sleuth.switch('djangae.environment.is_in_task', lambda: True)
     def test_get_params_propogate(self):
         request = RequestFactory().get('/?kind=django_admin_log&bucket=foobar')
-        with sleuth.watch('djangae.contrib.backup.views.backup_datastore') as backup_fn:
+        with sleuth.Fake('djangae.contrib.backup.views.backup_datastore', None) as backup_fn:
             create_datastore_backup(request)
             self.assertTrue(backup_fn.called)
             self.assertEqual(

--- a/djangae/contrib/backup/views.py
+++ b/djangae/contrib/backup/views.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def create_datastore_backup(request):
     """
     Handler which triggers a datastore backup if DJANGAE_BACKUP_ENABLED set.
-    
+
     GET params can be passed to override the default bucket target and entity
     kinds to backup. This allows us to have different types of backup and not
     be constrained by the settings config (e.g. we might have different cron

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -66,8 +66,10 @@ DJANGAE_BACKUP_EXCLUDE_APPS = [
 
 ### Exclude specific models
 
+Use the form <app_label>_<model_name>
+
 ```python
 DJANGAE_BACKUP_EXCLUDE_MODELS = [
-    'sessions.Session',
+    'sessions_session',
 ]
 ```


### PR DESCRIPTION
Fixes #1184

* Update the `django.contrib.backups` app to use db_table when determining which datastore kinds to backup for a model. 
* Fix some function naming to use kind when operating/returning kinds.
* Updates tests and fix false positive.

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
