### PR TITLE
Customise emulator ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - lib.memcache (memcache doesn't exist on the Python 3 runtime)
 - Control deferred task routing & default to routing tasks to their parent GAE version
 - Make `djangae/contrib/security/middleware.py` Python 3.7 compatible
+- Update sandbox to allow caller to control emulator ports
 
 
 ### Bug fixes:

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -26,6 +26,8 @@ STORAGE_PORT = 10911
 DEFAULT_PROJECT_ID = "example"
 DEFAULT_BUCKET = "%s.appspot.com" % DEFAULT_PROJECT_ID
 
+logger = logging.getLogger(__name__)
+
 
 def _launch_process(command_line):
     env = os.environ.copy()
@@ -45,7 +47,7 @@ def _wait_for_storage(port):
 
 
 def _wait(port, service):
-    print("Waiting for %s..." % service)
+    logger.info("Waiting for %s..." % service)
 
     TIMEOUT = 60.0
     start = datetime.now()
@@ -61,7 +63,7 @@ def _wait(port, service):
             time.sleep(1)
             if failures > 5:
                 # Only start logging if this becomes persistent
-                logging.exception("Error connecting to the %s. Retrying..." % service)
+                logger.exception("Error connecting to the %s. Retrying..." % service)
             continue
 
         if response.status == 200:
@@ -143,8 +145,7 @@ def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_
 
 
 def stop_emulators(emulators=None):
-    # This prevents restarting of the emulators when Django code reload
-    # kicks in
+    # This prevents restarting of the emulators when Django code reload kicks in
     if os.environ.get(DJANGO_AUTORELOAD_ENV) == 'true':
         return
 

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -81,7 +81,7 @@ def _wait(port, service):
 def start_emulators(
     persist_data: bool,
     project_id: str = DEFAULT_PROJECT_ID,
-    emulators: Optional[Sequence[str]] = None,
+    emulators: Sequence[str] = _ALL_EMULATORS,
     datastore_port: int = DATASTORE_PORT,
     tasks_port: int = TASKS_PORT,
     task_target_port: Optional[int] = None,
@@ -94,7 +94,6 @@ def start_emulators(
     if os.environ.get(DJANGO_AUTORELOAD_ENV) == 'true':
         return
 
-    emulators = emulators or _ALL_EMULATORS
     storage_dir = storage_dir or os.path.join(get_application_root(), ".storage")
     enable_test_environment_variables()
 

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import time
 from datetime import datetime
+from typing import Optional, Sequence
 from urllib.error import (
     HTTPError,
     URLError,
@@ -77,9 +78,19 @@ def _wait(port, service):
         time.sleep(1)
 
 
-def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_port=None, autodetect_task_port=True):
-    # This prevents restarting of the emulators when Django code reload
-    # kicks in
+def start_emulators(
+    persist_data: bool,
+    project_id: str = DEFAULT_PROJECT_ID,
+    emulators: Optional[Sequence[str]] = None,
+    datastore_port: int = DATASTORE_PORT,
+    tasks_port: int = TASKS_PORT,
+    task_target_port: Optional[int] = None,
+    autodetect_task_port: bool = True,
+    storage_port: int = STORAGE_PORT,
+    storage_dir: Optional[str] = None,
+
+):
+    # This prevents restarting of the emulators when Django code reload kicks in
     if os.environ.get(DJANGO_AUTORELOAD_ENV) == 'true':
         return
 
@@ -88,18 +99,18 @@ def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_
     enable_test_environment_variables()
 
     if "datastore" in emulators:
-        os.environ["DATASTORE_EMULATOR_HOST"] = "127.0.0.1:%s" % DATASTORE_PORT
-        os.environ["DATASTORE_PROJECT_ID"] = DEFAULT_PROJECT_ID
+        os.environ["DATASTORE_EMULATOR_HOST"] = "127.0.0.1:%s" % datastore_port
+        os.environ["DATASTORE_PROJECT_ID"] = project_id
 
         # Start the cloud datastore emulator
         command = "gcloud beta emulators datastore start --consistency=1.0 --quiet --project=example"
-        command += " --host-port=127.0.0.1:%s" % DATASTORE_PORT
+        command += " --host-port=127.0.0.1:%s" % datastore_port
 
         if not persist_data:
             command += " --no-store-on-disk"
 
         _ACTIVE_EMULATORS["datastore"] = _launch_process(command)
-        _wait_for_datastore(DATASTORE_PORT)
+        _wait_for_datastore(datastore_port)
 
     if "tasks" in emulators:
         from djangae.tasks import cloud_tasks_parent_path, cloud_tasks_project, cloud_tasks_location
@@ -118,7 +129,7 @@ def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_
                 task_target_port = _DJANGO_DEFAULT_PORT
 
         command = "gcloud-tasks-emulator start -q --port=%s --target-port=%s --default-queue=%s" % (
-            TASKS_PORT, task_target_port, default_queue
+            tasks_port, task_target_port, default_queue
         )
 
         # If the project contains a queue.yaml, pass it to the Tasks Emulator so that those queues
@@ -129,19 +140,20 @@ def start_emulators(persist_data, emulators=None, storage_dir=None, task_target_
                 queue_yaml, cloud_tasks_project(), cloud_tasks_location()
             )
 
-        os.environ["TASKS_EMULATOR_HOST"] = "127.0.0.1:%s" % TASKS_PORT
+        os.environ["TASKS_EMULATOR_HOST"] = "127.0.0.1:%s" % tasks_port
         _ACTIVE_EMULATORS["tasks"] = _launch_process(command)
-        _wait_for_tasks(TASKS_PORT)
+        _wait_for_tasks(tasks_port)
 
     if "storage" in emulators:
-        os.environ["STORAGE_EMULATOR_HOST"] = "http://127.0.0.1:%s" % STORAGE_PORT
-        command = "gcloud-storage-emulator start -q --port=%s --default-bucket=%s" % (STORAGE_PORT, DEFAULT_BUCKET)
+        os.environ["STORAGE_EMULATOR_HOST"] = "http://127.0.0.1:%s" % storage_port
+        command = "gcloud-storage-emulator start -q --port=%s --default-bucket=%s" % (
+            storage_port, DEFAULT_BUCKET)
 
         if not persist_data:
             command += " --no-store-on-disk"
 
         _ACTIVE_EMULATORS["storage"] = _launch_process(command)
-        _wait_for_storage(STORAGE_PORT)
+        _wait_for_storage(storage_port)
 
 
 def stop_emulators(emulators=None):

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -162,9 +162,11 @@ def stop_emulators(emulators=None):
         return
 
     emulators = emulators or _ALL_EMULATORS
-    for k, v in _ACTIVE_EMULATORS.items():
-        if k in emulators:
-            v.kill()
+    for name, proc in _ACTIVE_EMULATORS.items():
+        if name in emulators:
+            logger.info('Stopping %s emulator', name)
+            proc.terminate()
+            proc.wait()
 
 
 def enable_test_environment_variables():


### PR DESCRIPTION
### Summary of changes proposed in this Pull Request:
- allow caller to specify the emulator ports to use
- allow multiple Djangae apps to run on the same machine, each with its own emulators (on separate ports)

### PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
