### PR TITLE
Non indexable search fields

### DIFF
--- a/djangae/contrib/search/__init__.py
+++ b/djangae/contrib/search/__init__.py
@@ -8,6 +8,14 @@ from .model_document import (  # noqa
     register,
 )
 
+from .fields import (  # noqa
+    IntegrityError,
+    TextField,
+    NumberField,
+    DateField,
+    FuzzyTextField
+)
+
 default_app_config = 'djangae.contrib.search.apps.SearchConfig'
 
 

--- a/djangae/contrib/search/fields.py
+++ b/djangae/contrib/search/fields.py
@@ -8,10 +8,25 @@ from .constants import STOP_WORDS
 from .tokens import tokenize_content
 
 
+class IntegrityError(ValueError):
+    pass
+
+
 class Field(object):
-    def __init__(self, default=None, null=True):
+    def __init__(self, default=None, null=True, index=True):
+        """
+            default: The default value for this field. A value of None or a string of
+            non-indexable tokens will not be indexed, but the value will be stored on the document
+
+            null: If False, will throw an IntegrityError if the value of the field is None. It will
+                  *not* throw if the field contains a value that results in no indexable tokens, or
+                  if the field is an empty string, only if the value is explicitly None.
+
+            index: If False, the field will not be searchable, but will be stored on the document
+        """
         self.default = default
         self.null = null
+        self.index = index
 
     def normalize_value(self, value):
         # Default behaviour is to lower-case, remove punctuation

--- a/djangae/contrib/search/index.py
+++ b/djangae/contrib/search/index.py
@@ -94,6 +94,10 @@ class Index(object):
                     if field_name == "id":
                         continue
 
+                    if not field.index:
+                        # Some fields are just stored, not indexed
+                        continue
+
                     # Get the field value, use the default if it's not set
                     value = getattr(document, field.attname, None)
                     value = field.default if value is None else value

--- a/djangae/contrib/search/index.py
+++ b/djangae/contrib/search/index.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from gcloudc.db import transaction
 
 from .document import Document
-
+from .fields import IntegrityError
 
 _DEFAULT_INDEX_NAME = "default"
 
@@ -23,6 +23,14 @@ class Index(object):
     @property
     def id(self):
         return self.index.pk if self.index else None
+
+    def _validate_documents(self, documents):
+        for document in documents:
+            for field in document.get_fields().values():
+                if not field.null:
+                    value = getattr(document, field.attname, None)
+                    if value is None:
+                        raise IntegrityError()
 
     def add(self, document_or_documents):
         """
@@ -46,6 +54,9 @@ class Index(object):
         else:
             was_list = True
             documents = document_or_documents[:]
+
+        # First-pass validation
+        self._validate_documents(documents)
 
         with transaction.atomic(independent=True):
             for document in documents:

--- a/djangae/contrib/search/tests/test_indexing.py
+++ b/djangae/contrib/search/tests/test_indexing.py
@@ -232,3 +232,24 @@ class IndexingTests(TestCase):
 
         self.assertRaises(IntegrityError, index.add, [doc1, doc2])
         self.assertEqual(index.document_count(), 0)  # Nothing should've been indexed
+
+    def test_field_index_flag_respected(self):
+        class Doc(Document):
+            text = fields.TextField()
+            other_text = fields.TextField(index=False)
+
+        index = Index("test")
+        doc1 = Doc(text="foo", other_text="bar")
+        doc2 = Doc(text="bar", other_text="foo")
+
+        index.add([doc1, doc2])
+
+        results = list(index.search("foo", Doc))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, "foo")
+        self.assertEqual(results[0].other_text, "bar")
+
+        results = list(index.search("bar", Doc))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].text, "bar")
+        self.assertEqual(results[0].other_text, "foo")

--- a/djangae/contrib/search/tests/test_indexing.py
+++ b/djangae/contrib/search/tests/test_indexing.py
@@ -1,6 +1,6 @@
 from unittest import skip
 
-from djangae.contrib.search import fields
+from djangae.contrib.search import fields, IntegrityError
 from djangae.contrib.search.document import Document
 from djangae.contrib.search.index import Index
 from djangae.contrib.search.models import TokenFieldIndex
@@ -215,3 +215,20 @@ class IndexingTests(TestCase):
             tokens + new_tokens,
             ["This", "-", "is", "some", "text", "with", "-", "hyphens", ".", "I-B-M", "IBM", "I.B.M"]
         )
+
+    def test_null_validation(self):
+        """
+            If a field is marked as null=False, and someone tries to index
+            None, then an IntegrityError should throw. None of the documents
+            should be indexed if one of them is invalid.
+        """
+
+        class Doc(Document):
+            text = fields.TextField(null=False)
+
+        index = Index("test")
+        doc1 = Doc(text="test")
+        doc2 = Doc(text=None)
+
+        self.assertRaises(IntegrityError, index.add, [doc1, doc2])
+        self.assertEqual(index.document_count(), 0)  # Nothing should've been indexed

--- a/djangae/contrib/search/tests/test_searchable.py
+++ b/djangae/contrib/search/tests/test_searchable.py
@@ -42,6 +42,19 @@ class SearchableTest(TestCase):
         self.i5 = SearchableModel1.objects.create(name="Alton Powers")
         self.instances = [self.i1, self.i2, self.i3, self.i4, self.i5]
 
+    def test_pk_not_implicitly_searchable(self):
+        """
+            All ModelDocuments have an implicit instance_id. We need
+            to make sure that isn't implicitly searchable
+        """
+
+        SearchableModel1.objects.create(id=999, name="test")
+        results = list(SearchableModel1.objects.search("999"))
+        self.assertFalse(results)
+
+        results = list(SearchableModel1.objects.search("test"))
+        self.assertTrue(results)
+
     def test_searching_models(self):
         results = SearchableModel1.objects.search("luke")
         self.assertCountEqual(results, [self.i1])

--- a/djangaeidx.yaml
+++ b/djangaeidx.yaml
@@ -1,0 +1,3 @@
+search_documentrecord:
+  data:
+  - json_path__instance_id


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Add index=False/True to search fields
- Implement null=False
- Make ModelDocument.instance_id index=False

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
