### PR TITLE
De-dupe kinds before they are passed to the datastore export API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes:
 
+- Fixes bug where `djangae.contrib.backups` would fail if models shared the same kind.
 - Fixes bug where `djangae.contrib.backups` would not backup models who explictly set table name with `db_table`.
 - Handle transaction errors when trying to acquire a lock. Improved the retry countdown.
 

--- a/djangae/contrib/backup/tasks.py
+++ b/djangae/contrib/backup/tasks.py
@@ -87,12 +87,17 @@ def _get_valid_export_kinds(kinds=None):
     # If kinds we explcitly provided by the caller, we only return those
     # already validated by our previous checks
     if kinds:
-        return [
+        to_backup = [
             kind for (_model_def, kind) in to_backup
             if _model_def in kinds or kind in kinds
         ]
     else:
-        return [kind for (_model_def, kind) in to_backup]
+        to_backup = [kind for (_model_def, kind) in to_backup]
+
+    # If 2 models share the same underlying table they will return the same
+    # kind. The datastore backup API will return a validation error when a kind
+    # is listed more than once.
+    return list(set(to_backup))
 
 
 def _get_service():

--- a/djangae/contrib/backup/tests/test_tasks.py
+++ b/djangae/contrib/backup/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from django.test import override_settings
 from django.contrib.admin.models import LogEntry
+from django.db import models
 
 from djangae.contrib.gauth_datastore.models import GaeDatastoreUser
 from djangae.contrib import sleuth
@@ -50,6 +51,33 @@ class GetValidExportKindsTestCase(TestCase):
         )
         self.assertIn('djangae_gaedatastoreuser', valid_models)
         self.assertNotIn('django_admin_log', valid_models)
+
+    def test_models_using_the_same_table_only_listed_once(self):
+        class ModelFoo(models.Model):
+            class Meta:
+                db_table = "foo"
+
+        class ModelBar(models.Model):
+            class Meta:
+                db_table = "foo"
+
+        def mock_get_app_models(**kwargs):
+            return [ModelFoo, ModelBar]
+
+        with sleuth.switch('django.apps.apps.get_models', mock_get_app_models):
+            valid_models = _get_valid_export_kinds()
+            self.assertEquals(['foo'], valid_models)
+
+    @override_settings(DJANGAE_BACKUP_EXCLUDE_MODELS=['django_admin_log'])
+    def test_kinds_are_deduplicated(self):
+        valid_models = _get_valid_export_kinds(kinds=[
+            'gauth_datastore_gaedatastoreuser',
+            'gauth_datastore_gaedatastoreuser',
+            'djangae_gaedatastoreuser',
+            'djangae_gaedatastoreuser',
+        ])
+        self.assertEquals(['djangae_gaedatastoreuser'], valid_models)
+
 
 
 class BackupTestCase(TestCase):


### PR DESCRIPTION
Fixes #1192 

The datastore export API returns an error when passing the same kind more than once. This PR de-de-dupes the list of kinds before doing the call.

PR checklist:
- [ ] ~~Updated relevant documentation~~
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
