### PR TITLE
Make sure project is passed to storage client

### DIFF
--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -23,6 +23,9 @@ DATASTORE_PORT = 10901
 TASKS_PORT = 10908
 STORAGE_PORT = 10911
 
+DEFAULT_PROJECT_ID = "example"
+DEFAULT_BUCKET = "%s.appspot.com" % DEFAULT_PROJECT_ID
+
 
 def _launch_process(command_line):
     env = os.environ.copy()
@@ -80,10 +83,11 @@ def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_
 
     emulators = emulators or _ALL_EMULATORS
     storage_dir = storage_dir or os.path.join(get_application_root(), ".storage")
+    enable_test_environment_variables()
 
     if "datastore" in emulators:
         os.environ["DATASTORE_EMULATOR_HOST"] = "127.0.0.1:%s" % DATASTORE_PORT
-        os.environ["DATASTORE_PROJECT_ID"] = "example"
+        os.environ["DATASTORE_PROJECT_ID"] = DEFAULT_PROJECT_ID
 
         # Start the cloud datastore emulator
         command = "gcloud beta emulators datastore start --consistency=1.0 --quiet --project=example"
@@ -129,7 +133,7 @@ def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_
 
     if "storage" in emulators:
         os.environ["STORAGE_EMULATOR_HOST"] = "http://127.0.0.1:%s" % STORAGE_PORT
-        command = "gcloud-storage-emulator start -q --port=%s" % STORAGE_PORT
+        command = "gcloud-storage-emulator start -q --port=%s --default-bucket=%s" % (STORAGE_PORT, DEFAULT_BUCKET)
 
         if not persist_data:
             command += " --no-store-on-disk"
@@ -148,3 +152,13 @@ def stop_emulators(emulators=None):
     for k, v in _ACTIVE_EMULATORS.items():
         if k in emulators:
             v.kill()
+
+
+def enable_test_environment_variables():
+    """
+        Sets up sample environment variables that are available on production
+    """
+
+    os.environ.setdefault("GOOGLE_CLOUD_PROJECT", DEFAULT_PROJECT_ID)
+    os.environ.setdefault("GAE_APPLICATION", "e~%s" % DEFAULT_PROJECT_ID)
+    os.environ.setdefault("GAE_ENV", "development")

--- a/djangae/storage.py
+++ b/djangae/storage.py
@@ -35,6 +35,7 @@ def _get_storage_client():
 
     from google.cloud import storage
     return storage.Client(
+        project=project_id(),
         _http=http,
     )
 

--- a/djangae/test.py
+++ b/djangae/test.py
@@ -1,4 +1,3 @@
-import os
 
 from django.test.runner import DiscoverRunner
 from djangae.tasks.test import (
@@ -15,19 +14,9 @@ TaskFailedError = TaskFailedError
 TaskFailedBehaviour = TaskFailedBehaviour
 
 
-def enable_test_environment_variables():
-    """
-        Sets up sample environment variables that are available on production
-    """
-
-    os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "example")
-    os.environ.setdefault("GAE_APPLICATION", "e~example")
-    os.environ.setdefault("GAE_ENV", "development")
-
 
 class TestEnvironmentMixin(object):
     def setUp(self):
-        enable_test_environment_variables()
         cache.clear()
         super().setUp()
 

--- a/djangae/test.py
+++ b/djangae/test.py
@@ -14,7 +14,6 @@ TaskFailedError = TaskFailedError
 TaskFailedBehaviour = TaskFailedBehaviour
 
 
-
 class TestEnvironmentMixin(object):
     def setUp(self):
         cache.clear()

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     include_package_data=True,
     # dependencies
     install_requires=[
-        'django-gcloud-connectors @ git+https://gitlab.com/potato-oss/google-cloud/django-gcloud-connectors.git',
+        'django-gcloud-connectors >= 0.1.0',
         'google-api-python-client>=1.7.11',
         # requests required by cloud storage file backend
         'requests>=2.22.0'

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
 commands =
     pip install beautifulsoup4  # Test requirements
     pip install gcloud-tasks-emulator>=0.4.0
-    pip install gcloud-storage-emulator
+    pip install gcloud-storage-emulator>=0.2.2
     pip install -e .
     django-admin.py test --settings=test_settings {posargs}
 whitelist_externals = gcloud


### PR DESCRIPTION
Configure env variable when starting emulators

Fixes #1230

Summary of changes proposed in this Pull Request:
- Make sure client uses the correct project id
- Configure the project id in `start_emulators`
- 

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
