### PR TITLE
Pass project-id to datastore start #1279

### DIFF
--- a/djangae/sandbox.py
+++ b/djangae/sandbox.py
@@ -103,7 +103,7 @@ def start_emulators(
         os.environ["DATASTORE_PROJECT_ID"] = project_id
 
         # Start the cloud datastore emulator
-        command = "gcloud beta emulators datastore start --consistency=1.0 --quiet --project=example"
+        command = f"gcloud beta emulators datastore start --consistency=1.0 --quiet --project={project_id}"
         command += " --host-port=127.0.0.1:%s" % datastore_port
 
         if datastore_dir:


### PR DESCRIPTION
Fixes #1279 
Summary of changes proposed in this Pull Request:
- Pass project_id to datasatore start command

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [ ] Added tests for my change
