### PR TITLE
Fix ranking of model querysets

### DIFF
--- a/djangae/contrib/search/model_document.py
+++ b/djangae/contrib/search/model_document.py
@@ -155,9 +155,19 @@ def register(model, model_document):
 
             return qs
 
-        def search(self, query, **options):
+        def search(self, query, ordered_ids=None, **options):
             keys = _do_search(query, **options)
+            if ordered_ids is not None:
+                ordered_ids.extend(keys)
             return model.objects.filter(pk__in=keys)
+
+        def search_and_rank(self, query, **options):
+            keys = _do_search(query, **options)
+
+            return sorted(
+                model.objects.filter(pk__in=keys),
+                key=lambda x: keys.index(x.pk)
+            )
 
     # FIXME: Is this safe? I feel like it should be but 'objects' is
     # a ManagerDescriptor so this might not be doing what I think it

--- a/djangae/contrib/search/query.py
+++ b/djangae/contrib/search/query.py
@@ -253,7 +253,7 @@ def build_document_queryset(
                         best = sorted(potentials, key=lambda x: len(x))[0]
 
                         # Just use a percentage of matched length
-                        score += len(token) / len(best)
+                        score += len(best) / len(token)
 
             return score
 

--- a/djangae/contrib/search/tests/test_searchable.py
+++ b/djangae/contrib/search/tests/test_searchable.py
@@ -124,3 +124,27 @@ class SearchableTest(TestCase):
 
         results = list(SearchableModel1.objects.search("you"))
         self.assertEqual(len(results), 1)
+
+    def test_search_ranking_applied(self):
+        i1 = SearchableModel1.objects.create(name="testing")
+        i2 = SearchableModel1.objects.create(name="test")
+        i3 = SearchableModel1.objects.create(name="testy")
+
+        ordered_ids = []
+
+        results = list(
+            SearchableModel1.objects.search(
+                "test", use_startswith=True, ordered_ids=ordered_ids
+            )
+        )
+
+        results = sorted(results, key=lambda x: ordered_ids.index(x.pk))
+
+        self.assertEqual([i2, i3, i1], results)
+
+        # Same as above
+        results = SearchableModel1.objects.search_and_rank(
+            "test", use_startswith=True
+        )
+
+        self.assertEqual([i2, i3, i1], results)

--- a/docs/contrib_search.md
+++ b/docs/contrib_search.md
@@ -145,6 +145,17 @@ algorithm treats stop-word matching as weaker than other words.
 
 If you don't want to match stop words, pass `match_stopwords=False` to the search() method.
 
+## Queryset Search Ranking
+
+If you're using `ModelDocument` the Django queryset `.search()` method, then ranking order **will not apply** by default. Instead results
+will be ordered by whatever the Django queryset is ordered by. You have two options if you want ranking to apply to your
+queryset.
+
+ 1. Pass an empty list to search using the `ordered_ids` kwarg. This will be populated with the primary keys of the result set
+    ordered by the default search ranking. You can then use this to reorder you final results.
+ 2. Use `.search_and_rank()` instead. This however will not return a queryset, and will instead evaluate the queryset and return
+    an ordered list.
+
 # Caveats / Issues
 
 ## Handling common tokens


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Fix partial token matching ranking
- Add ordered_ids as an optional kwarg to `qs.search(...)`
- Add `search_and_rank()` as a search queryset method

PR checklist:
- [x] Updated relevant documentation
- [x] Updated CHANGELOG.md 
- [x] Added tests for my change
