### PR TITLE
Add the ability to order by a document field

### DIFF
--- a/djangae/contrib/search/index.py
+++ b/djangae/contrib/search/index.py
@@ -201,8 +201,10 @@ class Index(object):
             match_all=match_all,
         )[:limit]
 
+        doc_instance = document_class()
+
         def get_field_value(field_name, record):
-            field = document_class().get_field(field_name)
+            field = doc_instance.get_field(field_name)
             return field.convert_from_index(record.data[field_name])
 
         if order_by:

--- a/djangae/contrib/search/index.py
+++ b/djangae/contrib/search/index.py
@@ -180,6 +180,7 @@ class Index(object):
         use_stemming=False,
         use_startswith=False,
         match_all=True,
+        order_by=None
     ):
         """
             Perform a search of the index.
@@ -200,12 +201,18 @@ class Index(object):
             match_all=match_all,
         )[:limit]
 
+        def get_field_value(field_name, record):
+            field = document_class().get_field(field_name)
+            return field.convert_from_index(record.data[field_name])
+
+        if order_by:
+            qs = sorted(list(qs), key=lambda x: get_field_value(order_by, x))
+
         for record in qs:
             data = {}
 
-            for k, v in record.data.items():
-                field = document_class().get_field(k)
-                data[k] = field.convert_from_index(v)
+            for field_name in record.data:
+                data[field_name] = get_field_value(field_name, record)
 
             yield document_class(_record=record, **data)
 

--- a/djangae/contrib/search/tests/test_query.py
+++ b/djangae/contrib/search/tests/test_query.py
@@ -196,3 +196,22 @@ class QueryTests(TestCase):
         results = list(index.search("1-2-3", Doc))
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].id, doc2)
+
+
+class SearchRankingTests(TestCase):
+
+    def test_ordered_by_rank(self):
+        class Doc(Document):
+            text = fields.TextField()
+            rank = fields.NumberField()
+
+        index = Index(name="test")
+        doc1 = index.add(Doc(text="test", rank=100))
+        doc2 = index.add(Doc(text="test", rank=50))
+        doc3 = index.add(Doc(text="test", rank=150))
+
+        results = list(index.search("test", Doc, order_by="rank"))
+
+        self.assertEqual(results[0].id, doc2)
+        self.assertEqual(results[1].id, doc1)
+        self.assertEqual(results[2].id, doc3)


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Adds the ability to pass an order_by field to index.search()

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
