### PR TITLE
Handle task routing using defer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - djangae.fields (moved to gcloud-connectors)
   - djangae.forms (used for database fields which no longer exist in djangae)
   - lib.memcache (memcache doesn't exist on the Python 3 runtime)
+- Control deferred task routing & default to routing tasks to their parent GAE version
 
 
 ### Bug fixes:

--- a/djangae/environment.py
+++ b/djangae/environment.py
@@ -60,6 +60,11 @@ def task_queue_name():
         return None
 
 
+def gae_version():
+    """Returns the current GAE version."""
+    return os.environ.get('GAE_VERSION')
+
+
 @memoized
 def get_application_root():
     """Traverse the filesystem upwards and return the directory containing app.yaml"""

--- a/djangae/tasks/deferred.py
+++ b/djangae/tasks/deferred.py
@@ -205,9 +205,11 @@ def defer(obj, *args, **kwargs):
 
     # build the routing payload
     # default to using the current GAE version
-    routing = {"version": task_args.get("version", gae_version())}
+    routing = {
+        "version": task_args["version"] or gae_version(),
+    }
     for key in ("service", "instance"):
-        if key in task_args:
+        if task_args.get(key):
             routing[key] = task_args[key]
 
     if wipe_related_caches:

--- a/djangae/tasks/deferred.py
+++ b/djangae/tasks/deferred.py
@@ -26,7 +26,7 @@ import types
 from datetime import timedelta
 from urllib.parse import unquote
 
-from djangae.environment import task_queue_name, gae_version
+from djangae.environment import gae_version, task_queue_name
 from djangae.models import DeferIterationMarker
 from djangae.processing import find_key_ranges_for_queryset
 from djangae.utils import retry

--- a/djangae/tasks/deferred.py
+++ b/djangae/tasks/deferred.py
@@ -193,16 +193,15 @@ def defer(obj, *args, **kwargs):
 
     # build the routing payload
     routing = {}
-    target = task_args.get('target', gae_version())
+    target = task_args.get('target')
     if isinstance(target, dict):
         # handle multiple target values
         for key in ("service", "version", "instance", "host"):
             if key in target:
                 routing[key] = target[key]
     else:
-        # when only one value is specified, set it as the routing version;
-        # when `target` isn't specified, we default to using the current GAE version for routing
-        routing["version"] = target
+        # when `target` isn't specified, we default to using the current GAE version
+        routing["version"] = gae_version()
 
     if wipe_related_caches:
         args = list(args)

--- a/djangae/tasks/tests/test_deferred.py
+++ b/djangae/tasks/tests/test_deferred.py
@@ -83,3 +83,6 @@ class DeferTests(TestCase):
             self.assertEqual(routing['instance'], instance)
 
         del os.environ['GAE_VERSION']
+
+    def test_deprecated_target_parameter(self):
+        self.assertRaises(UserWarning, defer, test_task, _target='test')

--- a/djangae/tasks/tests/test_deferred.py
+++ b/djangae/tasks/tests/test_deferred.py
@@ -1,3 +1,6 @@
+import os
+
+from djangae.contrib import sleuth
 from django.db import models
 from djangae.tasks.deferred import defer
 from djangae.test import TestCase, TaskFailedError
@@ -48,3 +51,35 @@ class DeferTests(TestCase):
         initial_count = self.get_task_count()
         defer(test_task)
         self.assertEqual(self.get_task_count(), initial_count + 1)
+
+    def test_task_default_routing(self):
+        gae_version = 'demo'
+        os.environ['GAE_VERSION'] = gae_version
+
+        with sleuth.watch('google.cloud.tasks_v2.CloudTasksClient.create_task') as _create_task:
+            defer(test_task)
+
+            self.assertTrue(_create_task.called)
+            routing = _create_task.calls[0].args[2]['app_engine_http_request']['app_engine_routing']
+            self.assertFalse('service' in routing)
+            self.assertFalse('instance' in routing)
+            self.assertEqual(routing['version'], gae_version)
+
+        del os.environ['GAE_VERSION']
+
+    def test_task_routing(self):
+        service = 'service123'
+        version = 'version456'
+        instance = 'instance789'
+        os.environ['GAE_VERSION'] = 'demo'
+
+        with sleuth.watch('google.cloud.tasks_v2.CloudTasksClient.create_task') as _create_task:
+            defer(test_task, _service=service, _version=version, _instance=instance)
+
+            self.assertTrue(_create_task.called)
+            routing = _create_task.calls[0].args[2]['app_engine_http_request']['app_engine_routing']
+            self.assertEqual(routing['service'], service)
+            self.assertEqual(routing['version'], version)
+            self.assertEqual(routing['instance'], instance)
+
+        del os.environ['GAE_VERSION']


### PR DESCRIPTION
### Summary of changes proposed in this Pull Request

#### 1. Default to routing tasks to their parent GAE version

Cloud Tasks run on the default GAE version, by default. I suggest we change the default behaviour to route tasks to the GAE version which created the task. This will ensure that the deferred task exists.

#### 2. Allow user to control task routing

When calling `deferred.defer()`, allow the user to control [task routing](https://cloud.google.com/tasks/docs/reference/rest/v2/AppEngineRouting) using the `_service`, `_version`, and `_instance` parameters.

### PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
