### PR TITLE
Add @task_or_superuser_only, and move decorators to djangae/decorator…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 - Update `environment.task_queue_name()` to return `default` if we're in a task and a queue name is not set, otherwise return `None`
 - Update `djangae/tasks/deferred.py` to handle the case where a queue name is not set
 - Add `google-cloud-tasks` as a requirement
+- Move `@task_only` to `djangae.decorators`
+- Add `@task_or_superuser_only` and `@csrf_exempt_if_task`
 
 ### Bug fixes:
 

--- a/djangae/contrib/backup/views.py
+++ b/djangae/contrib/backup/views.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.http import HttpResponse
-from djangae.environment import task_only
+from djangae.decorators import task_only
 
 from .tasks import backup_datastore
 from .utils import get_backup_setting

--- a/djangae/decorators.py
+++ b/djangae/decorators.py
@@ -48,10 +48,6 @@ def task_or_superuser_only(view_function):
 
 
 def csrf_exempt_if_task(view_function):
-    @wraps(view_function)
-    def replacement(request, *args, **kwargs):
-        return view_function(request, *args, **kwargs)
-
     class Replacement(object):
         def __call__(self, request, *args, **kwargs):
             return view_function(request, *args, **kwargs)

--- a/djangae/decorators.py
+++ b/djangae/decorators.py
@@ -54,7 +54,7 @@ def csrf_exempt_if_task(view_function):
 
     class Replacement(object):
         def __call__(self, request, *args, **kwargs):
-            view_function(request, *args, **kwargs)
+            return view_function(request, *args, **kwargs)
 
         @property
         def csrf_exempt(self):

--- a/djangae/decorators.py
+++ b/djangae/decorators.py
@@ -1,8 +1,10 @@
 
 from functools import wraps
-from django.http import HttpResponseForbidden
-from django.core.exceptions import ImproperlyConfigured
 
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponseForbidden
+
+from djangae.contrib.common import get_request
 
 _TASK_NAME_HEADER = "HTTP_X_APPENGINE_TASKNAME"
 _CRON_TASK_HEADER = "HTTP_X_APPENGINE_CRON"
@@ -54,7 +56,6 @@ def csrf_exempt_if_task(view_function):
 
         @property
         def csrf_exempt(self):
-            from djangae.contrib.common import get_request
             request = get_request()
 
             if not request:

--- a/djangae/decorators.py
+++ b/djangae/decorators.py
@@ -1,0 +1,46 @@
+
+from functools import wraps
+from django.http import HttpResponseForbidden
+
+
+_TASK_NAME_HEADER = "HTTP_X_APPENGINE_TASKNAME"
+_CRON_TASK_HEADER = "HTTP_X_APPENGINE_CRON"
+
+
+def task_only(view_function):
+    """ View decorator for restricting access to tasks (and crons) of the application
+        only.
+    """
+
+    @wraps(view_function)
+    def replacement(request, *args, **kwargs):
+
+        is_in_task = bool(request.META.get(_TASK_NAME_HEADER, False))
+        is_in_cron = bool(request.META.get(_CRON_TASK_HEADER, False))
+
+        if not any((is_in_task, is_in_cron)):
+            return HttpResponseForbidden("Access denied.")
+
+        return view_function(request, *args, **kwargs)
+
+    return replacement
+
+
+def task_or_superuser_only(view_function):
+    @wraps(view_function)
+    def replacement(request, *args, **kwargs):
+        is_superuser = (
+            getattr(request, "user", None) and
+            request.user.is_authenticated and
+            request.user.is_superuser
+        )
+
+        is_in_task = bool(request.META.get(_TASK_NAME_HEADER, False))
+        is_in_cron = bool(request.META.get(_CRON_TASK_HEADER, False))
+
+        if not any((is_superuser, is_in_task, is_in_cron)):
+            return HttpResponseForbidden("Access denied.")
+
+        return view_function(request, *args, **kwargs)
+
+    return replacement

--- a/djangae/environment.py
+++ b/djangae/environment.py
@@ -1,9 +1,7 @@
 import os
-from functools import wraps
 from typing import Optional
 
 from djangae.utils import memoized
