### PR TITLE
Pass queue.yaml to the task emulator

### DIFF
--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -96,7 +96,7 @@ def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_
         _wait_for_datastore(DATASTORE_PORT)
 
     if "tasks" in emulators:
-        from djangae.tasks import cloud_tasks_parent_path
+        from djangae.tasks import cloud_tasks_parent_path, cloud_tasks_project, cloud_tasks_location
         default_queue = "%s/queues/default" % cloud_tasks_parent_path()
 
         if task_target_port is None:
@@ -111,12 +111,20 @@ def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_
             else:
                 task_target_port = _DJANGO_DEFAULT_PORT
 
-        os.environ["TASKS_EMULATOR_HOST"] = "127.0.0.1:%s" % TASKS_PORT
-        _ACTIVE_EMULATORS["tasks"] = _launch_process(
-            "gcloud-tasks-emulator start -q --port=%s --target-port=%s --default-queue=%s" % (
-                TASKS_PORT, task_target_port, default_queue
-            )
+        command = "gcloud-tasks-emulator start -q --port=%s --target-port=%s --default-queue=%s" % (
+            TASKS_PORT, task_target_port, default_queue
         )
+
+        # If the project contains a queue.yaml, pass it to the Tasks Emulator so that those queues
+        # can be created (needs version >= 0.4.0)
+        queue_yaml = os.path.join(get_application_root(), "queue.yaml")
+        if os.path.exists(queue_yaml):
+            command += " --queue-yaml=%s --queue-yaml-project=%s --queue-yaml-location=%s"  % (
+                queue_yaml, cloud_tasks_project(), cloud_tasks_location()
+            )
+
+        os.environ["TASKS_EMULATOR_HOST"] = "127.0.0.1:%s" % TASKS_PORT
+        _ACTIVE_EMULATORS["tasks"] = _launch_process(command)
         _wait_for_tasks(TASKS_PORT)
 
     if "storage" in emulators:

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -119,7 +119,7 @@ def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_
         # can be created (needs version >= 0.4.0)
         queue_yaml = os.path.join(get_application_root(), "queue.yaml")
         if os.path.exists(queue_yaml):
-            command += " --queue-yaml=%s --queue-yaml-project=%s --queue-yaml-location=%s"  % (
+            command += " --queue-yaml=%s --queue-yaml-project=%s --queue-yaml-location=%s" % (
                 queue_yaml, cloud_tasks_project(), cloud_tasks_location()
             )
 

--- a/djangae/tasks/__init__.py
+++ b/djangae/tasks/__init__.py
@@ -71,6 +71,12 @@ def cloud_tasks_project():
     return project_id
 
 
+def cloud_tasks_location():
+    location_id = getattr(settings, CLOUD_TASKS_LOCATION_SETTING, None)
+    assert(location_id)
+    return location_id
+
+
 def cloud_tasks_parent_path():
     """
         Returns the path based on settings.CLOUD_TASK_PROJECT_ID

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -1,6 +1,18 @@
-# Deferred
+# djangae.tasks
 
-# djangae.tasks.deferred.defer
+The djangae.tasks app provides functionality for working with Google Cloud Tasks from your Django application.
+
+The main functionality it provides is the ability to "defer" a function to be run later by Cloud Tasks. It
+also provides a number of helper methods that leverage that ability.
+
+## Google Cloud Tasks Emulator
+
+When developing locally, it is recommended you make use of the [GCloud Tasks Emulator](https://gitlab.com/potato-oss/google-cloud/gcloud-tasks-emulator)
+project that simulates the Cloud Task API locally.
+
+Djangae's sandbox.py provides functionality to start/stop the emulator for you, and djangae.tasks integrates with the emulator when it's running.
+
+## djangae.tasks.deferred.defer
 
 The App Engine SDK provides a utility function called `defer()` which is used to call
 functions and methods from the task queue.
@@ -14,9 +26,9 @@ The built-in `defer()` method suffers from a number of issues with both bugs, an
  - If a Django instance is passed as an argument to the called function, then the foreign key caches are wiped before
    deferring to avoid bloating and stale data when the task runs. This can be disabled with `_wipe_related_caches=False`
 
-Everything else should behave in the same way. The actual running of deferred tasks still uses the Google handler (which is wrapped by Djangae)
+Everything else should behave in the same way.
 
-# djange.tasks.deferred.defer_iteration_with_finalize
+## djange.tasks.deferred.defer_iteration_with_finalize
 
 `defer_iteration_with_finalize(queryset, callback, finalize, args=None, _queue='default', _shards=5, _delete_marker=True, _transactional=False)`
 
@@ -39,7 +51,7 @@ tracks complete shards is deleted. If you want to keep these (as a log of sorts)
 
 `_transactional` and `_queue` work in the same way as `defer()`
 
-## Identifying a task shard
+### Identifying a task shard
 
 From a shard callback, you can identify the current shard by accessing `os.environ["DEFERRED_ITERATION_SHARD_INDEX"]` there is a constant defined for this key:
 
@@ -47,4 +59,3 @@ From a shard callback, you can identify the current shard by accessing `os.envir
 from djangae.deferred import DEFERRED_ITERATION_SHARD_INDEX_KEY
 shard_index = int(os.environ[DEFERRED_ITERATION_SHARD_INDEX_KEY])
 ```
-

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     30: Django >= 3.0, < 3.1
 commands =
     pip install beautifulsoup4  # Test requirements
-    pip install gcloud-tasks-emulator==0.3.1
+    pip install gcloud-tasks-emulator>=0.4.0
     pip install gcloud-storage-emulator
     pip install -e .
     django-admin.py test --settings=test_settings {posargs}


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Passes the `--queue-yaml`, `--queue-yaml-project`, and `--queue-yaml-location` args to the task emulator

PR checklist:
- [x] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
