### PR TITLE
Add max_wait_ms to Lock.acquire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ## v1.0.1 (bug fix release)
 
+### New features & improvements:
+ - Add `max_wait_ms` to `Lock.acquire` which returns early if no lock is available after this long
+
 ### Bug fixes:
 
 - Fixes bug where `djangae.contrib.backups` would fail if models shared the same kind.

--- a/djangae/contrib/locking/models.py
+++ b/djangae/contrib/locking/models.py
@@ -61,7 +61,7 @@ class LockQuerySet(models.query.QuerySet):
         lock = trans()
         while wait and lock is None:
             # If more than max_wait_ms has elapsed, then give up
-            if timezone.now() - start_time > timedelta(microseconds=max_wait_ms * 1000):
+            if max_wait_ms is not None and timezone.now() - start_time > timedelta(microseconds=max_wait_ms * 1000):
                 break
 
             time.sleep(random.uniform(0, 1))  # Sleep for a random bit between retries

--- a/djangae/contrib/locking/models.py
+++ b/djangae/contrib/locking/models.py
@@ -16,7 +16,7 @@ from djangae.fields import CharField
 
 class LockQuerySet(models.query.QuerySet):
 
-    def acquire(self, identifier, wait=True, steal_after_ms=None):
+    def acquire(self, identifier, wait=True, steal_after_ms=None, max_wait_ms=None):
         """ Create or fetch the Lock with the given `identifier`.
         `wait`:
             If True, wait until the Lock is available, otherwise if the lcok is not available then
@@ -25,8 +25,13 @@ class LockQuerySet(models.query.QuerySet):
             If the lock is not available (already exists), then steal it if it's older than this.
             E.g. if you know that the section of code you're locking should never take more than
             3 seconds, then set this to 3000.
+        `max_wait_ms`:
+            Wait, but only for this long. If no lock has been acquired then returns
+            None.
         """
         identifier_hash = hashlib.md5(identifier).hexdigest()
+
+        start_time = timezone.now()
 
         def trans():
             """ Wrapper for the atomic transaction that handles transaction errors """
@@ -55,6 +60,10 @@ class LockQuerySet(models.query.QuerySet):
 
         lock = trans()
         while wait and lock is None:
+            # If more than max_wait_ms has elapsed, then give up
+            if timezone.now() - start_time > timedelta(microseconds=max_wait_ms * 1000):
+                break
+
             time.sleep(random.uniform(0, 1))  # Sleep for a random bit between retries
             lock = trans()
         return lock

--- a/djangae/contrib/locking/tests.py
+++ b/djangae/contrib/locking/tests.py
@@ -103,6 +103,15 @@ class DatastoreLocksTestCase(TestCase):
             lock = Lock.acquire("my_lock", wait=False)
             self.assertIsNone(lock)
 
+    def test_max_wait_ms(self):
+        lock1 = Lock.acquire("my_lock")   # Get the lock
+        self.assertTrue(lock1)
+
+        lock2 = Lock.acquire("my_lock", max_wait_ms=100, wait=True, steal_after_ms=150)  # Wait 100 ms
+
+        # If we stole it, this wouldn't be None
+        self.assertIsNone(lock2)
+
 
 class MemcacheLocksTestCase(TestCase):
     """ Tests for the implementation of the WEAK kind of lock (MemcacheLock). """

--- a/docs/locking.md
+++ b/docs/locking.md
@@ -42,6 +42,7 @@ The main utility is the `lock` object, which can be used as a function decorator
     - In the context manager case, bailing means that `LockAcquisitionError` will be raised when
     entering `with`.
 * `steal_after_ms` - if passed, then any existing lock which is older than this value will be ignored.
+* `wait_for_ms` - if passed, this is the max time to wait before giving up getting the lock
 * `kind` - which kind of lock implementation to use.
     - LOCK_KINDS.WEAK is not guaranteed to be robust, but can be used for situations where avoiding
       simultaneous code execution is preferable but not critical (uses memcache).


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
-  Adds a max_wait_ms argument to Lock.acquire

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
