### PR TITLE
1211 invalid decorator

### DIFF
--- a/djangae/contrib/security/decorators.py
+++ b/djangae/contrib/security/decorators.py
@@ -19,8 +19,10 @@ def without_security_middleware(func):
     # thus allowing you to avoid the afore-described issue.
     middleware = list(settings.MIDDLEWARE_CLASSES[:])
     middleware.remove('djangae.contrib.security.middleware.AppEngineSecurityMiddleware')
+
     @wraps(func)
     def _wrapped(*args, **kwargs):
         with override_settings(MIDDLEWARE_CLASSES=middleware):
             return func(*args, **kwargs)
+
     return _wrapped

--- a/djangae/tests/test_views.py
+++ b/djangae/tests/test_views.py
@@ -1,0 +1,14 @@
+import os
+from djangae.test import TestCase
+from django.urls import reverse
+
+
+class ViewsTests(TestCase):
+    def test_clearsessions(self):
+        response = self.client.post(reverse("clearsessions"))
+        self.assertEqual(response.status_code, 403)
+
+        os.environ["HTTP_X_APPENGINE_CRON"] = "1"
+        response = self.client.post(reverse("clearsessions"))
+        self.assertEqual(response.status_code, 200)
+        del os.environ["HTTP_X_APPENGINE_CRON"]

--- a/djangae/urls.py
+++ b/djangae/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    url(r'^start$', views.start),
-    url(r'^stop$', views.stop),
-    url(r'^warmup$', views.warmup),
-    url(r'^clearsessions$', views.clearsessions),
+    path('start', views.start, name="instance_start"),
+    path('stop', views.stop, name="instance_stop"),
+    path('warmup', views.warmup, name="instance_warmup"),
+    path('clearsessions', views.clearsessions, name="clearsessions"),
 ]

--- a/djangae/views.py
+++ b/djangae/views.py
@@ -74,16 +74,6 @@ def deferred(request):
     return response
 
 
-@csrf_exempt
-@require_POST
-def internalupload(request):
-    try:
-        return HttpResponse(str(request.FILES['file'].blobstore_info.key()))
-    except Exception:
-        logger.exception("DJANGAE UPLOAD FAILED: The internal upload handler couldn't retrieve the blob info key.")
-        return HttpResponseServerError()
-
-
 @environment.task_only
 def clearsessions(request):
     engine = import_module(settings.SESSION_ENGINE)

--- a/djangae/views.py
+++ b/djangae/views.py
@@ -3,8 +3,7 @@ import logging
 from importlib import import_module
 
 from django.conf import settings
-from django.http import HttpResponse, HttpResponseServerError
-from django.views.decorators.http import require_POST
+from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 
 from djangae import environment

--- a/djangae/views.py
+++ b/djangae/views.py
@@ -25,17 +25,17 @@ def warmup(request):
                 import_module('%s.%s' % (app, name))
             except ImportError:
                 pass
-    return HttpResponse("Ok.")
+    return HttpResponse("OK")
 
 
 def start(request):
     module_started.send(sender=__name__, request=request)
-    return HttpResponse("Ok.")
+    return HttpResponse("OK")
 
 
 def stop(request):
     module_stopped.send(sender=__name__, request=request)
-    return HttpResponse("Ok.")
+    return HttpResponse("OK")
 
 
 @csrf_exempt
@@ -84,7 +84,7 @@ def internalupload(request):
         return HttpResponseServerError()
 
 
-@environment.task_or_admin_only
+@environment.task_only
 def clearsessions(request):
     engine = import_module(settings.SESSION_ENGINE)
     try:
@@ -94,4 +94,4 @@ def clearsessions(request):
             "Session engine '%s' doesn't support clearing "
             "expired sessions.\n", settings.SESSION_ENGINE
         )
-    return HttpResponse("Ok.")
+    return HttpResponse("OK")

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,3 +89,18 @@ CACHES = {
     },
 }
 ```
+
+# System views
+
+Djangae ships handlers for various system functions. To enable them include djangae.urls in your url patterns. E.g.
+
+```
+urlpatterns = [
+    path('_ah/', include('djangae.urls')),
+]
+```
+
+The `_ah/` path is important as the views handle the built-in App Engine requests to `/_ah/warmup`, `/_ah/start`, and `/_ah/stop`.
+
+Additionally Djangae implements a view at `/_ah/clearsessions` to handle clearing expired Django sessions from the database. You should
+configure cron to post to this URL (see [sessions.md](Sessions))

--- a/test_settings.py
+++ b/test_settings.py
@@ -69,4 +69,5 @@ ROOT_URLCONF = __name__
 
 urlpatterns = [
     path('tasks/', include('djangae.tasks.urls')),
+    path('_ah/', include('djangae.urls')),
 ]


### PR DESCRIPTION
Fixes #1211 

Summary of changes proposed in this Pull Request:
- Fixes broken decorator
- Updates djangae.urls to use modern Django path() rather than url()
- Removes the unused internalupload view

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
