### PR TITLE
Use google_oauth_id to fetch oauth session, authenticate with iap if …

### DIFF
--- a/djangae/contrib/googleauth/middleware.py
+++ b/djangae/contrib/googleauth/middleware.py
@@ -104,6 +104,7 @@ class AuthenticationMiddleware(AuthenticationMiddleware):
             if iap_backend and IAPBackend.can_authenticate(request):
                 user = iap_backend.authenticate(request)
                 if user and user.is_authenticated:
+                    user.backend = 'djangae.contrib.googleauth.backends.iap.%s' % IAPBackend.__name__
                     login(request, user)
 
 

--- a/djangae/contrib/googleauth/middleware.py
+++ b/djangae/contrib/googleauth/middleware.py
@@ -10,7 +10,7 @@ from django.contrib.auth import (
     HASH_SESSION_KEY,
     REDIRECT_FIELD_NAME,
     _get_user_session_key,
-    authenticate,
+    get_backends,
     constant_time_compare,
     load_backend,
     login,
@@ -75,14 +75,14 @@ class AuthenticationMiddleware(AuthenticationMiddleware):
         ) % ("_CLASSES" if settings.MIDDLEWARE is None else "")
 
         request.user = SimpleLazyObject(lambda: get_user(request))
-
         backend_str = request.session.get(BACKEND_SESSION_KEY)
+
         if request.user.is_authenticated:
             if backend_str and isinstance(load_backend(backend_str), OAuthBackend):
                 # The user is authenticated with Django, and they use the OAuth backend, so they
                 # should have a valid oauth session
                 oauth_session = OAuthUserSession.objects.filter(
-                    pk=request.user.username
+                    pk=request.user.google_oauth_id
                 ).first()
 
                 # Their oauth session expired, so let's log them out
@@ -93,10 +93,16 @@ class AuthenticationMiddleware(AuthenticationMiddleware):
                 if not IAPBackend.can_authenticate(request):
                     logout(request)
         else:
+            backends = get_backends()
+            try:
+                iap_backend = next(filter(lambda be: isinstance(be, IAPBackend), backends))
+            except StopIteration:
+                iap_backend = None
+
             # Try to authenticate with IAP if the headers
             # are available
-            if IAPBackend.can_authenticate(request):
-                user = authenticate(request)
+            if iap_backend and IAPBackend.can_authenticate(request):
+                user = iap_backend.authenticate(request)
                 if user and user.is_authenticated:
                     login(request, user)
 

