### PR TITLE
Re-raise errors from deferred iteration shards if it's the first-iter…

### DIFF
--- a/djangae/tasks/tests/test_defer_iteration.py
+++ b/djangae/tasks/tests/test_defer_iteration.py
@@ -4,7 +4,10 @@ from djangae.tasks.deferred import (
     defer_iteration_with_finalize,
     get_deferred_shard_index,
 )
-from djangae.test import TestCase
+from djangae.test import (
+    TaskFailedBehaviour,
+    TestCase,
+)
 
 _SHARD_COUNT = 5
 
@@ -107,7 +110,7 @@ class DeferIterationTestCase(TestCase):
             _shards=_SHARD_COUNT
         )
 
-        self.process_task_queues()
+        self.process_task_queues(failure_behaviour=TaskFailedBehaviour.RETRY_TASK)
 
         self.assertEqual(25, DeferIterationTestModel.objects.filter(touched=True).count())
         self.assertEqual(25, DeferIterationTestModel.objects.filter(finalized=True).count())


### PR DESCRIPTION
…ation

Fixes #1312 

Summary of changes proposed in this Pull Request:
- If a deferred iteration shard fails on the first iteration, it now just re-raises the error to retry the same task, rather than deferring a new one.

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [x] Added tests for my change
