### PR TITLE
Don't log an error-level msg with each retry.

### DIFF
--- a/djangae/utils.py
+++ b/djangae/utils.py
@@ -132,10 +132,6 @@ def retry(func, *args, **kwargs):
                     logger.error("Ran out of attempts while retrying function")
                     raise  # Re-raise original exception
 
-                # The location of the errors on each attempt may change, so we log
-                # each one
-                logger.exception("Exception during retry attempt. Will retry.")
-
                 logger.info("Retrying function: %s(%s, %s) - %s", func, args, kwargs, exc)
 
                 # Add a slight bit of randomness (up to a second) to avoid competing tasks


### PR DESCRIPTION
Retries may be part of normal datastore operations, but right now each reply is flagged as an 'error' level msg in the logs.
This change removes the retry logs, leaving only an 'info' level log about each retry.
