### PR TITLE
1292 oauth consent screen

### DIFF
--- a/djangae/contrib/googleauth/decorators.py
+++ b/djangae/contrib/googleauth/decorators.py
@@ -63,3 +63,11 @@ def oauth_scopes_required(scopes, offline=False):
 
         return wrapper
     return func_wrapper
+
+
+def auth_middleware_exempt(view_func):
+    """Decorator to mark a view function that is to be skipped by
+    the AuthenticationMiddleware.process_view method.
+    """
+    view_func._auth_middleware_exempt = True
+    return view_func

--- a/djangae/contrib/googleauth/middleware.py
+++ b/djangae/contrib/googleauth/middleware.py
@@ -92,7 +92,7 @@ class AuthenticationMiddleware(AuthenticationMiddleware):
                     pk=request.user.google_oauth_id
                 ).first()
 
-                # Their oauth session expired, so let's log them out
+                # Their oauth session does not exist, so let's log them out
                 if not oauth_session:
                     logout(request)
                     return None

--- a/djangae/contrib/googleauth/middleware.py
+++ b/djangae/contrib/googleauth/middleware.py
@@ -2,7 +2,6 @@
 import hashlib
 import logging
 import os
-
 from django import forms
 from django.conf import settings
 from django.contrib.auth import (
@@ -18,8 +17,11 @@ from django.contrib.auth import (
 )
 from django.contrib.auth.middleware import AuthenticationMiddleware
 from django.http import HttpResponseRedirect
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.urls.base import reverse
 from django.utils.functional import SimpleLazyObject
+from django.utils.http import urlencode
+
 
 from djangae.environment import is_production_environment
 
@@ -67,6 +69,9 @@ def get_user(request):
 
 class AuthenticationMiddleware(AuthenticationMiddleware):
     def process_request(self, request):
+        request.user = SimpleLazyObject(lambda: get_user(request))
+
+    def process_view(self, request, callback, callback_args, callback_kwargs):
         assert hasattr(request, 'session'), (
             "The djangae.contrib.googleauth middleware requires session middleware "
             "to be installed. Edit your MIDDLEWARE%s setting to insert "
@@ -74,7 +79,9 @@ class AuthenticationMiddleware(AuthenticationMiddleware):
             "'djangae.contrib.googleauth.middleware.AuthenticationMiddleware'."
         ) % ("_CLASSES" if settings.MIDDLEWARE is None else "")
 
-        request.user = SimpleLazyObject(lambda: get_user(request))
+        if getattr(callback, '_auth_middleware_exempt', False):
+            return None
+
         backend_str = request.session.get(BACKEND_SESSION_KEY)
 
         if request.user.is_authenticated:
@@ -86,8 +93,15 @@ class AuthenticationMiddleware(AuthenticationMiddleware):
                 ).first()
 
                 # Their oauth session expired, so let's log them out
-                if not oauth_session or not oauth_session.is_valid:
+                if not oauth_session:
                     logout(request)
+                    return None
+
+                # Their oauth session expired but we still have an active user session
+                if not oauth_session.is_valid:
+                    return redirect(
+                        reverse("googleauth_oauth2login") + '?' + urlencode(dict(next=request.path))
+                    )
 
             elif backend_str and isinstance(load_backend(backend_str), IAPBackend):
                 if not IAPBackend.can_authenticate(request):

--- a/djangae/contrib/googleauth/tests/test_iap.py
+++ b/djangae/contrib/googleauth/tests/test_iap.py
@@ -1,10 +1,17 @@
+from django.http.response import HttpResponse
+from django.test.utils import override_settings
 from djangae.test import TestCase
 from django.contrib.auth import get_user_model
-
+from django.urls import path
 
 User = get_user_model()
 
+urlpatterns = [
+    path('', lambda request: HttpResponse('Ok'), name='index')
+]
 
+
+@override_settings(ROOT_URLCONF=__name__)
 class IAPAuthenticationTests(TestCase):
     def test_user_created_if_authenticated(self):
         headers = {

--- a/djangae/contrib/googleauth/tests/test_local_iap_middleware.py
+++ b/djangae/contrib/googleauth/tests/test_local_iap_middleware.py
@@ -2,12 +2,20 @@ import os
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.http.response import HttpResponse
+from django.test.utils import override_settings
+from django.urls.conf import path
 
 from djangae.test import TestCase
 
 User = get_user_model()
 
+urlpatterns = [
+    path('', lambda request: HttpResponse('Ok'), name='index')
+]
 
+
+@override_settings(ROOT_URLCONF=__name__)
 class LocalIAPMiddlewareTests(TestCase):
 
     def setUp(self):
@@ -33,7 +41,7 @@ class LocalIAPMiddlewareTests(TestCase):
         }
 
         response = self.client.post("/_dj/login/?next=/", form_data, follow=True)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
 
         self.assertIn('_auth_user_id', self.client.session)
 
@@ -70,4 +78,4 @@ class LocalIAPMiddlewareTests(TestCase):
             follow=True
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)

--- a/djangae/contrib/googleauth/views.py
+++ b/djangae/contrib/googleauth/views.py
@@ -27,6 +27,7 @@ from . import (
     _pop_scopes,
 )
 from .backends.oauth2 import OAuthBackend
+from .decorators import auth_middleware_exempt
 from .models import OAuthUserSession
 
 STATE_SESSION_KEY = 'oauth-state'
@@ -78,6 +79,7 @@ def _google_oauth2_session(request, additional_scopes=None, with_scope=True, **k
     return OAuth2Session(client_id, **kwargs)
 
 
+@auth_middleware_exempt
 def oauth_login(request):
     """
         This view should be set as your login_url for using OAuth
@@ -102,6 +104,9 @@ def oauth_login(request):
         "prompt": "select_account",
         "include_granted_scopes": 'true'
     }
+
+    if request.user.is_authenticated:
+        kwargs["prompt"] = "none"
 
     if offline:
         kwargs["access_type"] = "offline"
@@ -137,6 +142,7 @@ def _calc_expires_at(expires_in):
     return timezone.now() + datetime.timedelta(seconds=expires_in)
 
 
+@auth_middleware_exempt
 def oauth2callback(request):
     if environment.is_development_environment():
         # hack required for login to work when running the app locally;


### PR DESCRIPTION
Make sure we do not show the consent screen to the user every time the oauth session expires.
If a django session exists, the prompt should not be shown, while it should otherwise (ie. to allow user to log with a different account).

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [x] Added tests for my change