--- a/djangae/contrib/googleauth/tests/test_middleware.py
+++ b/djangae/contrib/googleauth/tests/test_middleware.py
@@ -1,0 +1,215 @@
+from djangae.contrib.googleauth.backends.iap import IAPBackend
+from django.conf import settings
+from djangae.contrib.googleauth.models import AnonymousUser
+from djangae.test import TestCase
+from unittest.mock import patch, Mock
+from djangae.contrib.googleauth.middleware import AuthenticationMiddleware
+from djangae.contrib.googleauth.backends.oauth2 import OAuthBackend
+from djangae.contrib.googleauth.models import OAuthUserSession
+from django.test import (RequestFactory)
+from django.contrib.auth import get_user_model, BACKEND_SESSION_KEY
+
+
+class AuthBackendTests(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        settings.AUTHENTICATION_BACKENDS = (
+             "djangae.contrib.googleauth.backends.oauth2.OAuthBackend",
+             "djangae.contrib.googleauth.backends.iap.IAPBackend",
+        )
+        self.middleware = AuthenticationMiddleware()
+        self.request = RequestFactory().get('/')
+        self.request.session = {}
+
+    @patch('djangae.contrib.googleauth.middleware.load_backend', return_value=OAuthBackend())
+    def test_anonymous_user_if_not_authenticated(self, load_backend_mock):
+        self.middleware.process_request(self.request)
+        self.assertIsInstance(self.request.user, AnonymousUser)
+
+    @patch('djangae.contrib.googleauth.middleware.IAPBackend.can_authenticate', return_value=True)
+    @patch('djangae.contrib.googleauth.middleware.login')
+    @patch('djangae.contrib.googleauth.middleware.get_backends')
+    def test_user_if_iap_headers(self, get_backends_mock, login_mock, can_auth):
+        iap_backend_mock = Mock(spec=IAPBackend)
+        user = Mock()
+        iap_backend_mock.authenticate.return_value = user
+        get_backends_mock.return_value = [iap_backend_mock]
+
+        self.middleware.process_request(self.request)
+
+        can_auth.assert_called_once()
+        iap_backend_mock.authenticate.assert_called_once()
+        login_mock.assert_called_once_with(self.request, user)
+
+    @patch('djangae.contrib.googleauth.middleware.IAPBackend.can_authenticate', return_value=True)
+    @patch('djangae.contrib.googleauth.middleware.login')
+    @patch('djangae.contrib.googleauth.middleware.get_backends')
+    def test_no_iap_login_if_not_installed(self, get_backends_mock, login_mock, can_auth):
+        oauth_backend_mock = Mock(spec=OAuthBackend)
+        get_backends_mock.return_value = [oauth_backend_mock]
+
+        self.middleware.process_request(self.request)
+
+        can_auth.assert_not_called()
+        login_mock.assert_not_called()
+
+    @patch('djangae.contrib.googleauth.middleware.get_user')
+    @patch('djangae.contrib.googleauth.middleware.logout')
+    @patch('djangae.contrib.googleauth.middleware.load_backend')
+    def test_oauth_no_oauth_session(self, load_backend_mock, logout_mock, get_user_mock):
+        # Session has an authenticated user
+        user_mock = Mock(spec=get_user_model())
+        user_mock.is_authenticated = True
+        user_mock.google_oauth_id = '1'
+        get_user_mock.return_value = user_mock
+
+        # It has a session that uses oauth
+        OAUTH_SESSION_KEY = 'key'
+        self.request.session[BACKEND_SESSION_KEY] = OAUTH_SESSION_KEY
+
+        # Loads the oauth backend
+        oauth_backend_mock = Mock(spec=OAuthBackend)
+        load_backend_mock.return_value = oauth_backend_mock
+
+        self.middleware.process_request(self.request)
+
+        # Check is loading the right backend
+        load_backend_mock.assert_called_once_with(OAUTH_SESSION_KEY)
+
+        # Session does not exist, logging out.
+        logout_mock.assert_called_once_with(self.request)
+
+    @patch('djangae.contrib.googleauth.middleware.OAuthUserSession', spec=OAuthUserSession)
+    @patch('djangae.contrib.googleauth.middleware.get_user')
+    @patch('djangae.contrib.googleauth.middleware.logout')
+    @patch('djangae.contrib.googleauth.middleware.load_backend')
+    def test_oauth_oauth_session_invalid(self, load_backend_mock, logout_mock, get_user_mock, OAuthUserSession_mock):
+        # Session has an authenticated user
+        user_mock = Mock(spec=get_user_model())
+        user_mock.is_authenticated = True
+        user_mock.google_oauth_id = '1'
+        get_user_mock.return_value = user_mock
+
+        # It has a session that uses oauth
+        OAUTH_SESSION_KEY = 'key'
+        self.request.session[BACKEND_SESSION_KEY] = OAUTH_SESSION_KEY
+
+        # Loads the oauth backend
+        oauth_backend_mock = Mock(spec=OAuthBackend)
+        load_backend_mock.return_value = oauth_backend_mock
+
+        # Loads a OAuthUserSession that is invalid
+        invalid_OAuth_session = Mock(OAuthUserSession)
+        invalid_OAuth_session.is_valid = False
+        OAuthUserSession_mock.objects.filter.return_value.first.return_value = invalid_OAuth_session
+
+        self.middleware.process_request(self.request)
+
+        # Check is getting user
+        get_user_mock.assert_called_once_with(self.request)
+
+        # Check is loading the right backend
+        load_backend_mock.assert_called_once_with(OAUTH_SESSION_KEY)
+
+        # Check is fetching the right session with
+        OAuthUserSession_mock.objects.filter.assert_called_once_with(pk=self.request.user.google_oauth_id)
+
+        # Session does not exist, logging out.
+        logout_mock.assert_called_once_with(self.request)
+
+    @patch('djangae.contrib.googleauth.middleware.OAuthUserSession', spec=OAuthUserSession)
+    @patch('djangae.contrib.googleauth.middleware.get_user')
+    @patch('djangae.contrib.googleauth.middleware.logout')
+    @patch('djangae.contrib.googleauth.middleware.load_backend')
+    def test_oauth_oauth_session_valid(self, load_backend_mock, logout_mock, get_user_mock, OAuthUserSession_mock):
+        # Session has an authenticated user
+        user_mock = Mock(spec=get_user_model())
+        user_mock.is_authenticated = True
+        user_mock.google_oauth_id = '1'
+        get_user_mock.return_value = user_mock
+
+        # It has a session that uses oauth
+        OAUTH_SESSION_KEY = 'key'
+        self.request.session[BACKEND_SESSION_KEY] = OAUTH_SESSION_KEY
+
+        # Loads the oauth backend
+        oauth_backend_mock = Mock(spec=OAuthBackend)
+        load_backend_mock.return_value = oauth_backend_mock
+
+        # Loads a OAuthUserSession that is valid
+        valid_OAuth_session = Mock(OAuthUserSession)
+        valid_OAuth_session.is_valid = True
+        OAuthUserSession_mock.objects.filter.return_value.first.return_value = valid_OAuth_session
+
+        self.middleware.process_request(self.request)
+
+        # Check is getting user
+        get_user_mock.assert_called_once_with(self.request)
+
+        # Check is loading the right backend
+        load_backend_mock.assert_called_once_with(OAUTH_SESSION_KEY)
+
+        # Check is fetching the right session with
+        OAuthUserSession_mock.objects.filter.assert_called_once_with(pk=self.request.user.google_oauth_id)
+
+        # Session does not exist, logging out.
+        logout_mock.assert_not_called()
+
+    @patch('djangae.contrib.googleauth.middleware.IAPBackend.can_authenticate', return_value=False)
+    @patch('djangae.contrib.googleauth.middleware.get_user')
+    @patch('djangae.contrib.googleauth.middleware.logout')
+    @patch('djangae.contrib.googleauth.middleware.load_backend')
+    def test_iap_iap_cant_authenticate(
+        self,
+        load_backend_mock,
+        logout_mock,
+        get_user_mock,
+        can_authenticate_mock
+    ):
+        # Session has an authenticated user
+        user_mock = Mock(spec=get_user_model())
+        user_mock.is_authenticated = True
+        get_user_mock.return_value = user_mock
+
+        # It has a session_str
+        OAUTH_SESSION_KEY = 'key'
+        self.request.session[BACKEND_SESSION_KEY] = OAUTH_SESSION_KEY
+
+        # Loads the iap backend
+        iap_backend_mock = Mock(spec=IAPBackend)
+        load_backend_mock.return_value = iap_backend_mock
+
+        self.middleware.process_request(self.request)
+
+        # Logging out.
+        logout_mock.assert_called_once_with(self.request)
+
+    @patch('djangae.contrib.googleauth.middleware.IAPBackend.can_authenticate', return_value=True)
+    @patch('djangae.contrib.googleauth.middleware.get_user')
+    @patch('djangae.contrib.googleauth.middleware.logout')
+    @patch('djangae.contrib.googleauth.middleware.load_backend')
+    def test_iap_iap_session_valid(
+        self,
+        load_backend_mock,
+        logout_mock,
+        get_user_mock,
+        can_authenticate_mock
+    ):
+        # Session has an authenticated user
+        user_mock = Mock(spec=get_user_model())
+        user_mock.is_authenticated = True
+        get_user_mock.return_value = user_mock
+
+        # It has a session_str
+        OAUTH_SESSION_KEY = 'key'
+        self.request.session[BACKEND_SESSION_KEY] = OAUTH_SESSION_KEY
+
+        # Loads the iap backend
+        iap_backend_mock = Mock(spec=IAPBackend)
+        load_backend_mock.return_value = iap_backend_mock
+
+        self.middleware.process_request(self.request)
+
+        # Logging out.
+        logout_mock.not_called()

--- a/djangae/contrib/googleauth/tests/test_middleware.py
+++ b/djangae/contrib/googleauth/tests/test_middleware.py
@@ -1,5 +1,4 @@
 from djangae.contrib.googleauth.backends.iap import IAPBackend
-from django.conf import settings
 from djangae.contrib.googleauth.models import AnonymousUser
 from djangae.test import TestCase
 from unittest.mock import patch, Mock
@@ -14,10 +13,7 @@ class AuthBackendTests(TestCase):
 
     def setUp(self):
         super().setUp()
-        settings.AUTHENTICATION_BACKENDS = (
-             "djangae.contrib.googleauth.backends.oauth2.OAuthBackend",
-             "djangae.contrib.googleauth.backends.iap.IAPBackend",
-        )
+
         self.middleware = AuthenticationMiddleware()
         self.request = RequestFactory().get('/')
         self.request.session = {}


### PR DESCRIPTION
…iap is available and add tests #1263

Fixes #[include a number of issue this PR is fixing].

Summary of changes proposed in this Pull Request:
- Using google_oauth_id to get the OauthSession
- Authenticating with IAP only if is installed
- If IAP installed use it to authenticate 
- Added some tests to the middleware ( not for everything, but few should still be better than none)

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
