### PR TITLE
Use function to determine class based view info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixes bug where `djangae.contrib.backups` would fail if models shared the same kind.
 - Fixes bug where `djangae.contrib.backups` would not backup models who explictly set table name with `db_table`.
 - Handle transaction errors when trying to acquire a lock. Improved the retry countdown.
+- Fixes bug where `dumpurls` command would fail if a view linked to a named url has a parameter.
 
 ## v1.0.0
 

--- a/djangae/contrib/security/management/commands/dumpurls.py
+++ b/djangae/contrib/security/management/commands/dumpurls.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
                 allowed_http_methods='',
             )
 
-            cbv_info = get_cbv_info(url_name)
+            cbv_info = get_cbv_info(func)
             if cbv_info:
                 view_info['parents'] = ', '.join(cbv_info['parent_class_names'])
                 view_info['allowed_http_methods'] = ', '.join(cbv_info['allowed_http_methods'])
@@ -100,12 +100,7 @@ class Command(BaseCommand):
         return console_output
 
 
-def get_cbv_info(url_name):
-    if url_name is None:
-        return
-
-    url = reverse(url_name)
-    view = resolve(url).func
+def get_cbv_info(view):
     is_class_based_view = inspect.isclass(view)
 
     if is_class_based_view:

--- a/djangae/contrib/security/tests.py
+++ b/djangae/contrib/security/tests.py
@@ -2,11 +2,32 @@ import logging
 
 from djangae.test import TestCase
 from djangae.contrib.security.management.commands import dumpurls
+from django.test import override_settings
+from django.conf.urls import url
+
+
+def view_with_param(request, param):
+    return
+
+
+urlpatterns = [
+    url("^public_view/(?P<param>[\w]+)/$", view_with_param, name="named_view"),
+    url("^public_view/(?P<param>[\w]+)/$", view_with_param),
+]
 
 
 class DumpUrlsTests(TestCase):
     def test_dumpurls(self):
         """ Test that the `dumpurls` command runs without dying. """
+        logging.debug('%s', "*" * 50)
+        command = dumpurls.Command()
+        command.handle()
+
+    @override_settings(
+        ROOT_URLCONF=__name__,
+    )
+    def test_dumpurls_unnamed_urls(self):
+        """ Test that the `dumpurls` command runs without dying when a named url has a parameter. """
         logging.debug('%s', "*" * 50)
         command = dumpurls.Command()
         command.handle()


### PR DESCRIPTION
Fixes `dumpurls` command which fails for named views when the view contains one or more parameters.

Summary of changes proposed in this Pull Request:
- Fixes bug where `dumpurls` command would fail if a view linked to  a named url has a parameter.

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
