### PR TITLE
Update environment.task_queue_name() return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix error classes not inheriting from `Exception`
 - Fix an issue with `djangae.storage.CloudStorage` where calling `_open()` or `delete()` wouldn't use the correct bucket
 - Add parameter to control datastore emulator `--data-dir`
+- Update `environment.task_queue_name()` to return `default` if a queue name is not set
 
 ### Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@
 - Fix error classes not inheriting from `Exception`
 - Fix an issue with `djangae.storage.CloudStorage` where calling `_open()` or `delete()` wouldn't use the correct bucket
 - Add parameter to control datastore emulator `--data-dir`
-- Update `environment.task_queue_name()` to return `default` if a queue name is not set
+- Remove `environment.queue_name()` function, use `environment.task_queue_name()` instead
+- Update `environment.task_queue_name()` to return `default` if we're in a task and a queue name is not set, otherwise return `None`
+- Update `djangae/tasks/deferred.py` to handle the case where a queue name is not set
 
 ### Bug fixes:
 

--- a/djangae/environment.py
+++ b/djangae/environment.py
@@ -25,17 +25,12 @@ def is_development_environment():
 
 def is_in_task():
     "Returns True if the request is a task, False otherwise"
-    return bool(task_name()) or bool(queue_name())
+    return bool(task_name())
 
 
 def is_in_cron():
     "Returns True if the request is in a cron, False otherwise"
     return bool(os.environ.get("HTTP_X_APPENGINE_CRON"))
-
-
-def queue_name():
-    "Returns the name of the current task if any, else None"
-    return os.environ.get("HTTP_X_APPENGINE_QUEUENAME")
 
 
 def task_name():

--- a/djangae/environment.py
+++ b/djangae/environment.py
@@ -1,5 +1,6 @@
 import os
 from functools import wraps
+from typing import Optional
 
 from djangae.utils import memoized
 from django.http import HttpResponseForbidden
@@ -8,37 +9,37 @@ from django.http import HttpResponseForbidden
 # imports this before the SDK is added to sys.path. See bugs #899, #1055.
 
 
-def application_id():
+def application_id() -> str:
     # Fallback to example on local or if this is not specified in the
     # environment already
     result = os.environ.get("GAE_APPLICATION", "e~example").split("~", 1)[-1]
     return result
 
 
-def is_production_environment():
+def is_production_environment() -> bool:
     return not is_development_environment()
 
 
-def is_development_environment():
+def is_development_environment() -> bool:
     return 'GAE_ENV' not in os.environ or os.environ['GAE_ENV'] != 'standard'
 
 
-def is_in_task():
+def is_in_task() -> bool:
     "Returns True if the request is a task, False otherwise"
     return bool(task_name())
 
 
-def is_in_cron():
+def is_in_cron() -> bool:
     "Returns True if the request is in a cron, False otherwise"
     return bool(os.environ.get("HTTP_X_APPENGINE_CRON"))
 
 
-def task_name():
+def task_name() -> Optional[str]:
     "Returns the name of the current task if any, else None"
     return os.environ.get("HTTP_X_APPENGINE_TASKNAME")
 
 
-def task_retry_count():
+def task_retry_count() -> Optional[int]:
     "Returns the task retry count, or None if this isn't a task"
     try:
         return int(os.environ.get("HTTP_X_APPENGINE_TASKRETRYCOUNT"))
@@ -46,20 +47,20 @@ def task_retry_count():
         return None
 
 
-def task_queue_name():
+def task_queue_name() -> Optional[str]:
     "Returns the name of the current task queue (if this is a task) else 'default'"
     if "HTTP_X_APPENGINE_QUEUENAME" in os.environ:
         return os.environ["HTTP_X_APPENGINE_QUEUENAME"]
     return "default"
 
 
-def gae_version():
+def gae_version() -> Optional[str]:
     """Returns the current GAE version."""
     return os.environ.get('GAE_VERSION')
 
 
 @memoized
-def get_application_root():
+def get_application_root() -> str:
     """Traverse the filesystem upwards and return the directory containing app.yaml"""
     from django.conf import settings  # Avoid circular
 
@@ -106,11 +107,11 @@ def task_only(view_function):
     return replacement
 
 
-def default_gcs_bucket_name():
+def default_gcs_bucket_name() -> str:
     return "%s.appspot.com" % application_id()
 
 
-def project_id():
+def project_id() -> str:
     # Environment variable will exist on production servers
     # fallback to "example" locally if it doesn't exist
     return os.environ.get("GOOGLE_CLOUD_PROJECT", "example")

--- a/djangae/environment.py
+++ b/djangae/environment.py
@@ -1,4 +1,3 @@
-
 import os
 from functools import wraps
 
@@ -56,8 +55,7 @@ def task_queue_name():
     "Returns the name of the current task queue (if this is a task) else 'default'"
     if "HTTP_X_APPENGINE_QUEUENAME" in os.environ:
         return os.environ["HTTP_X_APPENGINE_QUEUENAME"]
-    else:
-        return None
+    return "default"
 
 
 def gae_version():

--- a/djangae/environment.py
+++ b/djangae/environment.py
@@ -49,9 +49,9 @@ def task_retry_count() -> Optional[int]:
 
 def task_queue_name() -> Optional[str]:
     "Returns the name of the current task queue (if this is a task) else 'default'"
