### PR TITLE
Improve stopword handling

### DIFF
--- a/djangae/contrib/search/document.py
+++ b/djangae/contrib/search/document.py
@@ -55,3 +55,9 @@ class Document(object):
 
     def get_field(self, name):
         return self._fields[name]
+
+    def __eq__(self, other):
+        return self.pk == other.pk
+
+    def __repr__(self):
+        return "<Document %s>" % self.pk

--- a/djangae/contrib/search/fields.py
+++ b/djangae/contrib/search/fields.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from django.utils import dateparse
 
 from . import indexers as search_indexers
-from .constants import STOP_WORDS
 from .tokens import tokenize_content
 
 
@@ -60,8 +59,6 @@ class Field(object):
         """
 
         token = token.strip()  # Just in case
-        if token in STOP_WORDS:
-            return None  # Ignore stop words
 
         # Remove + signs, unless they are trailing
         if "+" in token:

--- a/djangae/contrib/search/index.py
+++ b/djangae/contrib/search/index.py
@@ -212,7 +212,7 @@ class Index(object):
         """
         from .query import build_document_queryset
 
-        # If we using startswith matching, we need to include stopwords
+        # If we're using startswith matching, we need to include stopwords
         # regardless of what the user asked for
         if use_startswith:
             match_stopwords = True

--- a/djangae/contrib/search/index.py
+++ b/djangae/contrib/search/index.py
@@ -194,6 +194,7 @@ class Index(object):
         limit=1000,
         use_stemming=False,
         use_startswith=False,
+        match_stopwords=True,
         match_all=True,
         order_by=None
     ):
@@ -207,12 +208,18 @@ class Index(object):
             match_all: If true, only return results where all tokens are found, otherwise act as though all terms
                 are separated by OR operators.
         """
-
         from .query import build_document_queryset
+
+        # If we using startswith matching, we need to include stopwords
+        # regardless of what the user asked for
+        if use_startswith:
+            match_stopwords = True
+
         qs = build_document_queryset(
             query_string, self,
             use_stemming=use_stemming,
             use_startswith=use_startswith,
+            match_stopwords=match_stopwords,
             match_all=match_all,
         )[:limit]
 

--- a/djangae/contrib/search/tests/test_indexing.py
+++ b/djangae/contrib/search/tests/test_indexing.py
@@ -253,3 +253,23 @@ class IndexingTests(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].text, "bar")
         self.assertEqual(results[0].other_text, "foo")
+
+    def test_stopwords_indexed(self):
+        """
+            Stop words should be indexed. They should be ranked lower
+            and not included in searches if match_stopwords is False
+        """
+
+        class Doc(Document):
+            text = fields.TextField()
+
+        index = Index("test")
+        doc1 = Doc(text="about")
+        index.add(doc1)
+
+        self.assertTrue(list(index.search("about", Doc)))
+        self.assertTrue(list(index.search("abo", Doc, use_startswith=True)))
+        self.assertFalse(list(index.search("about", Doc, match_stopwords=False)))
+
+        # Startswith matching overrides matching of stopwords (as other tokens may start with the stop word)
+        self.assertTrue(list(index.search("about", Doc, use_startswith=True, match_stopwords=False)))

--- a/djangae/contrib/search/tests/test_query.py
+++ b/djangae/contrib/search/tests/test_query.py
@@ -26,7 +26,7 @@ class QueryTests(TestCase):
     def test_tokenization_breaks_at_punctuation(self):
         q = "hi, there is a 100% chance this works [honest]"
 
-        tokens = _tokenize_query_string(q)
+        tokens = _tokenize_query_string(q, match_stopwords=False)
         kinds = set(x[0] for x in tokens[0])
         tokens = [x[-1] for x in tokens[0]]
 

--- a/djangae/contrib/search/tests/test_query.py
+++ b/djangae/contrib/search/tests/test_query.py
@@ -271,3 +271,49 @@ class SearchRankingTests(TestCase):
         self.assertEqual(results[0].id, doc2)
         self.assertEqual(results[1].id, doc1)
         self.assertEqual(results[2].id, doc3)
+
+    def test_default_ordering_is_sensible(self):
+        """
+            Ranking should be as follows:
+
+             - Stopwords match weakest
+             - When startswith matching is enabled, closer matches to the
+               searched term will be stronger
+        """
+
+        class Doc(Document):
+            text = fields.TextField()
+
+            def __repr__(self):
+                return "<Document %s>" % self.text
+
+            def __eq__(self, other):
+                return self.id == other.id
+
+        index = Index(name="test")
+
+        doc1 = Doc(text="all about you")  # All stopwords
+        doc2 = Doc(text="ready to rumble")  # 2 stopwords
+        doc3 = Doc(text="live forever")  # no stopwords
+        doc4 = Doc(text="live and let die")  # 1 stop word
+        index.add([doc1, doc2, doc3, doc4])
+
+        results = list(index.search("live to forever", Doc, match_all=False))
+
+        expected_order = [
+            doc3,  # live forever
+            doc4,  # live
+            doc2,  # to
+        ]
+
+        self.assertEqual(results, expected_order)
+
+        results = list(index.search("all about forever and", Doc, match_all=False))
+
+        expected_order = [
+            doc3,  # live forever
+            doc1,  # all about
+            doc4,  # and
+        ]
+
+        self.assertEqual(results, expected_order)

--- a/djangae/contrib/search/tests/test_query.py
+++ b/djangae/contrib/search/tests/test_query.py
@@ -287,9 +287,6 @@ class SearchRankingTests(TestCase):
             def __repr__(self):
                 return "<Document %s>" % self.text
 
-            def __eq__(self, other):
-                return self.id == other.id
-
         index = Index(name="test")
 
         doc1 = Doc(text="all about you")  # All stopwords

--- a/docs/contrib_search.md
+++ b/docs/contrib_search.md
@@ -137,3 +137,10 @@ instances = MyModel.objects.filter(age=10).search("cat")
 ```
 
 There's no need to specify the Document subclass when searching for models.
+
+# Stopwords and Ranking
+
+By default stop words (i.e common tokens) are both indexed, and searched. The default ranking
+algorithm treats stop-word matching as weaker than other words.
+
+If you don't want to match stop words, pass `match_stopwords=False` to the search() method.


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Add `match_stopwords` as a kwarg to `search()`, defaults to True
- Index stopwords during search indexing
- Add a simple ranking algorithm to the search results by default

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
