### PR TITLE
Defer iteration with finalize for sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,9 @@
-## v2.0.0 (in development)
 
-### New features & improvements:
+## v1.0.1
 
--
+### New features & improvements
 
-### Bug fixes:
-
--
-
-## v1.0.1 (bug fix release)
+- Added SQL support for defer_iteration_with_finalize
 
 ### Bug fixes:
 

--- a/djangae/processing.py
+++ b/djangae/processing.py
@@ -1,3 +1,5 @@
+from django.db import router, connections
+from django.db.models import Min, Max
 
 
 def _find_random_keys(queryset, shard_count):
@@ -10,13 +12,11 @@ def _find_random_keys(queryset, shard_count):
     )
 
 
-def find_key_ranges_for_queryset(queryset, shard_count):
+def _find_key_ranges_for_datastore_queryset(queryset, shard_count):
     """
-        Given a queryset and a number of shard. This function makes use
-        of the __scatter__ property to return a list of key ranges
-        for sharded iteration.
+        This function makes use of the __scatter__ property to return
+        a list of key ranges for sharded iteration on the datastore.
     """
-
     if shard_count > 1:
         # Use the scatter property to generate shard points
         random_keys = _find_random_keys(queryset, shard_count)
@@ -42,3 +42,44 @@ def find_key_ranges_for_queryset(queryset, shard_count):
         key_ranges = [(None, None)]
 
     return key_ranges
+
+
+def _find_key_ranges_for_sql_queryset(queryset, shard_count):
+    """
+        This function returns a list of key ranges for sharded iteration
+        on SQL databases by looking at the min/max primary key values.
+    """
+    # Can't have more shards than items
+    if queryset.count() < shard_count:
+        shard_count = queryset.count()
+
+    if shard_count > 1:
+        min_max_pks = queryset.aggregate(Min('pk'), Max('pk'))
+        pk_range = range(min_max_pks['pk__min'], min_max_pks['pk__max'])
+
+        index_stride = len(pk_range) / float(shard_count)
+        split_keys = [pk_range[int(round(index_stride * i))] for i in range(1, shard_count)]
+
+        key_ranges = [(None, split_keys[0])] + [
+            (split_keys[i], split_keys[i + 1]) for i in range(len(split_keys) - 1)
+        ] + [(split_keys[-1], None)]
+    else:
+        # Don't shard
+        key_ranges = [(None, None)]
+
+    return key_ranges
+
+
+def find_key_ranges_for_queryset(queryset, shard_count):
+    """
+        Given a queryset and a number of shard, this function
+        returns a list of key ranges for sharded iteration.
+    """
+    model_db = router.db_for_read(queryset.model)
+    conn_engine = connections[model_db].settings_dict.get("ENGINE")
+
+    # Use different methods for finding the key ranges for the datastore and SQL
+    if conn_engine in ['djangae.db.backends.appengine', 'gcloudc.db.backends.datastore']:
+        return _find_key_ranges_for_datastore_queryset(queryset, shard_count)
+    else:
+        return _find_key_ranges_for_sql_queryset(queryset, shard_count)

--- a/djangae/tests/test_defer_iteration.py
+++ b/djangae/tests/test_defer_iteration.py
@@ -127,6 +127,7 @@ class DeferDatastoreIterationTestCase(TestCase):
 
 
 class DeferSQLIterationTestCase(TestCase):
+    multi_db = True
 
     def test_instances_hit(self):
         [DeferIterationTestSQLModel.objects.create() for i in range(25)]

--- a/testapp/testapp/routers.py
+++ b/testapp/testapp/routers.py
@@ -16,5 +16,5 @@ class TestRouter(object):
         try:
             model = hints.get('model', apps.get_model(app_label, model_name))
             return db == self._get_db(model)
-        except LookupError:
+        except (LookupError, ValueError):
             return False

--- a/testapp/testapp/routers.py
+++ b/testapp/testapp/routers.py
@@ -1,11 +1,20 @@
+from django.apps import apps
+
 class TestRouter(object):
     """A router for tests that allows setting a model's database explicitly."""
 
     def _get_db(self, model, **hints):
-        return getattr(model, 'test_database', None)
+        return getattr(model, 'test_database', 'default')
 
     def db_for_read(self, model, **hints):
         return self._get_db(model, **hints)
 
     def db_for_write(self, model, **hints):
         return self._get_db(model, **hints)
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        try:
+            model = hints.get('model', apps.get_model(app_label, model_name))
+            return db == self._get_db(model)
+        except LookupError:
+            return False

--- a/testapp/testapp/settings.py
+++ b/testapp/testapp/settings.py
@@ -139,6 +139,9 @@ DATABASES = {
     "nonamespace": {
         'ENGINE': 'djangae.db.backends.appengine',
     },
+    'sql': {
+        'ENGINE': 'django.db.backends.sqlite3',
+    }
 }
 
 DATABASE_ROUTERS = ['testapp.routers.TestRouter']


### PR DESCRIPTION
Fixes #1210.

Summary of changes proposed in this Pull Request:
- Added SQL support for defer_iteration_with_finalize
- Added tests and a new SQLite database to testapp
- This was branched from `1.x`, but it would work on the `master` branch too if the DB connection detection mechanism is compatible with the most recent changes in Djangae on `master`  (which I'm not familiar with). 
- Tested with Django 1.11

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change

Not sure where to add the item in the changelog file exactly as it doesn't look up to date.