-    if "HTTP_X_APPENGINE_QUEUENAME" in os.environ:
-        return os.environ["HTTP_X_APPENGINE_QUEUENAME"]
-    return "default"
+    if is_in_task():
+        return os.environ.get("HTTP_X_APPENGINE_QUEUENAME", "default")
+    return None
 
 
 def gae_version() -> Optional[str]:

--- a/djangae/tasks/deferred.py
+++ b/djangae/tasks/deferred.py
@@ -343,6 +343,10 @@ def _process_shard(marker_id, shard_number, model, query, callback, finalize, bu
         logger.warning("DeferIterationMarker with ID: %s has vanished, cancelling task", marker_id)
         return
 
+    queue = task_queue_name()
+    if queue:
+        queue = queue.rsplit("/", 1)[-1]
+
     # Redefer if the task isn't ready to begin
     if not marker.is_ready:
         defer(
@@ -350,7 +354,7 @@ def _process_shard(marker_id, shard_number, model, query, callback, finalize, bu
             buffer_time=buffer_time,
             args=args,
             kwargs=kwargs,
-            _queue=task_queue_name().rsplit("/", 1)[-1],
+            _queue=queue,
             _countdown=1
         )
         return
@@ -413,7 +417,7 @@ def _process_shard(marker_id, shard_number, model, query, callback, finalize, bu
                         finalize,
                         *args,
                         _transactional=True,
-                        _queue=task_queue_name().rsplit("/", 1)[-1],
+                        _queue=queue,
                         **kwargs
                     )
 
@@ -441,7 +445,7 @@ def _process_shard(marker_id, shard_number, model, query, callback, finalize, bu
             buffer_time=buffer_time,
             args=args,
             kwargs=kwargs,
-            _queue=task_queue_name().rsplit("/", 1)[-1],
+            _queue=queue,
             _countdown=1
         )
 
@@ -460,6 +464,10 @@ def _generate_shards(
         callback_name=callback.__name__,
         finalize_name=finalize.__name__
     )
+
+    queue = task_queue_name()
+    if queue:
+        queue = queue.rsplit("/", 1)[-1]
 
     for i, (start, end) in enumerate(key_ranges):
         is_last = i == (len(key_ranges) - 1)
@@ -494,7 +502,7 @@ def _generate_shards(
                 args=args,
                 kwargs=kwargs,
                 buffer_time=buffer_time,
-                _queue=task_queue_name().rsplit("/", 1)[-1],
+                _queue=queue,
                 _transactional=True
             )
 

--- a/djangae/tests/test_environment.py
+++ b/djangae/tests/test_environment.py
@@ -1,7 +1,12 @@
 import os
 
 from djangae.tasks.deferred import defer
-from djangae.environment import task_only, is_development_environment, is_production_environment
+from djangae.environment import (
+    is_development_environment,
+    is_production_environment,
+    task_only,
+    task_queue_name,
+)
 from djangae.test import TestCase
 from djangae.contrib import sleuth
 from django.http import HttpResponse
@@ -44,6 +49,7 @@ class TaskOnlyTestCase(TestCase):
 
 
 class EnvironmentUtilsTest(TestCase):
+
     def test_is_production_environment(self):
         self.assertFalse(is_production_environment())
         os.environ["GAE_ENV"] = 'standard'
@@ -55,6 +61,13 @@ class EnvironmentUtilsTest(TestCase):
         os.environ["GAE_ENV"] = 'standard'
         self.assertFalse(is_development_environment())
         del os.environ["GAE_ENV"]
+
+    def test_task_queue_name(self):
+        self.assertEqual(task_queue_name(), "default")
+        os.environ["HTTP_X_APPENGINE_QUEUENAME"] = "demo123"
+        self.assertEqual(task_queue_name(), "demo123")
+        del os.environ["HTTP_X_APPENGINE_QUEUENAME"]
+        self.assertEqual(task_queue_name(), "default")
 
 
 def deferred_func():

--- a/djangae/tests/test_environment.py
+++ b/djangae/tests/test_environment.py
@@ -63,11 +63,23 @@ class EnvironmentUtilsTest(TestCase):
         del os.environ["GAE_ENV"]
 
     def test_task_queue_name(self):
-        self.assertEqual(task_queue_name(), "default")
+        # when not in task
+        self.assertIsNone(task_queue_name())
         os.environ["HTTP_X_APPENGINE_QUEUENAME"] = "demo123"
-        self.assertEqual(task_queue_name(), "demo123")
+        self.assertIsNone(task_queue_name())
         del os.environ["HTTP_X_APPENGINE_QUEUENAME"]
-        self.assertEqual(task_queue_name(), "default")
+        self.assertIsNone(task_queue_name())
+
+        # when in task, w/o queue set
+        with sleuth.switch('djangae.environment.is_in_task', lambda: True):
+            self.assertEqual(task_queue_name(), "default")
+
+        # when in task, with queue set
+        with sleuth.switch('djangae.environment.is_in_task', lambda: True):
+            os.environ["HTTP_X_APPENGINE_QUEUENAME"] = "demo123"
+            self.assertEqual(task_queue_name(), "demo123")
+            del os.environ["HTTP_X_APPENGINE_QUEUENAME"]
+            self.assertEqual(task_queue_name(), "default")
 
 
 def deferred_func():


### PR DESCRIPTION
### Summary of changes proposed in this Pull Request:
- remove `environment.queue_name()` function, use `environment.task_queue_name()` instead
- update `environment.task_queue_name()` to return `default` if we're in a task and a queue name is not set, otherwise return `None`
- update `djangae/tasks/deferred.py` to handle the case where a queue name is not set

### PR checklist:
- [ ] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
