### PR TITLE
Fix oauth expiry

### DIFF
--- a/djangae/contrib/googleauth/tests/test_middleware.py
+++ b/djangae/contrib/googleauth/tests/test_middleware.py
@@ -55,6 +55,7 @@ class AuthBackendTests(TestCase):
         can_auth.assert_not_called()
         login_mock.assert_not_called()
 
+    @override_settings(GOOGLEAUTH_LINK_OAUTH_SESSION_EXPIRY=True)
     @patch('djangae.contrib.googleauth.middleware.get_user')
     @patch('djangae.contrib.googleauth.middleware.logout')
     @patch('djangae.contrib.googleauth.middleware.load_backend')
@@ -82,6 +83,7 @@ class AuthBackendTests(TestCase):
         # Session does not exist, logging out.
         logout_mock.assert_called_once_with(self.request)
 
+    @override_settings(GOOGLEAUTH_LINK_OAUTH_SESSION_EXPIRY=True)
     @patch('djangae.contrib.googleauth.middleware.OAuthUserSession', spec=OAuthUserSession)
     @patch('djangae.contrib.googleauth.middleware.get_user')
     @patch('djangae.contrib.googleauth.middleware.logout')
@@ -126,6 +128,7 @@ class AuthBackendTests(TestCase):
         # Test redirects to login
         redirect_mock.assert_called_once_with("/login/?next=%2F")
 
+    @override_settings(GOOGLEAUTH_LINK_OAUTH_SESSION_EXPIRY=True)
     @patch('djangae.contrib.googleauth.middleware.OAuthUserSession', spec=OAuthUserSession)
     @patch('djangae.contrib.googleauth.middleware.get_user')
     @patch('djangae.contrib.googleauth.middleware.logout')

--- a/docs/googleauth.md
+++ b/docs/googleauth.md
@@ -113,7 +113,7 @@ required to configure a list of Authorised domains and OAuth redirects.
 ## Linking OAuth & Django Session Expiry
 
 By default, an oauth session expiring doesn't force log-out the user from their Django session. If however you want to *require* that a Django session
-expires when the oauth session expires, you can do so by setting the `GOOGLEAUTH_LINK_OAUTH_SESSION_EXPIRY` setting to `True`.
+expires when the oauth session expires, you can do so by setting the `GOOGLEAUTH_LINK_OAUTH_SESSION_EXPIRY` setting to `True`. This will redirect the user back through the oauth flow (although normally transparently).
 
 ## Handling App Engine Versioning
 

--- a/docs/googleauth.md
+++ b/docs/googleauth.md
@@ -107,11 +107,18 @@ GOOGLEAUTH_CLIENT_SECRET = "..."
 
 You must generate these values in the Google Cloud Console.
 
-When you configure OAuth Consent Screen and Credentials on Google Cloud Platform you are 
+When you configure OAuth Consent Screen and Credentials on Google Cloud Platform you are
 required to configure a list of Authorised domains and OAuth redirects.
 
+## Linking OAuth & Django Session Expiry
+
+By default, an oauth session expiring doesn't force log-out the user from their Django session. If however you want to *require* that a Django session
+expires when the oauth session expires, you can do so by setting the `GOOGLEAUTH_LINK_OAUTH_SESSION_EXPIRY` setting to `True`.
+
+## Handling App Engine Versioning
+
 While working on multiple AppEngine versions it's quite inconvenient to have to update those lists for every new version you deploy.
-In order to workaround the problem we've added the `OAUTH2_REDIRECT_BASE_URL` setting. 
+In order to workaround the problem we've added the `OAUTH2_REDIRECT_BASE_URL` setting.
 If provided, the user will automatically be redirected to the configured base url during the OAuth2 flow (independently from which application version the flow is triggered from).
 The `oauth2callback` will automatically redirect the user back to the right application version that triggered the flow.
 
@@ -119,8 +126,6 @@ ie.
 ```python
 OAUTH2_REDIRECT_BASE_URL = "https://app.appspot.com"
 ```
-
-
 
 Finally, you'll probably want to set your `LOGIN_URL` setting to the oauth_login view which will trigger the oauth
 authentication if necessary:


### PR DESCRIPTION
Fixes #1303 

Summary of changes proposed in this Pull Request:
- By default, don't log out a Django session just because the oauth session became invalid
- Make this configurable via the `GOOGLEAUTH_LINK_OAUTH_SESSION_EXPIRY` setting

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
