### PR TITLE
Specify the datastore emulator data-dir parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix `djangae.contrib.security.commands_utils.extract_views_from_urlpatterns` function
 - Fix error classes not inheriting from `Exception`
 - Fix an issue with `djangae.storage.CloudStorage` where calling `_open()` or `delete()` wouldn't use the correct bucket
+- Add parameter to control datastore emulator `--data-dir`
 
 ### Bug fixes:
 

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -103,7 +103,7 @@ def start_emulators(
         os.environ["DATASTORE_PROJECT_ID"] = project_id
 
         # Start the cloud datastore emulator
-        command = "gcloud beta emulators datastore start --consistency=1.0 --quiet"
+        command = "gcloud beta emulators datastore start --consistency=1.0 --quiet --project=example"
         command += " --host-port=127.0.0.1:%s" % datastore_port
 
         if datastore_dir:

--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -83,6 +83,7 @@ def start_emulators(
     project_id: str = DEFAULT_PROJECT_ID,
     emulators: Sequence[str] = _ALL_EMULATORS,
     datastore_port: int = DATASTORE_PORT,
+    datastore_dir: Optional[str] = None,
     tasks_port: int = TASKS_PORT,
     task_target_port: Optional[int] = None,
     autodetect_task_port: bool = True,
@@ -102,9 +103,11 @@ def start_emulators(
         os.environ["DATASTORE_PROJECT_ID"] = project_id
 
         # Start the cloud datastore emulator
-        command = "gcloud beta emulators datastore start --consistency=1.0 --quiet --project=example"
+        command = "gcloud beta emulators datastore start --consistency=1.0 --quiet"
         command += " --host-port=127.0.0.1:%s" % datastore_port
 
+        if datastore_dir:
+            command += " --data-dir=%s" % datastore_dir
         if not persist_data:
             command += " --no-store-on-disk"
 


### PR DESCRIPTION
### Summary of changes proposed in this Pull Request:
- add parameter to `start_emulators` function to specify the datastore emulator `--data-dir` parameter

### PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [ ] Added tests for my change
