### PR TITLE
Prevent importing settings before sandbox

### DIFF
--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -10,9 +10,9 @@ from urllib.error import (
 )
 from urllib.request import urlopen
 
-from django.utils.autoreload import DJANGO_AUTORELOAD_ENV
-
-from djangae.environment import get_application_root
+# This is copied from Django so that we don't import Django, and therefore
+# settings.py before we've got the Datastore etc. up and running
+DJANGO_AUTORELOAD_ENV = 'RUN_MAIN'
 
 _ACTIVE_EMULATORS = {}
 _ALL_EMULATORS = ("datastore", "tasks", "storage")
@@ -72,14 +72,13 @@ def _wait(port, service):
         time.sleep(1)
 
 
-def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_port=None, autodetect_task_port=True):
+def start_emulators(persist_data, storage_dir, emulators=None, task_target_port=None, autodetect_task_port=True):
     # This prevents restarting of the emulators when Django code reload
     # kicks in
     if os.environ.get(DJANGO_AUTORELOAD_ENV) == 'true':
         return
 
     emulators = emulators or _ALL_EMULATORS
-    storage_dir = storage_dir or os.path.join(get_application_root(), ".storage")
 
     if "datastore" in emulators:
         os.environ["DATASTORE_EMULATOR_HOST"] = "127.0.0.1:%s" % DATASTORE_PORT

--- a/djangae/test.py
+++ b/djangae/test.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from django.test.runner import DiscoverRunner
 from djangae.tasks.test import (
@@ -42,7 +43,8 @@ class TransactionTestCase(TestEnvironmentMixin, TestCaseMixin, test.TransactionT
 
 class AppEngineDiscoverRunner(DiscoverRunner):
     def setup_test_environment(self, **kwargs):
-        start_emulators(persist_data=False)
+        tempdir = tempfile.mkdtemp()
+        start_emulators(persist_data=False, storage_dir=tempdir)
         super().setup_test_environment(**kwargs)
 
     def teardown_test_environment(self, **kwargs):


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- These changes prevent Django being imported from start_emulators as this causes problems if you need to access emulator services (e.g. the Datastore) from settings.py

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
