### PR TITLE
Generate username function now being used in OAuth flow

### DIFF
--- a/djangae/contrib/googleauth/backends/__init__.py
+++ b/djangae/contrib/googleauth/backends/__init__.py
@@ -12,12 +12,12 @@ def _find_atomic_decorator(model):
 
     # FIXME: When Django GCloud Connectors gets rid of its own atomic decorator
     # the Django atomic() decorator can be used regardless
-    
+
     if connection.settings_dict['ENGINE'] == 'gcloudc.db.backends.datastore':
         from gcloudc.db.transaction import atomic
     else:
         from django.db.transaction import atomic
-    
+
     return atomic
 
 

--- a/djangae/contrib/googleauth/backends/__init__.py
+++ b/djangae/contrib/googleauth/backends/__init__.py
@@ -1,8 +1,9 @@
+import random
+import string
 from django.db import (
     connections,
     router,
 )
-
 from ..models import User
 
 
@@ -11,11 +12,12 @@ def _find_atomic_decorator(model):
 
     # FIXME: When Django GCloud Connectors gets rid of its own atomic decorator
     # the Django atomic() decorator can be used regardless
+    
     if connection.settings_dict['ENGINE'] == 'gcloudc.db.backends.datastore':
         from gcloudc.db.transaction import atomic
     else:
         from django.db.transaction import atomic
-
+    
     return atomic
 
 

--- a/djangae/contrib/googleauth/backends/__init__.py
+++ b/djangae/contrib/googleauth/backends/__init__.py
@@ -3,6 +3,8 @@ from django.db import (
     router,
 )
 
+from ..models import User
+
 
 def _find_atomic_decorator(model):
     connection = connections[router.db_for_read(model)]
@@ -15,3 +17,25 @@ def _find_atomic_decorator(model):
         from django.db.transaction import atomic
 
     return atomic
+
+
+def _generate_unused_username(ideal):
+    """
+        Check the database for a user with the specified username
+        and return either that ideal username, or an unused generated
+        one using the ideal username as a base
+    """
+
+    if not User.objects.filter(username_lower=ideal.lower()).exists():
+        return ideal
+
+    exists = True
+
+    # We use random digits rather than anything sequential to avoid any kind of
+    # attack vector to get this loop stuck
+    while exists:
+        random_digits = "".join([random.choice(string.digits) for x in range(5)])
+        username = "%s-%s" % (ideal, random_digits)
+        exists = User.objects.filter(username_lower=username.lower).exists()
+
+    return username

--- a/djangae/contrib/googleauth/backends/iap.py
+++ b/djangae/contrib/googleauth/backends/iap.py
@@ -6,32 +6,10 @@ from django.contrib.auth import get_user_model
 
 from djangae.contrib.googleauth.models import UserManager
 
-from . import _find_atomic_decorator
+from . import _find_atomic_decorator, _generate_unused_username
 from .base import BaseBackend
 
 User = get_user_model()
-
-
-def _generate_unused_username(ideal):
-    """
-        Check the database for a user with the specified username
-        and return either that ideal username, or an unused generated
-        one using the ideal username as a base
-    """
-
-    if not User.objects.filter(username_lower=ideal.lower()).exists():
-        return ideal
-
-    exists = True
-
-    # We use random digits rather than anything sequential to avoid any kind of
-    # attack vector to get this loop stuck
-    while exists:
-        random_digits = "".join([random.choice(string.digits) for x in range(5)])
-        username = "%s-%s" % (ideal, random_digits)
-        exists = User.objects.filter(username_lower=username.lower).exists()
-
-    return username
 
 
 class IAPBackend(BaseBackend):

--- a/djangae/contrib/googleauth/backends/iap.py
+++ b/djangae/contrib/googleauth/backends/iap.py
@@ -1,6 +1,4 @@
 import logging
-import random
-import string
 
 from django.contrib.auth import get_user_model
 

--- a/djangae/contrib/googleauth/backends/oauth2.py
+++ b/djangae/contrib/googleauth/backends/oauth2.py
@@ -5,9 +5,8 @@ from ..models import (
     UserManager,
     UserPermission,
 )
-from . import _find_atomic_decorator
+from . import _find_atomic_decorator, _generate_unused_username
 from .base import BaseBackend
-from .iap import _generate_unused_username
 
 
 class OAuthBackend(BaseBackend):

--- a/djangae/contrib/googleauth/backends/oauth2.py
+++ b/djangae/contrib/googleauth/backends/oauth2.py
@@ -7,6 +7,7 @@ from ..models import (
 )
 from . import _find_atomic_decorator
 from .base import BaseBackend
+from .iap import _generate_unused_username
 
 
 class OAuthBackend(BaseBackend):
@@ -24,6 +25,7 @@ class OAuthBackend(BaseBackend):
 
         email = UserManager.normalize_email(profile["email"])
         assert email
+        username = email.split("@", 1)[0]
 
         with atomic():
             # Look for a user, either by oauth session ID, or email
@@ -51,7 +53,8 @@ class OAuthBackend(BaseBackend):
                 # First time we've seen this user
                 user = User.objects.create(
                     google_oauth_id=oauth_session.pk,
-                    email=email
+                    email=email,
+                    username=_generate_unused_username(username)
                 )
 
         return user


### PR DESCRIPTION
Fixes #[include a number of issue this PR is fixing].

Summary of changes proposed in this Pull Request:
- `_generate_unused_username` now being used in `oauth2.py`
- Profile object does not contain username - only userId, full name, given name, family name, image URL and email, so we won't create add char field `profile_username` to `AbstractGoogleUser`


PR checklist: 
- [ ] Added tests for my change
