### PR TITLE
Fix backup task credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Make `djangae/contrib/security/middleware.py` Python 3.7 compatible
 - Update sandbox to allow caller to control emulator ports
 - Update `djangae.contrib.backup` and `djangae.contrib.locking` URLs to use the Django 2 `path` function
+- Fix backup task credentials for GAE Python 3
 
 
 ### Bug fixes:

--- a/djangae/contrib/backup/tasks.py
+++ b/djangae/contrib/backup/tasks.py
@@ -8,7 +8,7 @@ from djangae.environment import (
     application_id,
     is_production_environment,
 )
-from google.auth import app_engine
+import google.auth
 from google.oauth2 import service_account
 
 from .utils import (
@@ -118,7 +118,7 @@ def _get_authentication_credentials():
     https://developers.google.com/api-client-library/python/auth/service-accounts
     """
     if is_production_environment():
-        credentials = app_engine.Credentials(scopes=AUTH_SCOPES)
+        credentials, _ = google.auth.default(scopes=AUTH_SCOPES)
     else:
         service_account_path = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
         credentials = service_account.Credentials.from_service_account_file(


### PR DESCRIPTION
### Summary of changes proposed in this Pull Request:
- fix backup task when running in production
- using `app_engine.Credentials` on GAE Python 3 raises an error `The App Engine APIs are not available.`

### PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
