### PR TITLE
Cache to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Upgraded the codebase to Python 3
 - Switched to running the tests using tox (remove testapp etc.)
+- Replaced memcache with FileBasedCache (or Memorystore for Redis)
 - Removed the following:
   - djangae.db (moved to gcloud-connectors)
   - contrib.consistency (new datastore is strongly consistent)

--- a/djangae/settings_base.py
+++ b/djangae/settings_base.py
@@ -1,9 +1,13 @@
+from djangae.environment import is_production_environment
+
+FILE_CACHE_LOCATION = '/tmp/cache' if is_production_environment() else '.cache'
 
 CACHES = {
-    # We default to the database cache, at least until
-    # there is a sensible caching alternative (or low MemoryStore latency)
+    # We default to the filesystem cache, since it's quick and easy for simple app
+    # For larger application you should consider Cloud Memory Store (which does not have a free tier)
     'default': {
-        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': FILE_CACHE_LOCATION,
     }
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@
 1. We also recommend that you:
     - Add `'djangae.contrib.security'` to `INSTALLED_APPS'`.
     - Add `'djangae.contrib.security.middleware.AppEngineSecurityMiddleware'` to `MIDDLEWARE_CLASSES`.
-1. At the top of your `settings.py`, insert the following line to setup some default settings: 
+1. At the top of your `settings.py`, insert the following line to setup some default settings:
 
 ```python
 from djangae.settings_base import *
@@ -73,3 +73,19 @@ It is recommended that for improved security you add `djangae.contrib.security.m
 ## Deployment
 
 Deploying your application is the same as deploying any Google App Engine project.
+
+## Cache Backend
+
+By default, Djangae uses `FileBasedCache` storing data in `.cache/` in your local env and in `/tmp` when deployed to GAE. This provides an in-memory caching system (`/tmp` is an in-memory filesystem), which is not shared across instances. If you need cross-instances cache we recomment using [Memorystore for Redis](https://cloud.google.com/memorystore/docs/redis) with [django-redis-cache](https://django-redis-cache.readthedocs.io/en/latest/index.html). Make sure you configure [VPC](https://cloud.google.com/appengine/docs/standard/python3/connecting-vpc) for your project to allow access to the redis instance from your GAE standard environment app. Your configuration should look something like this:
+
+```python
+# ...
+from djangae.settings_base import *
+
+CACHES = {
+    'default': {
+        'BACKEND': 'redis_cache.RedisCache',
+        'LOCATION': '10.237.7.251:6379',
+    },
+}
+```


### PR DESCRIPTION
The database cache doesn't work since it's not using django models but executing raw sql queries.

This PR replaces it with `FileBasedCache` (which can be used with the new standard environment).


PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