-from django.http import HttpResponseForbidden
 
 # No SDK imports allowed in module namespace because `./manage.py runserver`
 # imports this before the SDK is added to sys.path. See bugs #899, #1055.
@@ -88,23 +86,6 @@ def get_application_root() -> str:
     # Use the Django base directory as a fallback. We search for app.yaml
     # first because that will be the "true" root of the GAE app
     return settings.BASE_DIR
-
-
-def task_only(view_function):
-    """ View decorator for restricting access to tasks (and crons) of the application
-        only.
-    """
-
-    @wraps(view_function)
-    def replacement(*args, **kwargs):
-        if not any((
-            is_in_task(),
-            is_in_cron(),
-        )):
-            return HttpResponseForbidden("Access denied.")
-        return view_function(*args, **kwargs)
-
-    return replacement
 
 
 def default_gcs_bucket_name() -> str:

--- a/djangae/tasks/handlers.py
+++ b/djangae/tasks/handlers.py
@@ -3,7 +3,7 @@ import pickle
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 
-from djangae.environment import task_only
+from djangae.decorators import task_only
 
 
 @csrf_exempt

--- a/djangae/tests/test_environment.py
+++ b/djangae/tests/test_environment.py
@@ -1,28 +1,39 @@
 import os
 
-from djangae.tasks.deferred import defer
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+from djangae.contrib import sleuth
+from djangae.decorators import (
+    task_only,
+    task_or_superuser_only,
+    _TASK_NAME_HEADER
+)
 from djangae.environment import (
     is_development_environment,
     is_production_environment,
-    task_only,
     task_queue_name,
 )
+from djangae.tasks.deferred import defer
 from djangae.test import TestCase
-from djangae.contrib import sleuth
-from django.http import HttpResponse
 
 
 class TaskOnlyTestCase(TestCase):
     """ Tests for the @task_only decorator. """
 
-    def test_403_if_not_task_or_admin(self):
+    def setUp(self):
+        self.factory = RequestFactory()
+        super().setUp()
+
+    def test_403_if_not_task(self):
         # If we are neither in a task or logged in as an admin, we expect a 403 response
 
         @task_only
         def view(request):
             return HttpResponse("Hello")
 
-        response = view(None)
+        request = self.factory.get("/")
+        response = view(request)
         self.assertEqual(response.status_code, 403)
 
     def test_allowed_if_in_task(self):
@@ -32,8 +43,10 @@ class TaskOnlyTestCase(TestCase):
         def view(request):
             return HttpResponse("Hello")
 
+        request = self.factory.get("/")
         with sleuth.fake("djangae.environment.is_in_task", True):
-            response = view(None)
+            response = view(request)
+
         self.assertEqual(response.status_code, 200)
 
     def test_allowed_if_in_cron(self):
@@ -43,8 +56,62 @@ class TaskOnlyTestCase(TestCase):
         def view(request):
             return HttpResponse("Hello")
 
+        request = self.factory.get("/")
+
         with sleuth.fake("djangae.environment.is_in_cron", True):
-            response = view(None)
+            response = view(request)
+        self.assertEqual(response.status_code, 200)
+
+
+class TaskOrSuperuserOnlyTestCase(TestCase):
+    """ Tests for the @task_only decorator. """
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        super().setUp()
+
+    def test_403_if_not_task_or_superuser(self):
+        # If we are neither in a task or logged in as an admin, we expect a 403 response
+
+        @task_or_superuser_only
+        def view(request):
+            return HttpResponse("Hello")
+
+        request = self.factory.get("/")
+        response = view(request)
+        self.assertEqual(response.status_code, 403)
+
+    def test_allowed_if_in_task(self):
+        """ If we're in an App Engine task then it should allow the request through. """
+
+        @task_or_superuser_only
+        def view(request):
+            return HttpResponse("Hello")
+
+        request = self.factory.get("/")
+        request.META[_TASK_NAME_HEADER] = "test"
+
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_allowed_if_superuser(self):
+        """ If we're in an App Engine task then it should allow the request through. """
+
+        @task_or_superuser_only
+        def view(request):
+            return HttpResponse("Hello")
+
+        class User(object):
+            is_superuser = True
+            is_authenticated = True
+
+        request = self.factory.get("/")
+        request.user = None
+        response = view(request)
+        self.assertEqual(response.status_code, 403)
+
+        request.user = User()
+        response = view(request)
         self.assertEqual(response.status_code, 200)
 
 

