### PR TITLE
Fix issue where entities may be skipped in defer_iteration_with_finalize

### DIFF
--- a/djangae/tasks/deferred.py
+++ b/djangae/tasks/deferred.py
@@ -501,8 +501,7 @@ def _generate_shards(
         if end:
             filter_kwargs["pk__lt"] = end
 
-        # calling order_by with no args to clear any pre-existing ordering (e.g. from Meta.ordering)
-        qs = qs.filter(**filter_kwargs).order_by()
+        qs = qs.filter(**filter_kwargs)
 
         @transaction.atomic(xg=True)
         def make_shard():

--- a/djangae/tasks/deferred.py
+++ b/djangae/tasks/deferred.py
@@ -385,10 +385,9 @@ def _process_shard(marker_id, shard_number, model, query, callback, finalize, ar
     try:
         qs = model.objects.all()
         qs.query = query
-        qs.order_by("pk")
 
         last_pk = None
-        for instance in qs.all():
+        for instance in qs.order_by("pk"):
             last_pk = instance.pk
 
             shard_time = (datetime.now() - start_time).total_seconds()


### PR DESCRIPTION
Summary of changes proposed in this Pull Request:
- Fixes a bug which could cause instances to be skipped while iterating with defer_iteration_with_finalize

PR checklist:
- [ ] Updated relevant documentation
- [ ] Updated CHANGELOG.md 
- [x] Added tests for my change
