### PR TITLE
Implement transactional defer

### DIFF
--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -22,9 +22,12 @@ The built-in `defer()` method suffers from a number of issues with both bugs, an
 `djangae.deferred.defer` is a near-drop-in replacement for `google.appengine.ext.deferred.defer` with a few differences:
 
  - The code has been altered to always use a Datastore entity group unless the task is explicitly marked as being "small" (less than 100k) with the `_small_task=True` flag.
- - Transactional defers are always transactional, even if the task is > 100k (this is a bug in the original defer)
  - If a Django instance is passed as an argument to the called function, then the foreign key caches are wiped before
    deferring to avoid bloating and stale data when the task runs. This can be disabled with `_wipe_related_caches=False`
+ - Transactional tasks do not *guarantee* that the task will run. It's possible (but unlikely) for the transaction to complete
+   successfully, but the queuing of the task to fail. It is not possible for the transaction to fail and the task to queue however.
+ - `_transactional` defaults to `True` if called within an atomic() block, or `False` otherwise.
+ - `_using` is provided to choose which connection should control transactional queuing. Defaults to "default".
 
 Everything else should behave in the same way.
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     include_package_data=True,
     # dependencies
     install_requires=[
-        'django-gcloud-connectors >= 0.1.0',
+        'django-gcloud-connectors >= 0.2.1',
         'google-api-python-client>=1.7.11',
         # requests required by cloud storage file backend
         'requests>=2.22.0'


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Implements the _transactional flag to defer similar to what existed in the Python 2 App Engine runtime
- Adds a _using argument so you can choose which connection to tie transactionality to
- Defaults _transactional to True if inside an atomic block, or False otherwise (which is the path of least surprise)

PR checklist:
- [x] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [x] Added tests for my change