--- a/djangae/tests/test_environment.py
+++ b/djangae/tests/test_environment.py
@@ -146,6 +146,9 @@ class CsrfExemptIfTaskTest(TestCase):
         response = client.post(reverse("test_view"))
         self.assertEqual(response.status_code, 403)
 
+        response = client.post(reverse("test_view"), HTTP_X_APPENGINE_TASKNAME="test")
+        self.assertEqual(response.status_code, 200)
+
 
 class EnvironmentUtilsTest(TestCase):
 

--- a/djangae/tests/test_environment.py
+++ b/djangae/tests/test_environment.py
@@ -5,9 +5,10 @@ from django.test import RequestFactory
 
 from djangae.contrib import sleuth
 from djangae.decorators import (
+    _CRON_TASK_HEADER,
+    _TASK_NAME_HEADER,
     task_only,
     task_or_superuser_only,
-    _TASK_NAME_HEADER
 )
 from djangae.environment import (
     is_development_environment,
@@ -44,6 +45,7 @@ class TaskOnlyTestCase(TestCase):
             return HttpResponse("Hello")
 
         request = self.factory.get("/")
+        request.META[_TASK_NAME_HEADER] = "test"
         with sleuth.fake("djangae.environment.is_in_task", True):
             response = view(request)
 
@@ -57,6 +59,7 @@ class TaskOnlyTestCase(TestCase):
             return HttpResponse("Hello")
 
         request = self.factory.get("/")
+        request.META[_CRON_TASK_HEADER] = "test"
 
         with sleuth.fake("djangae.environment.is_in_cron", True):
             response = view(request)

--- a/djangae/tests/test_views.py
+++ b/djangae/tests/test_views.py
@@ -1,4 +1,3 @@
-import os
 from djangae.test import TestCase
 from django.urls import reverse
 

--- a/djangae/tests/test_views.py
+++ b/djangae/tests/test_views.py
@@ -8,7 +8,5 @@ class ViewsTests(TestCase):
         response = self.client.post(reverse("clearsessions"))
         self.assertEqual(response.status_code, 403)
 
-        os.environ["HTTP_X_APPENGINE_CRON"] = "1"
-        response = self.client.post(reverse("clearsessions"))
+        response = self.client.post(reverse("clearsessions"), HTTP_X_APPENGINE_CRON="1")
         self.assertEqual(response.status_code, 200)
-        del os.environ["HTTP_X_APPENGINE_CRON"]

--- a/djangae/views.py
+++ b/djangae/views.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 
-from djangae import environment
+from djangae import environment, decorators
 from djangae.core.signals import module_started, module_stopped
 
 
@@ -73,7 +73,7 @@ def deferred(request):
     return response
 
 
-@environment.task_only
+@decorators.task_only
 def clearsessions(request):
     engine = import_module(settings.SESSION_ENGINE)
     try:

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -36,6 +36,12 @@ Returns true if the code is running in a task on the task queue
 Returns the number of times the task has retried, or 0 if the code is not
 running on a queue
 
-## djangae.environment.task_only
+# Decorators
+
+## djangae.decorators.task_only
 
 View decorator to allow restricting views to tasks (including crons) or admins of the application.
+
+## djangae.decorators.task_or_superuser_only
+
+View decorator that allows through tasks, or users with `is_superuser == True`

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -45,3 +45,7 @@ View decorator to allow restricting views to tasks (including crons) or admins o
 ## djangae.decorators.task_or_superuser_only
 
 View decorator that allows through tasks, or users with `is_superuser == True`
+
+## djangae.decorators.csrf_except_if_task
+
+View decorator that marks the view csrf_exempt *only* if it's being requested by Cloud Tasks

--- a/test_settings.py
+++ b/test_settings.py
@@ -30,6 +30,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'djangae.contrib.common.middleware.RequestStorageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Move `@task_only` to djangae/decorators.py
- Add `@task_or_superuser_only`
- Add `@csrf_exempt_if_task`
- Changed `@task_only` to use request headers, rather than os.environ (which won't exist locally)

PR checklist:
- [x] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [x] Added tests for my change
